### PR TITLE
feat: add AWS Bedrock env var configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ You can provide API keys via environment variables to skip the `dirac auth` step
 - `HF_TOKEN` (HuggingFace)
 - ... and others (see `src/shared/storage/env-config.ts` for the full list).
 
+#### AWS Bedrock
+Use Bedrock by setting AWS credentials and region. When any of these are present, Dirac automatically switches to the Bedrock provider:
+
+- `AWS_REGION` — AWS region (e.g. `us-east-1`)
+- `AWS_ACCESS_KEY_ID` — AWS access key
+- `AWS_SECRET_ACCESS_KEY` — AWS secret key
+- `AWS_SESSION_TOKEN` — session token (for temporary credentials)
+- `AWS_BEDROCK_MODEL` — model ID for both act and plan modes (e.g. `us.anthropic.claude-sonnet-4-6`)
+- `AWS_BEDROCK_MODEL_ACT` — model ID for act mode only
+- `AWS_BEDROCK_MODEL_PLAN` — model ID for plan mode only
+
+Works seamlessly with [aws-vault](https://github.com/99designs/aws-vault):
+```bash
+AWS_REGION=us-east-1 AWS_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 \
+  aws-vault exec my-profile -- dirac "your task"
+```
+
+> **Note:** Newer Claude models on Bedrock (Sonnet 4.6+) require a cross-region inference profile prefix (`us.`, `eu.`, `ap.`). See the [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html) for supported model IDs.
+
 ### Common Commands
 - `dirac "prompt"`: Start an interactive task.
 - `dirac -p "prompt"`: Run in **Plan Mode** to see the strategy before executing.

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -200,9 +200,20 @@ export class AwsBedrockHandler implements ApiHandler {
 
 	getModel(): { id: string; info: ModelInfo } {
 		const modelId = this.options.apiModelId
-		if (modelId && modelId in bedrockModels) {
-			const id = modelId as BedrockModelId
-			return { id, info: bedrockModels[id] }
+
+		if (modelId) {
+			// Direct match in model map
+			if (modelId in bedrockModels) {
+				return { id: modelId as BedrockModelId, info: bedrockModels[modelId as BedrockModelId] }
+			}
+
+			// Strip cross-region/global inference prefix (e.g. "us.", "eu.", "ap.", "apac.", "jp.", "global.")
+			// so "us.anthropic.claude-sonnet-4-6" resolves to "anthropic.claude-sonnet-4-6" for capability info
+			// but the original prefixed ID is returned for the actual API call
+			const stripped = modelId.replace(/^(us|eu|ap|apac|jp|global)\./, "")
+			if (stripped !== modelId && stripped in bedrockModels) {
+				return { id: modelId, info: bedrockModels[stripped as BedrockModelId] }
+			}
 		}
 
 		const customSelected = this.options.awsBedrockCustomSelected

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -14,7 +14,7 @@ import {
     type Settings,
     type SettingsKey,
 } from "@shared/storage/state-keys"
-import { getSecretsFromEnv, getSettingsFromEnv } from "@shared/storage/env-config"
+import { getSecretsFromEnv, getSettingsFromEnv, getSettingsOverridesFromEnv } from "@shared/storage/env-config"
 import type { StorageContext } from "@shared/storage/storage-context"
 import chokidar, { FSWatcher } from "chokidar"
 import { initializeDistinctId } from "@/services/logging/distinctId"
@@ -150,6 +150,15 @@ export class StateManager {
 			await StateManager.instance.setupTaskHistoryWatcher()
 
 			StateManager.instance.isInitialized = true
+
+			// Apply env var overrides into sessionOverrideCache so they propagate
+			// to all reads including UI display, not just constructApiConfigurationFromCache
+			const envOverrides = getSettingsOverridesFromEnv()
+			for (const [key, value] of Object.entries(envOverrides)) {
+				if (value !== undefined) {
+					StateManager.instance.sessionOverrideCache[key as keyof Settings] = value as any
+				}
+			}
 
 			await AgentConfigLoader.getInstance().ready()
 		} catch (error) {
@@ -848,13 +857,14 @@ export class StateManager {
 		// Build API handler settings object with task override support
 		const settings = Object.fromEntries(ApiHandlerSettingsKeys.map((key) => [key, this.getSettingWithOverride(key)]))
 
-		// Merge environment variables as fallback for settings
+		// Merge environment variables as fallback for settings (only fills undefined values)
 		const envSettings = getSettingsFromEnv()
 		for (const [key, value] of Object.entries(envSettings)) {
 			if (value && (key in settings) && settings[key as keyof typeof settings] === undefined) {
 				settings[key as keyof typeof settings] = value as any
 			}
 		}
+
 
 		return {
 			...secrets,

--- a/src/shared/storage/__tests__/env-config.test.ts
+++ b/src/shared/storage/__tests__/env-config.test.ts
@@ -1,0 +1,177 @@
+import { expect } from "chai"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import { getProviderFromEnv, getSecretsFromEnv, getSettingsFromEnv, getSettingsOverridesFromEnv } from "../env-config"
+
+// Save and restore process.env around each test
+let savedEnv: NodeJS.ProcessEnv
+
+beforeEach(() => {
+	savedEnv = { ...process.env }
+})
+
+afterEach(() => {
+	// Remove any keys added during test
+	for (const key of Object.keys(process.env)) {
+		if (!(key in savedEnv)) {
+			delete process.env[key]
+		}
+	}
+	// Restore original values
+	Object.assign(process.env, savedEnv)
+})
+
+describe("getSecretsFromEnv - Bedrock credentials", () => {
+	it("maps AWS_ACCESS_KEY_ID to awsAccessKey", () => {
+		process.env.AWS_ACCESS_KEY_ID = "AKIATEST"
+		const secrets = getSecretsFromEnv()
+		expect(secrets.awsAccessKey).to.equal("AKIATEST")
+	})
+
+	it("maps AWS_SECRET_ACCESS_KEY to awsSecretKey", () => {
+		process.env.AWS_SECRET_ACCESS_KEY = "secret123"
+		const secrets = getSecretsFromEnv()
+		expect(secrets.awsSecretKey).to.equal("secret123")
+	})
+
+	it("maps AWS_SESSION_TOKEN to awsSessionToken", () => {
+		process.env.AWS_SESSION_TOKEN = "token456"
+		const secrets = getSecretsFromEnv()
+		expect(secrets.awsSessionToken).to.equal("token456")
+	})
+
+	it("maps all three AWS credential vars together", () => {
+		process.env.AWS_ACCESS_KEY_ID = "AKIATEST"
+		process.env.AWS_SECRET_ACCESS_KEY = "secret123"
+		process.env.AWS_SESSION_TOKEN = "token456"
+		const secrets = getSecretsFromEnv()
+		expect(secrets.awsAccessKey).to.equal("AKIATEST")
+		expect(secrets.awsSecretKey).to.equal("secret123")
+		expect(secrets.awsSessionToken).to.equal("token456")
+	})
+
+	it("returns no AWS secrets when env vars are absent", () => {
+		delete process.env.AWS_ACCESS_KEY_ID
+		delete process.env.AWS_SECRET_ACCESS_KEY
+		delete process.env.AWS_SESSION_TOKEN
+		const secrets = getSecretsFromEnv()
+		expect(secrets.awsAccessKey).to.be.undefined
+		expect(secrets.awsSecretKey).to.be.undefined
+		expect(secrets.awsSessionToken).to.be.undefined
+	})
+})
+
+describe("getSettingsFromEnv - Bedrock region", () => {
+	it("maps AWS_REGION to awsRegion", () => {
+		process.env.AWS_REGION = "us-east-1"
+		const settings = getSettingsFromEnv()
+		expect(settings.awsRegion).to.equal("us-east-1")
+	})
+
+	it("returns no awsRegion when AWS_REGION is absent", () => {
+		delete process.env.AWS_REGION
+		const settings = getSettingsFromEnv()
+		expect(settings.awsRegion).to.be.undefined
+	})
+})
+
+describe("getSettingsOverridesFromEnv - Bedrock provider and model", () => {
+	it("sets bedrock provider when AWS_REGION is present", () => {
+		process.env.AWS_REGION = "us-east-1"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiProvider).to.equal("bedrock")
+		expect(overrides.planModeApiProvider).to.equal("bedrock")
+	})
+
+	it("sets bedrock provider when AWS_ACCESS_KEY_ID is present", () => {
+		process.env.AWS_ACCESS_KEY_ID = "AKIATEST"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiProvider).to.equal("bedrock")
+		expect(overrides.planModeApiProvider).to.equal("bedrock")
+	})
+
+	it("does not set bedrock provider when no AWS env vars present", () => {
+		delete process.env.AWS_REGION
+		delete process.env.AWS_ACCESS_KEY_ID
+		delete process.env.AWS_SECRET_ACCESS_KEY
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiProvider).to.be.undefined
+		expect(overrides.planModeApiProvider).to.be.undefined
+	})
+
+	it("applies AWS_BEDROCK_MODEL to both act and plan modes", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("us.anthropic.claude-sonnet-4-6")
+		expect(overrides.planModeApiModelId).to.equal("us.anthropic.claude-sonnet-4-6")
+	})
+
+	it("AWS_BEDROCK_MODEL_ACT overrides act mode only", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6"
+		process.env.AWS_BEDROCK_MODEL_ACT = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+		expect(overrides.planModeApiModelId).to.equal("us.anthropic.claude-sonnet-4-6")
+	})
+
+	it("AWS_BEDROCK_MODEL_PLAN overrides plan mode only", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6"
+		process.env.AWS_BEDROCK_MODEL_PLAN = "us.anthropic.claude-opus-4-6-v1"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("us.anthropic.claude-sonnet-4-6")
+		expect(overrides.planModeApiModelId).to.equal("us.anthropic.claude-opus-4-6-v1")
+	})
+
+	it("per-mode vars take precedence over shared fallback for both modes", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "us.anthropic.claude-sonnet-4-6"
+		process.env.AWS_BEDROCK_MODEL_ACT = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+		process.env.AWS_BEDROCK_MODEL_PLAN = "us.anthropic.claude-opus-4-6-v1"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+		expect(overrides.planModeApiModelId).to.equal("us.anthropic.claude-opus-4-6-v1")
+	})
+
+	it("works with Nova model IDs (no prefix required)", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "amazon.nova-pro-v1:0"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("amazon.nova-pro-v1:0")
+		expect(overrides.planModeApiModelId).to.equal("amazon.nova-pro-v1:0")
+	})
+
+	it("works with Qwen model IDs (no prefix required)", () => {
+		process.env.AWS_REGION = "us-east-1"
+		process.env.AWS_BEDROCK_MODEL = "qwen.qwen3-coder-480b-a35b-v1:0"
+		const overrides = getSettingsOverridesFromEnv()
+		expect(overrides.actModeApiModelId).to.equal("qwen.qwen3-coder-480b-a35b-v1:0")
+		expect(overrides.planModeApiModelId).to.equal("qwen.qwen3-coder-480b-a35b-v1:0")
+	})
+})
+
+describe("getProviderFromEnv - Bedrock detection", () => {
+	it("returns bedrock when AWS_REGION is set", () => {
+		process.env.AWS_REGION = "us-east-1"
+		expect(getProviderFromEnv()).to.equal("bedrock")
+	})
+
+	it("returns bedrock when AWS_ACCESS_KEY_ID is set", () => {
+		process.env.AWS_ACCESS_KEY_ID = "AKIATEST"
+		expect(getProviderFromEnv()).to.equal("bedrock")
+	})
+
+	it("does not return bedrock when only AWS_SECRET_ACCESS_KEY is set", () => {
+		delete process.env.AWS_REGION
+		delete process.env.AWS_ACCESS_KEY_ID
+		process.env.AWS_SECRET_ACCESS_KEY = "secret"
+		expect(getProviderFromEnv()).to.not.equal("bedrock")
+	})
+
+	it("prefers anthropic over bedrock when ANTHROPIC_API_KEY also set", () => {
+		process.env.ANTHROPIC_API_KEY = "sk-ant-test"
+		process.env.AWS_REGION = "us-east-1"
+		expect(getProviderFromEnv()).to.equal("anthropic")
+	})
+})

