### PR TITLE
fix: should not ignore all generated content

### DIFF
--- a/src/core/ignore/DiracIgnoreController.ts
+++ b/src/core/ignore/DiracIgnoreController.ts
@@ -42,7 +42,6 @@ export const DEFAULT_IGNORE_PATTERNS = [
 	"target",
 	"bin",
 	"obj",
-	"generated",
 	"gen",
 	"CMakeFiles",
 	".gradle",


### PR DESCRIPTION
In some project, `generated` might contain information that can help the model understand the project, we should not just ignore them. For example, in my toy project, I use a script to generate data for an Astro site, when debugging, the agent naturally want to check if the generated content is in a good shape.