### PR TITLE
fix: the color of slash menu item is not right for light themes

### DIFF
--- a/webview-ui/src/features/chat/components/SlashCommandMenu.tsx
+++ b/webview-ui/src/features/chat/components/SlashCommandMenu.tsx
@@ -89,7 +89,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 		return (
 			<>
 				<div
-					className="text-xs text-(--vscode-descriptionForeground) px-3 py-1 font-bold border-b border-(--vscode-editorGroup-border)"
+					className="text-xs opacity-70 px-3 py-1 font-bold border-b border-(--vscode-editorGroup-border)"
 					role="presentation">
 					{title}
 				</div>
@@ -102,7 +102,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 								itemIndex === selectedIndex
 									? "bg-(--vscode-quickInputList-focusBackground) text-(--vscode-quickInputList-focusForeground)"
 									: ""
-							} hover:bg-(--vscode-list-hoverBackground)`}
+							}`}
 							id={`slash-command-menu-item-${itemIndex}`}
 							key={command.name}
 							onClick={() => handleClick(command)}
@@ -112,7 +112,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 								<span className="ph-no-capture">/{command.name}</span>
 							</div>
 							{showDescriptions && command.description && (
-								<div className="text-[0.85em] text-(--vscode-descriptionForeground) whitespace-normal overflow-hidden text-ellipsis">
+								<div className="text-[0.85em] whitespace-normal overflow-hidden text-ellipsis opacity-80">
 									<span className="ph-no-capture">{command.description}</span>
 								</div>
 							)}
@@ -144,7 +144,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
 					</>
 				) : (
 					<div aria-selected="false" className="py-2 px-3 cursor-default flex flex-col" role="option">
-						<div className="text-[0.85em] text-(--vscode-descriptionForeground)">No matching commands found</div>
+						<div className="text-[0.85em] opacity-70">No matching commands found</div>
 					</div>
 				)}
 			</div>


### PR DESCRIPTION
When I use a light theme like Light 2026, the menu items make my eyes uncomfortable.

## Tests

### Current state
<img width="627" height="294" alt="Screenshot 2026-05-14 at 14 52 41" src="https://github.com/user-attachments/assets/1d24f2e2-5606-4b23-8f74-5dd2d2315fb8" />

### Fixed
<img width="626" height="312" alt="Screenshot 2026-05-14 at 14 52 17" src="https://github.com/user-attachments/assets/3075d9d1-5e5c-447a-8932-8c8cbd6d2dd9" />