--- a/src/shared/storage/__tests__/provider-keys.test.ts
+++ b/src/shared/storage/__tests__/provider-keys.test.ts
@@ -1,4 +1,4 @@
-import { moonshotDefaultModelId } from "@shared/api"
+import { bedrockDefaultModelId, moonshotDefaultModelId } from "@shared/api"
 import { expect } from "chai"
 import { describe, it } from "mocha"
 import { getProviderDefaultModelId, getProviderModelIdKey } from "../provider-keys"
@@ -21,5 +21,14 @@ describe("Provider key mapping", () => {
 	it("uses provider-specific model key behavior for Dirac", () => {
 		expect(getProviderModelIdKey("dirac", "act")).to.equal("actModeDiracModelId")
 		expect(getProviderModelIdKey("dirac", "plan")).to.equal("planModeDiracModelId")
+	})
+
+	it("uses generic model key for Bedrock", () => {
+		expect(getProviderModelIdKey("bedrock", "act")).to.equal("actModeApiModelId")
+		expect(getProviderModelIdKey("bedrock", "plan")).to.equal("planModeApiModelId")
+	})
+
+	it("returns Bedrock default model ID", () => {
+		expect(getProviderDefaultModelId("bedrock")).to.equal(bedrockDefaultModelId)
 	})
 })

