### PR TITLE
fix: harden symbol index persistence

### DIFF
--- a/cli/src/agent/messageTranslator.ts
+++ b/cli/src/agent/messageTranslator.ts
@@ -28,7 +28,8 @@ const TOOL_KIND_MAP: Record<string, acp.ToolKind> = {
 	listFilesTopLevel: "read",
 	listFilesRecursive: "read",
 	listCodeDefinitionNames: "read",
-	searchFiles: "read",
+	fileDeleted: "delete",
+	searchFiles: "search",
 	// Other
 	summarizeTask: "think",
 	useSkill: "other",
@@ -56,6 +57,18 @@ const BROWSER_ACTION_KIND_MAP: Record<string, acp.ToolKind> = {
  */
 function generateToolCallId(): string {
 	return crypto.randomUUID()
+}
+
+function truncateTitleValue(value: string, maxLength = 50): string {
+	return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value
+}
+
+function buildCommandTitle(command: string): string {
+	return command ? `Execute: ${truncateTitleValue(command)}` : "Execute"
+}
+
+function buildBrowserActionTitle(action?: string): string {
+	return action ? `Browser: ${action}` : "Browser"
 }
 
 /**
@@ -308,7 +321,6 @@ function translateSayMessage(
 			// The ACP client already knows what they typed
 			break
 
-
 		case "hook_status":
 			// Format hook status as a human-readable message
 			if (message.text) {
@@ -420,15 +432,16 @@ function translateAskMessage(
 		case "command":
 			// Command permission request → tool_call + request_permission
 			{
+				const command = extractCommandFromText(message.text)
 				const toolCallId = generateToolCallId()
 				sessionState.currentToolCallId = toolCallId
 
 				const toolCall: acp.ToolCall = {
 					toolCallId,
-					title: "Execute",
+					title: buildCommandTitle(command),
 					kind: "execute",
 					status: "pending",
-					rawInput: { command: extractCommandFromText(message.text) },
+					rawInput: { command },
 				}
 
 				updates.push({
@@ -532,15 +545,21 @@ function translateAskMessage(
 		case "browser_action_launch":
 			// Browser launch permission
 			{
+				let action: DiracSayBrowserAction | null = null
+				try {
+					action = message.text ? (JSON.parse(message.text) as DiracSayBrowserAction) : null
+				} catch {
+					// Fall back to the raw text as URL below.
+				}
 				const toolCallId = generateToolCallId()
 				sessionState.currentToolCallId = toolCallId
 
 				const toolCall: acp.ToolCall = {
 					toolCallId,
-					title: "Browser",
+					title: buildBrowserActionTitle(action?.action || "launch"),
 					kind: "execute",
 					status: "pending",
-					rawInput: { url: message.text },
+					rawInput: action || { url: message.text },
 				}
 
 				updates.push({
@@ -689,7 +708,7 @@ function translateCommandMessage(message: DiracMessage, sessionState: AcpSession
 	updates.push({
 		sessionUpdate: "tool_call",
 		toolCallId,
-		title: "Execute",
+		title: buildCommandTitle(command),
 		kind: "execute",
 		status: message.partial ? "in_progress" : "completed",
 		rawInput: { command },
@@ -759,7 +778,7 @@ function translateBrowserActionMessage(message: DiracMessage, sessionState: AcpS
 		if (!sessionState.currentToolCallId) {
 			sessionState.currentToolCallId = toolCallId
 		}
-		const title = "Browser"
+		const title = buildBrowserActionTitle(action?.action)
 		const kind = action ? BROWSER_ACTION_KIND_MAP[action.action] || "execute" : "execute"
 
 		updates.push({
@@ -794,28 +813,34 @@ function translateBrowserActionMessage(message: DiracMessage, sessionState: AcpS
  */
 
 /**
-/**
  * Build a human-readable title for a tool operation.
  */
 function buildToolTitle(toolInfo: DiracSayTool): string {
+	const pathSuffix = toolInfo.path ? `: ${truncateTitleValue(toolInfo.path)}` : ""
+	const regexSuffix = (toolInfo as { regex?: string }).regex
+		? `: ${truncateTitleValue((toolInfo as { regex?: string }).regex!)}`
+		: ""
+
 	switch (toolInfo.tool) {
 		case "editFile":
 		case "editedExistingFile":
-			return "Edit"
+			return `Edit${pathSuffix}`
 		case "replaceSymbol":
-			return "Replace"
+			return `Replace${pathSuffix}`
 		case "newFileCreated":
-			return "Create"
+			return `Create file${pathSuffix}`
+		case "fileDeleted":
+			return `Delete file${pathSuffix}`
 		case "readFile":
 		case "readLineRange":
-			return "Read"
+			return `Read${pathSuffix}`
 		case "listFilesTopLevel":
 		case "listFilesRecursive":
-			return "List"
+			return `List${pathSuffix}`
 		case "listCodeDefinitionNames":
-			return "Definitions"
+			return `Definitions${pathSuffix}`
 		case "searchFiles":
-			return "Search"
+			return `Search${regexSuffix || pathSuffix}`
 		case "summarizeTask":
 			return "Summarize"
 		case "useSkill":

--- a/cli/src/components/ChatView.test.tsx
+++ b/cli/src/components/ChatView.test.tsx
@@ -148,6 +148,7 @@ vi.mock("../utils/tools", () => ({
 }))
 
 vi.mock("../utils/display", () => ({
+	centerText: vi.fn((text: string) => text),
 	setTerminalTitle: vi.fn(),
 }))
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -81,19 +81,25 @@ export async function initialize(storageContext: StorageContext): Promise<DiracW
 	// =============== Symbol Index Service ===============
 	// Initialize symbol index for the project in background with a delay to avoid blocking startup
 	const INITIALIZATION_DELAY_MS = 5000
-	setTimeout(() => {
-		HostProvider.workspace.getWorkspacePaths({}).then((response) => {
-			const paths = response.paths
-			if (paths && paths.length > 0) {
-				const projectRoot = paths[0]
-				SymbolIndexService.getInstance()
-					.initialize(projectRoot)
-					.catch((error) => {
-						Logger.error("[Dirac] Failed to initialize SymbolIndexService:", error)
-					})
-			}
-		})
+	const symbolIndexTimer = setTimeout(() => {
+		HostProvider.workspace
+			.getWorkspacePaths({})
+			.then((response) => {
+				const paths = response.paths
+				if (paths && paths.length > 0) {
+					const projectRoot = paths[0]
+					SymbolIndexService.getInstance()
+						.initialize(projectRoot)
+						.catch((error) => {
+							Logger.error("[Dirac] Failed to initialize SymbolIndexService:", error)
+						})
+				}
+			})
+			.catch((error) => {
+				Logger.error("[Dirac] Failed to resolve workspace paths for SymbolIndexService:", error)
+			})
 	}, INITIALIZATION_DELAY_MS)
+	symbolIndexTimer.unref?.()
 
 	return webview
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -552,8 +552,13 @@ ${ctx.cellJson || "{}"}
 		}
 		const timeout = setTimeout(async () => {
 			debounceMap.delete(fsPath)
-			await SymbolIndexService.getInstance().updateFile(fsPath)
+			try {
+				await SymbolIndexService.getInstance().updateFile(fsPath)
+			} catch (error) {
+				Logger.error(`[Dirac] Symbol index watcher failed to update ${fsPath}:`, error)
+			}
 		}, DEBOUNCE_MS)
+		timeout.unref?.()
 		debounceMap.set(fsPath, timeout)
 	}
 
@@ -565,7 +570,11 @@ ${ctx.cellJson || "{}"}
 			clearTimeout(debounceMap.get(fsPath))
 			debounceMap.delete(fsPath)
 		}
-		await SymbolIndexService.getInstance().removeFile(fsPath)
+		try {
+			await SymbolIndexService.getInstance().removeFile(fsPath)
+		} catch (error) {
+			Logger.error(`[Dirac] Symbol index watcher failed to remove ${fsPath}:`, error)
+		}
 	})
 
 	context.subscriptions.push(fileWatcher)

--- a/src/services/symbol-index/SymbolIndexDatabase.ts
+++ b/src/services/symbol-index/SymbolIndexDatabase.ts
@@ -3,29 +3,100 @@ import * as path from "path"
 import type { Database } from "sql.js"
 import initSqlJs from "sql.js"
 import { Logger } from "../../shared/services/Logger"
-import { SymbolLocation } from "./SymbolIndexService"
+import type { SymbolLocation } from "./SymbolIndexService"
 
 export interface FileMetadata {
 	mtime: number
 	size: number
 }
 
+export interface SymbolIndexDatabaseOptions {
+	maxPersistedBytes?: number
+}
+
+export interface SymbolIndexDatabaseStats {
+	estimatedSizeBytes: number | null
+	fileCount: number
+	symbolCount: number
+}
+
+const CHUNK_SIZE = 1024 * 1024 * 512 // 512 MiB
+const DEFAULT_MAX_PERSISTED_BYTES = 128 * 1024 * 1024
+
+function getConfiguredMaxPersistedBytes(): number {
+	const raw = process.env.DIRAC_SYMBOL_INDEX_MAX_DB_BYTES
+	if (!raw) return DEFAULT_MAX_PERSISTED_BYTES
+
+	const value = Number.parseInt(raw, 10)
+	if (!Number.isFinite(value) || value <= 0) return DEFAULT_MAX_PERSISTED_BYTES
+	return value
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MiB`
+	return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GiB`
+}
+
+function readFileChunked(filePath: string): Uint8Array {
+	const stats = fs.statSync(filePath)
+	const fileBuffer = new Uint8Array(stats.size)
+	const fd = fs.openSync(filePath, "r")
+	try {
+		let offset = 0
+		while (offset < stats.size) {
+			const length = Math.min(CHUNK_SIZE, stats.size - offset)
+			fs.readSync(fd, fileBuffer, offset, length, offset)
+			offset += length
+		}
+	} finally {
+		fs.closeSync(fd)
+	}
+	return fileBuffer
+}
+
+function writeFileChunked(filePath: string, data: Uint8Array): void {
+	const fd = fs.openSync(filePath, "w")
+	try {
+		let offset = 0
+		while (offset < data.length) {
+			const length = Math.min(CHUNK_SIZE, data.length - offset)
+			fs.writeSync(fd, data, offset, length)
+			offset += length
+		}
+	} finally {
+		fs.closeSync(fd)
+	}
+}
+
 export class SymbolIndexDatabase {
 	private db: Database
-	private dbPath: string
+	private dbPath: string | null
 	private isDirty = false
+	private maxPersistedBytes: number
 
-	private constructor(db: Database, dbPath: string) {
+	private constructor(db: Database, dbPath: string | null, options: SymbolIndexDatabaseOptions = {}) {
 		this.db = db
 		this.dbPath = dbPath
+		this.maxPersistedBytes = options.maxPersistedBytes ?? getConfiguredMaxPersistedBytes()
 	}
 
-	public static async create(dbPath: string): Promise<SymbolIndexDatabase> {
-		Logger.info(`[SymbolIndexDatabase] Initializing database at ${dbPath}`)
-		const dbDir = path.dirname(dbPath)
-		if (!fs.existsSync(dbDir)) {
-			Logger.info(`[SymbolIndexDatabase] Creating database directory: ${dbDir}`)
-			fs.mkdirSync(dbDir, { recursive: true })
+	public static async create(dbPath?: string | null, options: SymbolIndexDatabaseOptions = {}): Promise<SymbolIndexDatabase> {
+		Logger.info(`[SymbolIndexDatabase] Initializing database${dbPath ? ` at ${dbPath}` : " in memory"}`)
+
+		let skipExistingDb = false
+		if (dbPath) {
+			const dbDir = path.dirname(dbPath)
+			if (!fs.existsSync(dbDir)) {
+				Logger.info(`[SymbolIndexDatabase] Creating database directory: ${dbDir}`)
+				fs.mkdirSync(dbDir, { recursive: true })
+			}
+
+			skipExistingDb = SymbolIndexDatabase.quarantineOversizedExistingDatabase(
+				dbPath,
+				options.maxPersistedBytes ?? getConfiguredMaxPersistedBytes(),
+			)
 		}
 
 		const SQL = await initSqlJs({
@@ -33,27 +104,21 @@ export class SymbolIndexDatabase {
 		})
 		let db: Database
 
-		if (fs.existsSync(dbPath)) {
+		if (dbPath && !skipExistingDb && fs.existsSync(dbPath)) {
+			Logger.info(`[SymbolIndexDatabase] Loading existing database from ${dbPath}`)
 			try {
-				Logger.info(`[SymbolIndexDatabase] Loading existing database from ${dbPath}`)
-				const stats = fs.statSync(dbPath)
-				const size = stats.size
-				const fileBuffer = new Uint8Array(size)
-				const fd = fs.openSync(dbPath, "r")
-				try {
-					let offset = 0
-					const chunkSize = 1024 * 1024 * 512 // 512MB chunks
-					while (offset < size) {
-						const length = Math.min(chunkSize, size - offset)
-						fs.readSync(fd, fileBuffer, offset, length, offset)
-						offset += length
-					}
-				} finally {
-					fs.closeSync(fd)
-				}
-				db = new SQL.Database(fileBuffer)
+				db = new SQL.Database(readFileChunked(dbPath))
 			} catch (error) {
-				Logger.error(`[SymbolIndexDatabase] Failed to load database from ${dbPath}: ${error}. Creating new database.`)
+				const corruptPath = `${dbPath}.corrupt-${Date.now()}`
+				Logger.error(
+					`[SymbolIndexDatabase] Failed to load existing database. Quarantining at ${corruptPath} and rebuilding:`,
+					error,
+				)
+				try {
+					fs.renameSync(dbPath, corruptPath)
+				} catch (renameError) {
+					Logger.error(`[SymbolIndexDatabase] Failed to quarantine corrupt database at ${dbPath}:`, renameError)
+				}
 				db = new SQL.Database()
 			}
 		} else {
@@ -61,9 +126,54 @@ export class SymbolIndexDatabase {
 			db = new SQL.Database()
 		}
 
-		const instance = new SymbolIndexDatabase(db, dbPath)
-		instance.initialize()
-		return instance
+		const instance = new SymbolIndexDatabase(db, dbPath ?? null, options)
+		try {
+			instance.initialize()
+			return instance
+		} catch (error) {
+			if (!dbPath) {
+				throw error
+			}
+
+			const corruptPath = `${dbPath}.corrupt-${Date.now()}`
+			Logger.error(
+				`[SymbolIndexDatabase] Failed to initialize existing database. Quarantining at ${corruptPath} and rebuilding:`,
+				error,
+			)
+			try {
+				db.close()
+			} catch {
+				// Best-effort close before rebuilding.
+			}
+			try {
+				if (fs.existsSync(dbPath)) fs.renameSync(dbPath, corruptPath)
+			} catch (renameError) {
+				Logger.error(`[SymbolIndexDatabase] Failed to quarantine corrupt database at ${dbPath}:`, renameError)
+			}
+
+			const rebuilt = new SymbolIndexDatabase(new SQL.Database(), dbPath, options)
+			rebuilt.initialize()
+			return rebuilt
+		}
+	}
+
+	private static quarantineOversizedExistingDatabase(dbPath: string, maxPersistedBytes: number): boolean {
+		if (!fs.existsSync(dbPath)) return false
+
+		try {
+			const stats = fs.statSync(dbPath)
+			if (stats.size <= maxPersistedBytes) return false
+
+			const quarantinePath = `${dbPath}.oversized-${Date.now()}`
+			Logger.error(
+				`[SymbolIndexDatabase] Existing index database is ${formatBytes(stats.size)}, exceeding max ${formatBytes(maxPersistedBytes)}. Quarantining at ${quarantinePath} and rebuilding.`,
+			)
+			fs.renameSync(dbPath, quarantinePath)
+			return false
+		} catch (error) {
+			Logger.error(`[SymbolIndexDatabase] Failed to quarantine oversized database at ${dbPath}; skipping load:`, error)
+			return true
+		}
 	}
 
 	private initialize(): void {
@@ -96,31 +206,84 @@ export class SymbolIndexDatabase {
 		Logger.info("[SymbolIndexDatabase] Schema initialization complete")
 	}
 
-	public save(): void {
+	public save(): boolean {
 		if (!this.isDirty) {
-			return
+			return true
 		}
-		Logger.info(`[SymbolIndexDatabase] Saving database to ${this.dbPath}`)
-		try {
-			this.db.run("VACUUM")
-		} catch (error) {
-			Logger.warn(`[SymbolIndexDatabase] VACUUM failed: ${error}`)
+		if (!this.dbPath) {
+			this.isDirty = false
+			return true
 		}
-		const data = this.db.export()
-		const fd = fs.openSync(this.dbPath, "w")
+
+		const stats = this.getStats()
+		if (stats.estimatedSizeBytes !== null && stats.estimatedSizeBytes > this.maxPersistedBytes) {
+			Logger.error(
+				`[SymbolIndexDatabase] Refusing to save oversized symbol index. estimate=${formatBytes(stats.estimatedSizeBytes)} max=${formatBytes(this.maxPersistedBytes)} files=${stats.fileCount} symbols=${stats.symbolCount}`,
+			)
+			this.isDirty = false
+			return false
+		}
+
+		let tmpPath: string | null = null
 		try {
-			let offset = 0
-			const chunkSize = 1024 * 1024 * 512 // 512MB chunks
-			while (offset < data.length) {
-				const length = Math.min(chunkSize, data.length - offset)
-				fs.writeSync(fd, data, offset, length)
-				offset += length
+			Logger.info(`[SymbolIndexDatabase] Saving database to ${this.dbPath}`)
+			try {
+				this.db.run("VACUUM")
+			} catch (error) {
+				Logger.warn(`[SymbolIndexDatabase] VACUUM failed: ${error}`)
 			}
-		} finally {
-			fs.closeSync(fd)
+
+			const data = this.db.export()
+			if (data.byteLength > this.maxPersistedBytes) {
+				Logger.error(
+					`[SymbolIndexDatabase] Refusing to write oversized exported symbol index. export=${formatBytes(data.byteLength)} max=${formatBytes(this.maxPersistedBytes)} files=${stats.fileCount} symbols=${stats.symbolCount}`,
+				)
+				this.isDirty = false
+				return false
+			}
+
+			tmpPath = `${this.dbPath}.${process.pid}.${Date.now()}.tmp`
+			writeFileChunked(tmpPath, data)
+			fs.renameSync(tmpPath, this.dbPath)
+			this.isDirty = false
+			Logger.info(`[SymbolIndexDatabase] Database saved successfully (${formatBytes(data.byteLength)})`)
+			return true
+		} catch (error) {
+			Logger.error(`[SymbolIndexDatabase] Failed to save database to ${this.dbPath}:`, error)
+			if (tmpPath) {
+				try {
+					if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath)
+				} catch (cleanupError) {
+					Logger.error(`[SymbolIndexDatabase] Failed to remove temporary database ${tmpPath}:`, cleanupError)
+				}
+			}
+			this.isDirty = false
+			return false
 		}
-		this.isDirty = false
-		Logger.info(`[SymbolIndexDatabase] Database saved successfully`)
+	}
+
+	private getScalarNumber(query: string): number | null {
+		try {
+			const result = this.db.exec(query)
+			const value = result[0]?.values?.[0]?.[0]
+			const num = Number(value)
+			return Number.isFinite(num) ? num : null
+		} catch {
+			return null
+		}
+	}
+
+	public getStats(): SymbolIndexDatabaseStats {
+		const pageCount = this.getScalarNumber("PRAGMA page_count")
+		const pageSize = this.getScalarNumber("PRAGMA page_size")
+		const fileCount = this.getScalarNumber("SELECT COUNT(*) FROM files") ?? 0
+		const symbolCount = this.getScalarNumber("SELECT COUNT(*) FROM symbols") ?? 0
+
+		return {
+			estimatedSizeBytes: pageCount !== null && pageSize !== null ? pageCount * pageSize : null,
+			fileCount,
+			symbolCount,
+		}
 	}
 
 	public getFileMetadata(relPath: string): FileMetadata | null {
@@ -159,11 +322,12 @@ export class SymbolIndexDatabase {
 	): void {
 		this.isDirty = true
 		this.db.run("BEGIN TRANSACTION")
+		let insertSymbol: any = null
 		try {
 			this.db.run("DELETE FROM symbols WHERE file_path = ?", [relPath])
 			this.db.run("INSERT OR REPLACE INTO files (path, mtime, size) VALUES (?, ?, ?)", [relPath, mtime, size])
 
-			const insertSymbol = this.db.prepare(`
+			insertSymbol = this.db.prepare(`
 				INSERT INTO symbols (file_path, name, type, kind, start_line, start_column, end_line, end_column)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			`)
@@ -180,11 +344,12 @@ export class SymbolIndexDatabase {
 					sym.r[3],
 				])
 			}
-			insertSymbol.free()
 			this.db.run("COMMIT")
 		} catch (error) {
 			this.db.run("ROLLBACK")
 			throw error
+		} finally {
+			if (insertSymbol) insertSymbol.free()
 		}
 	}
 
@@ -247,7 +412,7 @@ export class SymbolIndexDatabase {
 		this.db.run("DELETE FROM files WHERE path = ?", [relPath])
 	}
 
-		public getSymbolsByName(name: string, type?: "definition" | "reference", limit?: number): SymbolLocation[] {
+	public getSymbolsByName(name: string, type?: "definition" | "reference", limit?: number): SymbolLocation[] {
 		let query =
 			"SELECT file_path, name, type, kind, start_line, start_column, end_line, end_column FROM symbols WHERE name = ?"
 		const params: any[] = [name]
@@ -281,8 +446,10 @@ export class SymbolIndexDatabase {
 		return results
 	}
 
-	public close(): void {
-		this.save()
+	public close(saveBeforeClose = true): void {
+		if (saveBeforeClose) {
+			this.save()
+		}
 		this.db.close()
 	}
 }

--- a/src/services/symbol-index/SymbolIndexService.ts
+++ b/src/services/symbol-index/SymbolIndexService.ts
@@ -1,10 +1,23 @@
 import { loadRequiredLanguageParsers } from "@services/tree-sitter/languageParser"
 import * as fs from "fs/promises"
+import ignore from "ignore"
 import pLimit from "p-limit"
 import * as path from "path"
 import Parser from "web-tree-sitter"
 import { Logger } from "../../shared/services/Logger"
 import { SymbolIndexDatabase } from "./SymbolIndexDatabase"
+
+function getPositiveIntegerEnv(name: string, fallback: number): number {
+	const raw = process.env[name]
+	if (!raw) return fallback
+
+	const value = Number.parseInt(raw, 10)
+	return Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function toIgnorePath(relPath: string): string {
+	return relPath.split(/[\\/]/).join("/")
+}
 
 export interface SymbolLocation {
 	path: string
@@ -115,6 +128,10 @@ export class SymbolIndexService {
 	private static readonly INDEX_DIR = ".dirac-symbol-index"
 	private static readonly INDEX_FILE = "data.db"
 	private static readonly SAVE_DEBOUNCE_MS = 2000
+	private static readonly MAX_FILES_PER_SCAN = getPositiveIntegerEnv("DIRAC_SYMBOL_INDEX_MAX_FILES", 20_000)
+	private static readonly MAX_SCAN_QUEUE_LENGTH = getPositiveIntegerEnv("DIRAC_SYMBOL_INDEX_MAX_SCAN_QUEUE", 100_000)
+	private static readonly MAX_SYMBOLS_PER_FILE = getPositiveIntegerEnv("DIRAC_SYMBOL_INDEX_MAX_SYMBOLS_PER_FILE", 2_000)
+	private static readonly MAX_REFERENCES_PER_FILE = getPositiveIntegerEnv("DIRAC_SYMBOL_INDEX_MAX_REFERENCES_PER_FILE", 1_000)
 	private static readonly VERSION = 1
 
 	private projectRoot = ""
@@ -126,6 +143,7 @@ export class SymbolIndexService {
 	private isPersistenceEnabled = true
 	private skipRepoCheck = false
 	private pendingUpdates: Set<string> = new Set()
+	private ignoreMatcher: ReturnType<typeof ignore> | null = null
 
 	private constructor() {}
 
@@ -143,6 +161,9 @@ export class SymbolIndexService {
 
 	public setPersistenceEnabled(enabled: boolean): void {
 		this.isPersistenceEnabled = enabled
+		if (!enabled) {
+			this.clearSaveTimer()
+		}
 	}
 
 	private async isRepository(dirPath: string): Promise<boolean> {
@@ -167,33 +188,32 @@ export class SymbolIndexService {
 
 		const isRepo = this.skipRepoCheck || (await this.isRepository(projectRoot))
 		if (!isRepo) {
-			Logger.info(`[SymbolIndexService] ${projectRoot} is not a repository. Skipping indexing to prevent performance issues.`)
+			Logger.info(
+				`[SymbolIndexService] ${projectRoot} is not a repository. Skipping indexing to prevent performance issues.`,
+			)
 			return
 		}
-
-
 		this.isScanningInternal = true
 		try {
 			const oldRoot = this.projectRoot
 			this.projectRoot = projectRoot
+			this.ignoreMatcher = await this.loadIgnoreMatcher(projectRoot)
 
 			if (oldRoot !== projectRoot) {
 				Logger.info(`[SymbolIndexService] Root changed from ${oldRoot} to ${projectRoot}`)
 				this.scanQueue = []
 				this.pendingUpdates.clear()
-
-				if (this.db) {
-					Logger.info("[SymbolIndexService] Closing old database")
-					this.db.close()
-					this.db = null
-				}
+				this.clearSaveTimer()
+				this.closeDatabase("root change")
 
 				if (this.isPersistenceEnabled) {
 					await this.ensureIndexDir()
 					await this.excludeIndexDirFromGit()
 				}
-				const dbPath = path.join(this.projectRoot, SymbolIndexService.INDEX_DIR, SymbolIndexService.INDEX_FILE)
-				Logger.info(`[SymbolIndexService] Creating database instance at ${dbPath}`)
+				const dbPath = this.isPersistenceEnabled
+					? path.join(this.projectRoot, SymbolIndexService.INDEX_DIR, SymbolIndexService.INDEX_FILE)
+					: null
+				Logger.info(`[SymbolIndexService] Creating database instance${dbPath ? ` at ${dbPath}` : " in memory"}`)
 				this.db = await SymbolIndexDatabase.create(dbPath)
 			}
 			this.isFullScanInProgress = true
@@ -206,6 +226,44 @@ export class SymbolIndexService {
 			this.isFullScanInProgress = false
 			this.isScanningInternal = false
 		}
+	}
+
+	private clearSaveTimer(): void {
+		if (!this.saveTimeout) return
+		clearTimeout(this.saveTimeout)
+		this.saveTimeout = null
+	}
+
+	private closeDatabase(reason: string): void {
+		if (!this.db) return
+		const db = this.db
+		this.db = null
+		try {
+			Logger.info(`[SymbolIndexService] Closing database (${reason})`)
+			db.close(this.isPersistenceEnabled)
+		} catch (error) {
+			Logger.error(`[SymbolIndexService] Failed to close database during ${reason}:`, error)
+		}
+	}
+
+	private async loadIgnoreMatcher(projectRoot: string): Promise<ReturnType<typeof ignore> | null> {
+		const matcher = ignore()
+		let hasPatterns = false
+
+		for (const fileName of [".gitignore", ".diracignore"]) {
+			const ignorePath = path.join(projectRoot, fileName)
+			try {
+				const content = await fs.readFile(ignorePath, "utf8")
+				if (content.trim()) {
+					matcher.add(content)
+					hasPatterns = true
+				}
+			} catch {
+				// Ignore files are optional.
+			}
+		}
+
+		return hasPatterns ? matcher : null
 	}
 
 	private async ensureIndexDir(): Promise<void> {
@@ -248,7 +306,8 @@ export class SymbolIndexService {
 			const entry = SymbolIndexService.INDEX_DIR + "/"
 			if (!lines.some((line) => line.trim() === entry || line.trim() === SymbolIndexService.INDEX_DIR)) {
 				Logger.info(`[SymbolIndexService] Adding ${entry} to .git/info/exclude`)
-				const newContent = content.endsWith("\n") || content === "" ? content + entry + "\n" : content + "\n" + entry + "\n"
+				const newContent =
+					content.endsWith("\n") || content === "" ? content + entry + "\n" : content + "\n" + entry + "\n"
 				await fs.writeFile(excludePath, newContent)
 			}
 		} catch (error) {
@@ -263,8 +322,21 @@ export class SymbolIndexService {
 		return false
 	}
 
+	private isIgnoredRelPath(relPath: string, isDirectory = false): boolean {
+		if (!this.ignoreMatcher || !relPath) return false
+		const ignorePath = toIgnorePath(relPath)
+		return this.ignoreMatcher.ignores(ignorePath) || (isDirectory && this.ignoreMatcher.ignores(`${ignorePath}/`))
+	}
+
+	private isRelPathInsideProject(relPath: string): boolean {
+		return relPath !== "" && !relPath.startsWith("..") && !path.isAbsolute(relPath)
+	}
+
 	private shouldIndexFile(relPath: string): boolean {
-		const parts = relPath.split(path.sep)
+		if (!this.isRelPathInsideProject(relPath)) return false
+		if (this.isIgnoredRelPath(relPath)) return false
+
+		const parts = relPath.split(/[\\/]/)
 		for (const part of parts) {
 			if (this.isExcluded(part)) return false
 		}
@@ -283,12 +355,13 @@ export class SymbolIndexService {
 
 		let filesChecked = 0
 		let filesIndexed = 0
+		let scanLimitReached = false
 		const limit = pLimit(SymbolIndexService.PARALLEL_PARSING_LIMIT)
 
 		const nameCache = new Map<string, string>()
 		let languageParsers: Record<string, { parser: Parser; query: Parser.Query }> = {}
 		let queueIndex = 0
-		while (queueIndex < this.scanQueue.length) {
+		while (queueIndex < this.scanQueue.length && !scanLimitReached) {
 			if (this.projectRoot !== root) return
 
 			const filesToUpdate: { absolutePath: string; relPath: string }[] = []
@@ -299,18 +372,38 @@ export class SymbolIndexService {
 				itemsProcessedInBatch++
 
 				try {
-					const stats = await fs.stat(absolutePath)
+					const stats = await fs.lstat(absolutePath)
+					if (stats.isSymbolicLink()) {
+						continue
+					}
 
 					if (stats.isDirectory()) {
+						if (relPath && this.isIgnoredRelPath(relPath, true)) continue
 						const entries = await fs.readdir(absolutePath, { withFileTypes: true })
 						for (const entry of entries) {
 							if (this.isExcluded(entry.name)) continue
+							if (entry.isSymbolicLink()) continue
 							const entryAbsPath = path.join(absolutePath, entry.name)
 							const entryRelPath = relPath === "" ? entry.name : path.join(relPath, entry.name)
+							if (this.isIgnoredRelPath(entryRelPath, entry.isDirectory())) continue
+							if (this.scanQueue.length >= SymbolIndexService.MAX_SCAN_QUEUE_LENGTH) {
+								Logger.error(
+									`[SymbolIndexService] Scan queue reached ${SymbolIndexService.MAX_SCAN_QUEUE_LENGTH}; stopping traversal to prevent runaway indexing.`,
+								)
+								scanLimitReached = true
+								break
+							}
 							this.scanQueue.push({ absolutePath: entryAbsPath, relPath: entryRelPath })
 						}
 					} else if (stats.isFile()) {
 						if (this.shouldIndexFile(relPath)) {
+							if (filesChecked >= SymbolIndexService.MAX_FILES_PER_SCAN) {
+								Logger.error(
+									`[SymbolIndexService] Reached ${SymbolIndexService.MAX_FILES_PER_SCAN} indexable files; stopping scan to prevent oversized idle background index.`,
+								)
+								scanLimitReached = true
+								break
+							}
 							filesChecked++
 							const existing = this.db?.getFileMetadata(relPath)
 							const mtimeSecs = existing ? Math.floor(existing.mtime / 1000) : 0
@@ -370,7 +463,7 @@ export class SymbolIndexService {
 						)
 						const previousIndexed = filesIndexed
 						filesIndexed += validResults.length
-						if (!this.isFullScanInProgress || Math.floor(previousIndexed / 5000) < Math.floor(filesIndexed / 5000)) {
+						if (!this.isFullScanInProgress || Math.floor(previousIndexed / 1000) < Math.floor(filesIndexed / 1000)) {
 							this.scheduleSave()
 						}
 						Logger.info(`[SymbolIndexService] Indexed ${validResults.length} files in this batch`)
@@ -394,10 +487,13 @@ export class SymbolIndexService {
 	private async indexFile(
 		absolutePath: string,
 		languageParsers: Record<string, { parser: Parser; query: Parser.Query }>,
-		nameCache?: Map<string, string>
+		nameCache?: Map<string, string>,
 	): Promise<FileIndexEntry | null> {
 		try {
-			const stats = await fs.stat(absolutePath)
+			const stats = await fs.lstat(absolutePath)
+			if (stats.isSymbolicLink()) {
+				return null
+			}
 			if (stats.size > SymbolIndexService.MAX_FILE_SIZE) {
 				return null
 			}
@@ -414,11 +510,15 @@ export class SymbolIndexService {
 				if (!tree || !tree.rootNode) return null
 
 				const symbols: FileIndexEntry["symbols"] = []
+				let referenceCount = 0
 				const captures = query.captures(tree.rootNode)
 
 				for (const capture of captures) {
 					const { node, name } = capture
 					if (name === "name.reference" || name.includes("name.definition")) {
+						if (symbols.length >= SymbolIndexService.MAX_SYMBOLS_PER_FILE) break
+						const isReference = name === "name.reference"
+						if (isReference && referenceCount >= SymbolIndexService.MAX_REFERENCES_PER_FILE) continue
 						let text = fileContent.slice(node.startIndex, node.endIndex)
 						if (nameCache) {
 							const cached = nameCache.get(text)
@@ -430,10 +530,11 @@ export class SymbolIndexService {
 						}
 						symbols.push({
 							n: text,
-							t: name.includes("name.definition") ? "d" : "r",
+							t: isReference ? "r" : "d",
 							k: name.split(".").pop(),
 							r: [node.startPosition.row, node.startPosition.column, node.endPosition.row, node.endPosition.column],
 						})
+						if (isReference) referenceCount++
 					}
 				}
 
@@ -454,7 +555,7 @@ export class SymbolIndexService {
 		}
 	}
 
-		public getSymbols(symbol: string, type?: "definition" | "reference", limit?: number): SymbolLocation[] {
+	public getSymbols(symbol: string, type?: "definition" | "reference", limit?: number): SymbolLocation[] {
 		return this.db?.getSymbolsByName(symbol, type, limit) || []
 	}
 
@@ -480,6 +581,8 @@ export class SymbolIndexService {
 				this.db.updateFileSymbols(relPath, entry.mtime, entry.size, entry.symbols)
 				this.scheduleSave()
 			}
+		} catch (error) {
+			Logger.error(`[SymbolIndexService] Failed to update symbol index for ${absolutePath}:`, error)
 		} finally {
 			this.pendingUpdates.delete(absolutePath)
 		}
@@ -487,8 +590,13 @@ export class SymbolIndexService {
 
 	async removeFile(absolutePath: string): Promise<void> {
 		const relPath = path.relative(this.projectRoot, absolutePath)
-		this.db?.removeFile(relPath)
-		this.scheduleSave()
+		if (!this.isRelPathInsideProject(relPath)) return
+		try {
+			this.db?.removeFile(relPath)
+			this.scheduleSave()
+		} catch (error) {
+			Logger.error(`[SymbolIndexService] Failed to remove ${absolutePath} from symbol index:`, error)
+		}
 	}
 
 	private scheduleSave(): void {
@@ -503,20 +611,26 @@ export class SymbolIndexService {
 		}
 		this.saveTimeout = setTimeout(() => {
 			this.saveTimeout = null
-			if (this.db) {
-				this.db.save()
+			try {
+				if (this.db) {
+					const saved = this.db.save()
+					if (!saved) {
+						Logger.error(
+							"[SymbolIndexService] Disabling symbol-index persistence after save failure; in-memory lookup remains available for this session.",
+						)
+						this.isPersistenceEnabled = false
+					}
+				}
+			} catch (error) {
+				Logger.error("[SymbolIndexService] Unhandled symbol-index save failure; disabling persistence:", error)
+				this.isPersistenceEnabled = false
 			}
 		}, SymbolIndexService.SAVE_DEBOUNCE_MS)
+		this.saveTimeout.unref?.()
 	}
 
 	public dispose(): void {
-		if (this.saveTimeout) {
-			clearTimeout(this.saveTimeout)
-			this.saveTimeout = null
-		}
-		if (this.db) {
-			this.db.close()
-			this.db = null
-		}
+		this.clearSaveTimer()
+		this.closeDatabase("dispose")
 	}
 }

--- a/src/services/symbol-index/__tests__/SymbolIndexDatabase.test.ts
+++ b/src/services/symbol-index/__tests__/SymbolIndexDatabase.test.ts
@@ -1,0 +1,72 @@
+import * as assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import { SymbolIndexDatabase } from "../SymbolIndexDatabase"
+
+describe("SymbolIndexDatabase", () => {
+	let tmpDir: string
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "dirac-symbol-index-"))
+	})
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true })
+	})
+
+	function dbPath(): string {
+		return path.join(tmpDir, ".dirac-symbol-index", "data.db")
+	}
+
+	it("refuses to persist a database that exceeds the configured size cap", async () => {
+		const db = await SymbolIndexDatabase.create(dbPath(), { maxPersistedBytes: 1 })
+		db.updateFileSymbols("src/example.ts", Date.now(), 42, [{ n: "example", t: "d", k: "function", r: [0, 0, 0, 7] }])
+
+		assert.equal(db.save(), false)
+		assert.equal(fs.existsSync(dbPath()), false)
+		db.close(false)
+	})
+
+	it("saves atomically and reloads persisted symbols", async () => {
+		const db = await SymbolIndexDatabase.create(dbPath(), { maxPersistedBytes: 1024 * 1024 })
+		db.updateFileSymbols("src/example.ts", Date.now(), 42, [{ n: "example", t: "d", k: "function", r: [0, 0, 0, 7] }])
+
+		assert.equal(db.save(), true)
+		db.close(false)
+
+		assert.equal(fs.existsSync(dbPath()), true)
+		const tempFiles = fs.readdirSync(path.dirname(dbPath())).filter((name) => name.endsWith(".tmp"))
+		assert.deepEqual(tempFiles, [])
+
+		const reloaded = await SymbolIndexDatabase.create(dbPath(), { maxPersistedBytes: 1024 * 1024 })
+		const symbols = reloaded.getSymbolsByName("example", "definition")
+		assert.equal(symbols.length, 1)
+		assert.equal(symbols[0].path, "src/example.ts")
+		reloaded.close(false)
+	})
+
+	it("quarantines oversized existing databases before loading", async () => {
+		fs.mkdirSync(path.dirname(dbPath()), { recursive: true })
+		fs.writeFileSync(dbPath(), Buffer.alloc(64))
+
+		const db = await SymbolIndexDatabase.create(dbPath(), { maxPersistedBytes: 8 })
+
+		assert.equal(fs.existsSync(dbPath()), false)
+		const quarantined = fs.readdirSync(path.dirname(dbPath())).filter((name) => name.includes(".oversized-"))
+		assert.equal(quarantined.length, 1)
+		db.close(false)
+	})
+
+	it("quarantines corrupt existing databases and rebuilds", async () => {
+		fs.mkdirSync(path.dirname(dbPath()), { recursive: true })
+		fs.writeFileSync(dbPath(), "not a sqlite database")
+
+		const db = await SymbolIndexDatabase.create(dbPath(), { maxPersistedBytes: 1024 * 1024 })
+
+		assert.equal(fs.existsSync(dbPath()), false)
+		const quarantined = fs.readdirSync(path.dirname(dbPath())).filter((name) => name.includes(".corrupt-"))
+		assert.equal(quarantined.length, 1)
+		db.close(false)
+	})
+})

--- a/src/shared/services/worker/worker.ts
+++ b/src/shared/services/worker/worker.ts
@@ -151,7 +151,12 @@ export class SyncWorker {
 		}
 
 		this.emit({ type: WorkerEvent.WorkerStarted })
-		this.interval = setInterval(() => this.processQueue(), this.options.intervalMs)
+		this.interval = setInterval(() => {
+			this.processQueue().catch((err) => {
+				Logger.error("SyncWorker interval process error:", err)
+			})
+		}, this.options.intervalMs)
+		this.interval.unref?.()
 
 		// Run immediately but don't await
 		this.processQueue().catch((err) => {


### PR DESCRIPTION
## 🤖 Authored by AI coding agent: Major (opencode GPT-5.5 xhigh)
## Summary
- Adds symbol-index persistence guardrails on top of the existing chunked SQL.js DB I/O path: size caps, atomic writes, corrupt/oversized DB quarantine, and persistence disablement after failed saves.
- Bounds background indexing work by honoring ignore files, skipping symlinks, enforcing project boundaries, and capping scan/file/symbol/reference volume.
- Restores CLI ACP tool metadata for command, browser, file delete, and search operations so the CLI test suite reflects useful tool titles/kinds.

## Testing
- `npm run lint`
- `npm run format`
- `npx tsc --noEmit`
- `npm run build --workspace cli`
- `npm run test:run --workspace cli` (363 passing)
- `npm run test:unit -- --grep "SymbolIndexDatabase"` (4 passing)
- `git diff --check`

## Notes
- No UI changes; screenshots not applicable.
- No breaking changes expected.
- Authored by AI coding agent: Major (opencode GPT-5.5 xhigh) <major@redletterlabs.com>. Commits include matching Signed-off-by trailers.