### PR TITLE
fix: keep Ink raw mode alive on Windows view transitions

### DIFF
--- a/cli/src/components/App.auth-navigation.test.tsx
+++ b/cli/src/components/App.auth-navigation.test.tsx
@@ -1,0 +1,111 @@
+import { Text } from "ink"
+import { render } from "ink-testing-library"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { App } from "./App"
+
+const inkMocks = vi.hoisted(() => ({
+	resume: vi.fn(),
+	setRawMode: vi.fn(),
+}))
+
+const authViewState = vi.hoisted(() => ({
+	props: undefined as
+		| {
+				onNavigateToWelcome?: () => void
+		  }
+		| undefined,
+}))
+
+vi.mock("ink", async () => {
+	const actual = await vi.importActual<typeof import("ink")>("ink")
+
+	return {
+		...actual,
+		useStdin: () => ({
+			stdin: { resume: inkMocks.resume },
+			setRawMode: inkMocks.setRawMode,
+			isRawModeSupported: true,
+		}),
+	}
+})
+
+vi.mock("ink-picture", () => ({
+	TerminalInfoProvider: ({ children }: any) => children,
+}))
+
+vi.mock("./ChatView", () => ({
+	ChatView: () => React.createElement(Text, null, "ChatView"),
+}))
+
+vi.mock("./TaskJsonView", () => ({
+	TaskJsonView: () => React.createElement(Text, null, "TaskJsonView"),
+}))
+
+vi.mock("./HistoryView", () => ({
+	HistoryView: () => React.createElement(Text, null, "HistoryView"),
+}))
+
+vi.mock("./ConfigView", () => ({
+	ConfigView: () => React.createElement(Text, null, "ConfigView"),
+}))
+
+vi.mock("./AuthView", () => ({
+	AuthView: (props: any) => {
+		authViewState.props = props
+		return React.createElement(Text, null, "AuthView")
+	},
+}))
+
+vi.mock("../context/TaskContext", () => ({
+	TaskContextProvider: ({ children }: any) => children,
+}))
+
+vi.mock("../hooks/useTerminalSize", () => ({
+	useTerminalSize: () => ({ columns: 80, rows: 24, resizeKey: 0 }),
+}))
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform) {
+	Object.defineProperty(process, "platform", {
+		configurable: true,
+		value: platform,
+	})
+}
+
+describe("App auth navigation", () => {
+	beforeEach(() => {
+		authViewState.props = undefined
+		inkMocks.resume.mockReset()
+		inkMocks.setRawMode.mockReset()
+	})
+
+	afterEach(() => {
+		setPlatform(originalPlatform)
+	})
+
+	it("keeps the session raw-mode claim alive across auth to welcome navigation on Windows", async () => {
+		setPlatform("win32")
+
+		const { lastFrame, unmount } = render(<App controller={{}} isRawModeSupported={true} view="auth" />)
+
+		await Promise.resolve()
+
+		expect(lastFrame()).toContain("AuthView")
+		expect(authViewState.props?.onNavigateToWelcome).toBeTypeOf("function")
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(1, true)
+		expect(inkMocks.resume).toHaveBeenCalledTimes(1)
+		expect(inkMocks.setRawMode.mock.calls.some(([isEnabled]) => isEnabled === false)).toBe(false)
+
+		authViewState.props?.onNavigateToWelcome?.()
+		await new Promise((resolve) => setTimeout(resolve, 0))
+
+		expect(lastFrame()).toContain("ChatView")
+		expect(inkMocks.setRawMode.mock.calls.some(([isEnabled]) => isEnabled === false)).toBe(false)
+
+		unmount()
+
+		expect(inkMocks.setRawMode.mock.calls.some(([isEnabled]) => isEnabled === false)).toBe(true)
+	})
+})

