### PR TITLE
feat(vscode): select the current file by default

### DIFF
--- a/proto/dirac/file.proto
+++ b/proto/dirac/file.proto
@@ -142,6 +142,7 @@ message FileSearchRequest {
   optional int32 limit = 4; // Optional limit for results (default: 20)
   optional FileSearchType selected_type = 5; // Optional selected type filter
   optional string workspace_hint = 6; // Optional workspace name to search in
+  optional bool prioritize_active_file = 7; // When true, the active editor file is placed first in results
 }
 
 // Result for file search operations

--- a/src/core/controller/file/searchFiles.ts
+++ b/src/core/controller/file/searchFiles.ts
@@ -5,6 +5,9 @@ import { convertSearchResultsToProtoFileInfos } from "@shared/proto-conversions/
 import { getWorkspacePath } from "@utils/path"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
+import { HostProvider } from "@/hosts/host-provider"
+import * as path from "path"
+import { workspaceResolver } from "@core/workspace"
 
 /**
  * Searches for files in the workspace with fuzzy matching
@@ -59,6 +62,42 @@ export async function searchFiles(controller: Controller, request: FileSearchReq
 				request.limit || 20, // Use default limit of 20 if not specified
 				selectedTypeString,
 			)
+		}
+
+		// If prioritize_active_file is set, place the active editor file at position 0
+		if (request.prioritizeActiveFile && searchResults.length > 0) {
+			try {
+				const activeEditorResponse = await HostProvider.window.getActiveEditor({})
+				const activeFilePath = activeEditorResponse.filePath
+				if (activeFilePath) {
+					// Convert absolute path to workspace-relative
+					const workspacePath = await getWorkspacePath()
+					if (workspacePath) {
+						const resolvedWs = workspaceResolver.resolveWorkspacePath(workspacePath, "", "searchFiles.prioritize")
+						const wsAbsPath = typeof resolvedWs === "string" ? resolvedWs : resolvedWs.absolutePath
+						const resolvedActive = workspaceResolver.resolveWorkspacePath(
+							activeFilePath,
+							"",
+							"searchFiles.prioritize",
+						)
+						const activeAbsPath = typeof resolvedActive === "string" ? resolvedActive : resolvedActive.absolutePath
+						let relativeActivePath = path.relative(wsAbsPath, activeAbsPath)
+						if (path.sep === "\\") {
+							relativeActivePath = relativeActivePath.replace(/\\/g, "/")
+						}
+						// Find and move the active file to position 0
+						const activeIndex = searchResults.findIndex(
+							(r) => r.path === relativeActivePath || r.path === `/${relativeActivePath}`,
+						)
+						if (activeIndex > 0) {
+							const [activeItem] = searchResults.splice(activeIndex, 1)
+							searchResults.unshift(activeItem)
+						}
+					}
+				}
+			} catch (err) {
+				Logger.error("Error prioritizing active file:", err)
+			}
 		}
 
 		// Convert search results to proto FileInfo objects using the conversion function

--- a/webview-ui/src/features/chat/components/ChatTextArea.tsx
+++ b/webview-ui/src/features/chat/components/ChatTextArea.tsx
@@ -17,25 +17,25 @@ import { useSettingsStore } from "@/features/settings/store/settingsStore"
 import { cn } from "@/lib/utils"
 import { FileServiceClient, StateServiceClient } from "@/shared/api/grpc-client"
 import {
-    ContextMenuOptionType,
-    getContextMenuOptionIndex,
-    getContextMenuOptions,
-    insertMention,
-    insertMentionDirectly,
-    removeMention,
-    type SearchResult,
-    shouldShowContextMenu,
+	ContextMenuOptionType,
+	getContextMenuOptionIndex,
+	getContextMenuOptions,
+	insertMention,
+	insertMentionDirectly,
+	removeMention,
+	type SearchResult,
+	shouldShowContextMenu,
 } from "@/shared/lib/context-mentions"
 import { useMetaKeyDetection, useShortcut } from "@/shared/lib/hooks"
 import { isSafari } from "@/shared/lib/platformUtils"
 import {
-    getMatchingSlashCommands,
-    insertSlashCommand,
-    removeSlashCommand,
-    shouldShowSlashCommandsMenu,
-    slashCommandDeleteRegex,
-    slashCommandRegexGlobal,
-    validateSlashCommand,
+	getMatchingSlashCommands,
+	insertSlashCommand,
+	removeSlashCommand,
+	shouldShowSlashCommandsMenu,
+	slashCommandDeleteRegex,
+	slashCommandRegexGlobal,
+	validateSlashCommand,
 } from "@/shared/lib/slash-commands"
 import Thumbnails from "@/shared/ui/Thumbnails"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip"
@@ -258,6 +258,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									query: "",
 									mentionsRequestId: "",
 									selectedType: searchType,
+									prioritizeActiveFile: true,
 								}),
 							)
 								.then((results: any) => {
@@ -677,6 +678,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									mentionsRequestId: query,
 									selectedType: searchType,
 									workspaceHint: workspaceHint,
+									prioritizeActiveFile: true,
 								}),
 							)
 								.then((results: any) => {


### PR DESCRIPTION
When we use `@` to add file context, select the current file by default.

## Manual tests

### Select current file by default
<img width="1128" height="682" alt="Screenshot 2026-05-13 at 18 32 11" src="https://github.com/user-attachments/assets/5788a2cc-12eb-44f4-9c61-a5061a458f9b" />
<img width="1148" height="691" alt="Screenshot 2026-05-13 at 18 32 26" src="https://github.com/user-attachments/assets/7b94d35e-b3b3-44be-807e-a54a0f6e0f5b" />

### Searching works as usual
<img width="1147" height="693" alt="Screenshot 2026-05-13 at 18 32 38" src="https://github.com/user-attachments/assets/c325b649-f2c4-401f-a42c-f7b139b95de4" />
