### PR TITLE
fix(vscode): the icon for generate commit message is invisible

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,15 +55,6 @@
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
-		"icons": {
-			"dirac-icon": {
-				"description": "dirac",
-				"default": {
-					"fontPath": "node_modules/@vscode/codicons/dist/codicon.ttf",
-					"fontCharacter": "\\e900"
-				}
-			}
-		},
 		"walkthroughs": [
 			{
 				"id": "DiracWalkthrough",
@@ -168,7 +159,10 @@
 				"command": "dirac.generateGitCommitMessage",
 				"title": "Generate Commit Message with Dirac",
 				"category": "Dirac",
-				"icon": "$(dirac-icon)"
+				"icon": {
+					"light": "assets/icons/icon.svg",
+					"dark": "assets/icons/icon.svg"
+				}
 			},
 			{
 				"command": "dirac.abortGitCommitMessage",
@@ -255,10 +249,6 @@
 				"win": "ctrl+'",
 				"linux": "ctrl+'",
 				"when": "editorHasSelection"
-			},
-			{
-				"command": "dirac.generateGitCommitMessage",
-				"when": "config.git.enabled && scmProvider == git"
 			},
 			{
 				"command": "dirac.focusChatInput",

--- a/src/hosts/vscode/hostbridge/workspace/executeCommandInTerminal.ts
+++ b/src/hosts/vscode/hostbridge/workspace/executeCommandInTerminal.ts
@@ -1,5 +1,6 @@
 import { ExecuteCommandInTerminalRequest, ExecuteCommandInTerminalResponse } from "@shared/proto/host/workspace"
 import * as vscode from "vscode"
+import { getDiracIconUri } from "@/hosts/vscode/iconUtils"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -14,7 +15,7 @@ export async function executeCommandInTerminal(
 		// Create terminal with fixed options
 		const terminalOptions: vscode.TerminalOptions = {
 			name: "Dirac",
-			iconPath: new vscode.ThemeIcon("dirac-icon"),
+			iconPath: getDiracIconUri(),
 			env: {
 				DIRAC_ACTIVE: "true",
 			},

--- a/src/hosts/vscode/iconUtils.ts
+++ b/src/hosts/vscode/iconUtils.ts
@@ -1,0 +1,6 @@
+import * as vscode from "vscode"
+import { HostProvider } from "@/hosts/host-provider"
+
+export function getDiracIconUri(): vscode.Uri {
+	return vscode.Uri.joinPath(vscode.Uri.file(HostProvider.get().extensionFsPath), "assets", "icons", "icon.svg")
+}

--- a/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
+++ b/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { getDiracIconUri } from "@/hosts/vscode/iconUtils"
 
 export interface TerminalInfo {
 	terminal: vscode.Terminal
@@ -28,7 +29,7 @@ export class TerminalRegistry {
 		const terminalOptions: vscode.TerminalOptions = {
 			cwd,
 			name: "Dirac",
-			iconPath: new vscode.ThemeIcon("dirac-icon"),
+			iconPath: getDiracIconUri(),
 			env: {
 				DIRAC_ACTIVE: "true",
 				...env,


### PR DESCRIPTION
Fix #81.
The problem is that `\\e900` is invalid in that font. Let's just use the existing icon in assets.
<img width="569" height="285" alt="Screenshot 2026-05-15 at 11 24 44" src="https://github.com/user-attachments/assets/abadf38f-22ff-411a-a78d-fb7da7bcd334" />