--- a/src/shared/storage/env-config.ts
+++ b/src/shared/storage/env-config.ts
@@ -29,7 +29,11 @@ export const ENV_VAR_TO_SECRET_KEY: Record<string, keyof Secrets> = {
 	TOGETHER_API_KEY: "togetherApiKey",
 	FIREWORKS_API_KEY: "fireworksApiKey",
 	NEBIUS_API_KEY: "nebiusApiKey",
-	OPENAI_COMPATIBLE_CUSTOM_KEY: "openAiCompatibleCustomApiKey"
+	OPENAI_COMPATIBLE_CUSTOM_KEY: "openAiCompatibleCustomApiKey",
+	// AWS credentials for Bedrock (picked up by the SDK provider chain, but also stored explicitly)
+	AWS_ACCESS_KEY_ID: "awsAccessKey",
+	AWS_SECRET_ACCESS_KEY: "awsSecretKey",
+	AWS_SESSION_TOKEN: "awsSessionToken",
 }
 
 /**
@@ -41,6 +45,8 @@ export const ENV_VAR_TO_SETTINGS_KEY: Record<string, keyof Settings> = {
 	GCP_PROJECT: "vertexProjectId",
 	GOOGLE_CLOUD_LOCATION: "vertexRegion",
 	GOOGLE_CLOUD_REGION: "vertexRegion",
+	// AWS Bedrock region
+	AWS_REGION: "awsRegion",
 }
 
 /**
@@ -87,6 +93,33 @@ export function getSettingsFromEnv(): Partial<Settings> {
 	return settings
 }
 
+/**
+ * Get settings from environment variables that should OVERRIDE stored settings.
+ * Unlike getSettingsFromEnv() (which only fills in missing values), these take precedence.
+ * Used for env-driven provider/model selection where stored defaults would otherwise win.
+ */
+export function getSettingsOverridesFromEnv(): Partial<Settings> {
+	const overrides: Partial<Settings> = {}
+
+	// When Bedrock credentials or region are present, force the provider for both modes
+	const hasBedrockConfig =
+		process.env.AWS_REGION ||
+		process.env.AWS_ACCESS_KEY_ID ||
+		process.env.AWS_SECRET_ACCESS_KEY
+	if (hasBedrockConfig) {
+		overrides.actModeApiProvider = "bedrock"
+		overrides.planModeApiProvider = "bedrock"
+	}
+
+	// Model overrides — per-mode vars take precedence over the shared fallback
+	const actModel = process.env.AWS_BEDROCK_MODEL_ACT || process.env.AWS_BEDROCK_MODEL
+	const planModel = process.env.AWS_BEDROCK_MODEL_PLAN || process.env.AWS_BEDROCK_MODEL
+	if (actModel) overrides.actModeApiModelId = actModel
+	if (planModel) overrides.planModeApiModelId = planModel
+
+	return overrides
+}
+
 
 /**
  * Get the best provider based on available environment variables.
@@ -98,6 +131,8 @@ export function getProviderFromEnv(): ApiProvider | undefined {
 	if (process.env.GEMINI_API_KEY) return "gemini"
 
 	if (process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT) return "vertex"
+	// AWS Bedrock: detected via region or explicit credentials
+	if (process.env.AWS_REGION || process.env.AWS_ACCESS_KEY_ID) return "bedrock"
 	if (process.env.GROQ_API_KEY) return "groq"
 	if (process.env.XAI_API_KEY) return "xai"
 	if (process.env.MISTRAL_API_KEY) return "mistral"


### PR DESCRIPTION
Allow configuring Bedrock provider, region, credentials, and model via environment variables. This enables workflows like aws-vault where credentials are injected at runtime rather than stored persistently.

New env vars:
- AWS_REGION → awsRegion
- AWS_ACCESS_KEY_ID → awsAccessKey
- AWS_SECRET_ACCESS_KEY → awsSecretKey
- AWS_SESSION_TOKEN → awsSessionToken
- AWS_BEDROCK_MODEL → model for both act and plan modes
- AWS_BEDROCK_MODEL_ACT → model for act mode only
- AWS_BEDROCK_MODEL_PLAN → model for plan mode only

When any AWS credential/region env var is present, actModeApiProvider and planModeApiProvider are overridden to 'bedrock' via sessionOverrideCache so the provider change is reflected in the UI as well as API calls.

Also fix BedrockHandler.getModel() to correctly resolve cross-region inference profile prefixes (e.g. 'us.anthropic.claude-sonnet-4-6') by stripping the prefix for model capability lookup while preserving the full prefixed ID for the actual API call.

docs: add AWS Bedrock environment variable configuration to README