### PR TITLE
refactor: simplify the isFirstRequest check

### DIFF
--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1354,7 +1354,7 @@ ${notice}`
 		userContent = mistakeResult.userContent
 
 		const previousApiReqIndex = findLastIndex(this.messageStateHandler.getDiracMessages(), (m) => m.say === "api_req_started")
-		const isFirstRequest = this.messageStateHandler.getDiracMessages().filter((m) => m.say === "api_req_started").length === 0
+		const isFirstRequest = previousApiReqIndex === -1
 		await this.initializeCheckpoints(isFirstRequest)
 
 		const useCompactPrompt = customPrompt === "compact" && isLocalModel(this.getCurrentProviderInfo())


### PR DESCRIPTION
Well, this `filter` basically confirms that no `api_req_started` message exists, we could just reuse the result in the previous line.