--- a/cli/src/context/StdinContext.test.tsx
+++ b/cli/src/context/StdinContext.test.tsx
@@ -1,0 +1,118 @@
+import { Text } from "ink"
+import { render } from "ink-testing-library"
+import React from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { StdinProvider } from "./StdinContext"
+
+const inkMocks = vi.hoisted(() => ({
+	resume: vi.fn(),
+	setRawMode: vi.fn(),
+}))
+
+vi.mock("ink", async () => {
+	const actual = await vi.importActual<typeof import("ink")>("ink")
+
+	return {
+		...actual,
+		useStdin: () => ({
+			stdin: { resume: inkMocks.resume },
+			setRawMode: inkMocks.setRawMode,
+			isRawModeSupported: true,
+		}),
+	}
+})
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform) {
+	Object.defineProperty(process, "platform", {
+		configurable: true,
+		value: platform,
+	})
+}
+
+describe("StdinProvider", () => {
+	beforeEach(() => {
+		inkMocks.resume.mockReset()
+		inkMocks.setRawMode.mockReset()
+	})
+
+	afterEach(() => {
+		setPlatform(originalPlatform)
+	})
+
+	it("keeps raw mode enabled for the full provider lifetime on Windows", () => {
+		setPlatform("win32")
+
+		const { unmount } = render(
+			<StdinProvider isRawModeSupported={true}>
+				<Text>child</Text>
+			</StdinProvider>,
+		)
+
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(1, true)
+		expect(inkMocks.resume).toHaveBeenCalledTimes(1)
+
+		unmount()
+
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(2, false)
+	})
+
+	it("does not force raw mode when raw mode is unsupported", () => {
+		setPlatform("win32")
+
+		const { unmount } = render(
+			<StdinProvider isRawModeSupported={false}>
+				<Text>child</Text>
+			</StdinProvider>,
+		)
+
+		expect(inkMocks.setRawMode).not.toHaveBeenCalled()
+		expect(inkMocks.resume).not.toHaveBeenCalled()
+
+		unmount()
+		expect(inkMocks.setRawMode).not.toHaveBeenCalled()
+	})
+
+	it("does not keep a session raw-mode claim alive on non-Windows platforms", () => {
+		setPlatform("linux")
+
+		const { unmount } = render(
+			<StdinProvider isRawModeSupported={true}>
+				<Text>child</Text>
+			</StdinProvider>,
+		)
+
+		expect(inkMocks.setRawMode).not.toHaveBeenCalled()
+		expect(inkMocks.resume).not.toHaveBeenCalled()
+
+		unmount()
+		expect(inkMocks.setRawMode).not.toHaveBeenCalled()
+	})
+
+	it("balances the session raw-mode claim across remount cycles on Windows", () => {
+		setPlatform("win32")
+
+		const firstRender = render(
+			<StdinProvider isRawModeSupported={true}>
+				<Text>first mount</Text>
+			</StdinProvider>,
+		)
+
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(1, true)
+
+		firstRender.unmount()
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(2, false)
+
+		const secondRender = render(
+			<StdinProvider isRawModeSupported={true}>
+				<Text>second mount</Text>
+			</StdinProvider>,
+		)
+
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(3, true)
+
+		secondRender.unmount()
+		expect(inkMocks.setRawMode).toHaveBeenNthCalledWith(4, false)
+	})
+})

--- a/cli/src/context/StdinContext.tsx
+++ b/cli/src/context/StdinContext.tsx
@@ -4,7 +4,8 @@
  * (e.g., when input is piped: echo "..." | diracdev)
  */
 
-import React, { createContext, type ReactNode, useContext } from "react"
+import { useStdin } from "ink"
+import React, { createContext, type ReactNode, useContext, useEffect } from "react"
 
 interface StdinContextValue {
 	/**
@@ -23,8 +24,38 @@ interface StdinProviderProps {
 	isRawModeSupported: boolean
 }
 
+const WindowsSessionRawModeKeeper: React.FC<{ isRawModeSupported: boolean }> = ({ isRawModeSupported }) => {
+	const { setRawMode, stdin } = useStdin()
+
+	useEffect(() => {
+		if (process.platform !== "win32" || !isRawModeSupported) {
+			return
+		}
+
+		// Keep one Ink raw-mode claim alive for the full session so view transitions
+		// do not briefly drop keyboard handling on Windows.
+		setRawMode(true)
+		if (stdin && typeof stdin.resume === "function") {
+			stdin.resume()
+		}
+
+		return () => {
+			// Leave pause/resume restoration to the outer runInkApp cleanup, which
+			// records and restores the original stdin paused state for the session.
+			setRawMode(false)
+		}
+	}, [isRawModeSupported, setRawMode, stdin])
+
+	return null
+}
+
 export const StdinProvider: React.FC<StdinProviderProps> = ({ children, isRawModeSupported }) => {
-	return <StdinContext.Provider value={{ isRawModeSupported }}>{children}</StdinContext.Provider>
+	return (
+		<StdinContext.Provider value={{ isRawModeSupported }}>
+			<WindowsSessionRawModeKeeper isRawModeSupported={isRawModeSupported} />
+			{children}
+		</StdinContext.Provider>
+	)
 }
 
 /**

--- a/cli/src/utils/ink.ts
+++ b/cli/src/utils/ink.ts
@@ -7,6 +7,19 @@ export async function runInkApp(element: any, cleanup: () => Promise<void>): Pro
 
 	// Clear terminal for clean UI - robot will render at row 1
 	process.stdout.write("\x1b[2J\x1b[H")
+	const shouldPrimeRawMode =
+		process.platform === "win32" && process.stdin.isTTY && typeof process.stdin.setRawMode === "function"
+	const wasRaw = process.stdin.isRaw === true
+	const wasPaused = process.stdin.isPaused()
+
+	if (shouldPrimeRawMode) {
+		try {
+			process.stdin.setRawMode(true)
+			process.stdin.resume()
+		} catch {
+			// Ink will still attempt to initialize raw mode.
+		}
+	}
 
 	// Note: incrementalRendering is enabled to reduce terminal bandwidth and improve responsiveness.
 	// We previously disabled this due to resize glitches, but our useTerminalSize hook now
@@ -27,6 +40,16 @@ export async function runInkApp(element: any, cleanup: () => Promise<void>): Pro
 			unmount()
 		} catch {
 			// Already unmounted
+		}
+		if (shouldPrimeRawMode) {
+			try {
+				process.stdin.setRawMode(wasRaw)
+				if (wasPaused) {
+					process.stdin.pause()
+				}
+			} catch {
+				// Ignore cleanup failures on nonstandard terminals.
+			}
 		}
 		restoreConsole()
 		await cleanup()


### PR DESCRIPTION
## Summary
- prime stdin raw mode before the first Ink render on Windows
- keep one Ink raw-mode claim alive for the full mounted session so internal view changes do not briefly disable keyboard handling
- add focused tests for the Windows session keeper and the auth -> welcome transition

## Context
I am submitting this PR as AI assistance on behalf of a Windows user who ran into this bug during normal Dirac use.

The original auth-screen fix was only partial. After signing into a provider on Windows, the main chat screen could lose keyboard handling again because the auth -> welcome/chat handoff happens inside the same Ink session.

## Reproduction
Before this change on Windows:
- run dirac auth
- complete a provider login or setup flow
- land on the next screen
- arrow keys and other keyboard handling can stop working again until Enter is pressed

Expected behavior:
- Ink keyboard handling should work immediately on first render and remain live across internal view transitions

## Fix
- pre-enable raw mode on Windows before calling Ink render()
- keep a session-level raw-mode owner mounted in StdinProvider for the full Ink session
- leave pause/resume restoration to the outer cleanup that already tracks the original stdin state
- keep the workaround scoped to win32 TTY environments only

## Validation
- npm run test:run -- src/context/StdinContext.test.tsx src/components/App.auth-navigation.test.tsx
- npm run typecheck

## Notes
- this remains intentionally scoped to Windows
- I could not fully automate the real arrow-key terminal repro through the terminal tool here because it appends Enter to sent input, so the included tests cover the specific auth -> welcome transition that regressed after the first PR revision