### PR TITLE
fix: gate OpenRouter/Vercel AI Gateway prompt-cache markers by supportsPromptCache

### DIFF
--- a/src/core/api/transform/__tests__/openrouter-stream.test.ts
+++ b/src/core/api/transform/__tests__/openrouter-stream.test.ts
@@ -23,11 +23,11 @@ describe("createOpenRouterStream", () => {
 		}
 	}
 
-	const createModelInfo = (maxTokens: number): ModelInfo => ({
+	const createModelInfo = (maxTokens: number, supportsPromptCache = false): ModelInfo => ({
 		maxTokens,
 		contextWindow: 1_048_576,
 		supportsImages: true,
-		supportsPromptCache: false,
+		supportsPromptCache,
 	})
 
 	it("caps Gemini Flash OpenRouter requests to 32768 max_tokens", async () => {
@@ -76,5 +76,42 @@ describe("createOpenRouterStream", () => {
 
 		const payload = create.firstCall.args[0] as Record<string, unknown>
 		payload.should.have.property("max_tokens", 32_768)
+	})
+
+	it("adds cache_control blocks when the model reports supportsPromptCache, regardless of id", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "deepseek/deepseek-chat",
+			info: createModelInfo(65_536, true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("adds cache_control blocks for MiniMax models even without the flag", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "minimax/minimax-m2",
+			info: createModelInfo(65_536, false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("does not add cache_control blocks for models without prompt cache support", async () => {
+		const { client, create } = createClient()
+
+		await createOpenRouterStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "google/gemini-2.5-pro",
+			info: createModelInfo(65_536, false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content.should.be.a.String()
 	})
 })

--- a/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
+++ b/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
@@ -56,6 +56,19 @@ describe("createVercelAIGatewayStream", () => {
 		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
 	})
 
+	it("adds cache_control blocks for Anthropic models even when the flag is unset", async () => {
+		// Guards against registry pricing data being missing or stale for an Anthropic model.
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-4.5",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
 	it("adds cache_control blocks for MiniMax models even without the flag", async () => {
 		const { client, create } = createClient()
 

--- a/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
+++ b/src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "mocha"
+import "should"
+import type { ModelInfo } from "@shared/api"
+import sinon from "sinon"
+import { createVercelAIGatewayStream } from "../vercel-ai-gateway-stream"
+
+describe("createVercelAIGatewayStream", () => {
+	const createAsyncIterable = () => ({
+		async *[Symbol.asyncIterator]() {},
+	})
+
+	const createClient = () => {
+		const create = sinon.stub().resolves(createAsyncIterable())
+		return {
+			client: {
+				chat: {
+					completions: {
+						create,
+					},
+				},
+			},
+			create,
+		}
+	}
+
+	const createModelInfo = (supportsPromptCache: boolean): ModelInfo => ({
+		maxTokens: 8_192,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache,
+	})
+
+	it("adds cache_control blocks when the model reports supportsPromptCache", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "anthropic/claude-sonnet-4.5",
+			info: createModelInfo(true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("adds cache_control blocks for non-anthropic cache-capable models", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "zai/glm-4.6",
+			info: createModelInfo(true),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+		payload.messages[1].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("adds cache_control blocks for MiniMax models even without the flag", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "minimax/minimax-m2",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content[0].cache_control.should.deepEqual({ type: "ephemeral" })
+	})
+
+	it("does not add cache_control blocks for models without prompt cache support", async () => {
+		const { client, create } = createClient()
+
+		await createVercelAIGatewayStream(client as any, "system prompt", [{ role: "user", content: "hello" }] as any, {
+			id: "openai/gpt-4o",
+			info: createModelInfo(false),
+		})
+
+		const payload = create.firstCall.args[0] as any
+		payload.messages[0].content.should.be.a.String()
+	})
+})

--- a/src/core/api/transform/openrouter-stream.ts
+++ b/src/core/api/transform/openrouter-stream.ts
@@ -21,6 +21,14 @@ import { convertToOpenAiMessages, sanitizeGeminiMessages } from "./openai-format
 import { addReasoningContent, convertToR1Format } from "./r1-format"
 import { getOpenAIToolParams } from "./tool-call-processor"
 
+function needsExplicitCacheControl(baseModelId: string, info: ModelInfo): boolean {
+	// Honor the capability flag the model registry computes (refreshOpenRouterModels.ts),
+	// so cache-capable models don't silently miss caching just because they're absent from
+	// the id list below. The id checks remain as a fallback for envelope-honoring families
+	// (Anthropic/MiniMax shapes) that may not be flagged in the registry yet.
+	return info.supportsPromptCache || baseModelId.startsWith("anthropic/") || baseModelId.startsWith("minimax/")
+}
+
 export async function createOpenRouterStream(
 	client: OpenAI,
 	systemPrompt: string,
@@ -68,73 +76,38 @@ export async function createOpenRouterStream(
 
 	// prompt caching: https://openrouter.ai/docs/prompt-caching
 	// this was initially specifically for claude models (some models may 'support prompt caching' automatically without this)
-	// handles direct model.id match logic
-	switch (baseModelId) {
-		case "anthropic/claude-opus-4.6":
-		case "anthropic/claude-haiku-4.5":
-		case "anthropic/claude-4.5-haiku":
-		case "anthropic/claude-sonnet-4.6":
-		case "anthropic/claude-4.6-sonnet":
-		case "anthropic/claude-sonnet-4.5":
-		case "anthropic/claude-4.5-sonnet": // OpenRouter accidentally included this in model list for a brief moment, and users may be using this model id. And to support prompt caching, we need to add it here.
-		case "anthropic/claude-sonnet-4":
-		case "anthropic/claude-opus-4.5":
-		case "anthropic/claude-opus-4.1":
-		case "anthropic/claude-opus-4":
-		case "anthropic/claude-3.7-sonnet":
-		case "anthropic/claude-3.7-sonnet:beta":
-		case "anthropic/claude-3.7-sonnet:thinking":
-		case "anthropic/claude-3-7-sonnet":
-		case "anthropic/claude-3-7-sonnet:beta":
-		case "anthropic/claude-3.5-sonnet":
-		case "anthropic/claude-3.5-sonnet:beta":
-		case "anthropic/claude-3.5-sonnet-20240620":
-		case "anthropic/claude-3.5-sonnet-20240620:beta":
-		case "anthropic/claude-3-5-haiku":
-		case "anthropic/claude-3-5-haiku:beta":
-		case "anthropic/claude-3-5-haiku-20241022":
-		case "anthropic/claude-3-5-haiku-20241022:beta":
-		case "anthropic/claude-3-haiku":
-		case "anthropic/claude-3-haiku:beta":
-		case "anthropic/claude-3-opus":
-		case "anthropic/claude-3-opus:beta":
-		case "minimax/minimax-m2":
-		case "minimax/minimax-m2.1":
-		case "minimax/minimax-m2.1-lightning":
-		case "minimax/minimax-m2.5":
-			openAiMessages[0] = {
-				role: "system",
-				content: [
-					{
-						type: "text",
-						text: systemPrompt,
-						// @ts-expect-error-next-line
-						cache_control: { type: "ephemeral" },
-					},
-				],
-			}
-			// Add cache_control to the last two user messages
-			// (note: this works because we only ever add one user message at a time, but if we added multiple we'd need to mark the user message before the last assistant message)
-			const lastTwoUserMessages = openAiMessages.filter((msg) => msg.role === "user").slice(-2)
-			lastTwoUserMessages.forEach((msg) => {
-				if (typeof msg.content === "string") {
-					msg.content = [{ type: "text", text: msg.content }]
-				}
-				if (Array.isArray(msg.content)) {
-					// NOTE: this is fine since env details will always be added at the end. but if it weren't there, and the user added a image_url type message, it would pop a text part before it and then move it after to the end.
-					let lastTextPart = msg.content.filter((part) => part.type === "text").pop()
-
-					if (!lastTextPart) {
-						lastTextPart = { type: "text", text: "..." }
-						msg.content.push(lastTextPart)
-					}
+	// gate the cache_control envelope by the registry capability flag instead of a hardcoded id list
+	if (needsExplicitCacheControl(baseModelId, model.info)) {
+		openAiMessages[0] = {
+			role: "system",
+			content: [
+				{
+					type: "text",
+					text: systemPrompt,
 					// @ts-expect-error-next-line
-					lastTextPart["cache_control"] = { type: "ephemeral" }
+					cache_control: { type: "ephemeral" },
+				},
+			],
+		}
+		// Add cache_control to the last two user messages
+		// (note: this works because we only ever add one user message at a time, but if we added multiple we'd need to mark the user message before the last assistant message)
+		const lastTwoUserMessages = openAiMessages.filter((msg) => msg.role === "user").slice(-2)
+		lastTwoUserMessages.forEach((msg) => {
+			if (typeof msg.content === "string") {
+				msg.content = [{ type: "text", text: msg.content }]
+			}
+			if (Array.isArray(msg.content)) {
+				// NOTE: this is fine since env details will always be added at the end. but if it weren't there, and the user added a image_url type message, it would pop a text part before it and then move it after to the end.
+				let lastTextPart = msg.content.filter((part) => part.type === "text").pop()
+
+				if (!lastTextPart) {
+					lastTextPart = { type: "text", text: "..." }
+					msg.content.push(lastTextPart)
 				}
-			})
-			break
-		default:
-			break
+				// @ts-expect-error-next-line
+				lastTextPart["cache_control"] = { type: "ephemeral" }
+			}
+		})
 	}
 
 	let temperature: number | undefined = model.info.temperature ?? (baseModelId.startsWith("anthropic/") ? undefined : 0)

--- a/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -43,12 +43,15 @@ export async function createVercelAIGatewayStream(
 	// Sanitize messages for Gemini models (removes tool_calls without reasoning_details)
 	openAiMessages = sanitizeGeminiMessages(openAiMessages, model.id)
 
-	// Prompt caching for supported models
-	// This handles cache_control for Claude and MiniMax models
-	const isAnthropicModel = model.id.startsWith("anthropic/")
+	// Prompt caching for supported models.
+	// Gate on the capability flag the model registry computes from pricing
+	// (refreshVercelAiGatewayModels.ts sets supportsPromptCache when the Gateway
+	// reports cache read/write pricing), so any cache-capable model gets cache_control
+	// rather than only ids that start with "anthropic/". Keep the MiniMax id check as a
+	// fallback for envelope-honoring shapes that may not be flagged by pricing.
 	const isMinimaxModel = model.id.startsWith("minimax/")
 
-	if (isAnthropicModel || isMinimaxModel) {
+	if (model.info.supportsPromptCache || isMinimaxModel) {
 		openAiMessages[0] = {
 			role: "system",
 			content: [

--- a/src/core/api/transform/vercel-ai-gateway-stream.ts
+++ b/src/core/api/transform/vercel-ai-gateway-stream.ts
@@ -47,11 +47,13 @@ export async function createVercelAIGatewayStream(
 	// Gate on the capability flag the model registry computes from pricing
 	// (refreshVercelAiGatewayModels.ts sets supportsPromptCache when the Gateway
 	// reports cache read/write pricing), so any cache-capable model gets cache_control
-	// rather than only ids that start with "anthropic/". Keep the MiniMax id check as a
-	// fallback for envelope-honoring shapes that may not be flagged by pricing.
+	// rather than only ids that start with "anthropic/". Keep the Anthropic/MiniMax id
+	// checks as a fallback for envelope-honoring families whose pricing data may be
+	// missing or stale in the registry (e.g. a new Anthropic model before pricing lands).
+	const isAnthropicModel = model.id.startsWith("anthropic/")
 	const isMinimaxModel = model.id.startsWith("minimax/")
 
-	if (model.info.supportsPromptCache || isMinimaxModel) {
+	if (model.info.supportsPromptCache || isAnthropicModel || isMinimaxModel) {
 		openAiMessages[0] = {
 			role: "system",
 			content: [


### PR DESCRIPTION
### Description

Two streaming transforms decide whether to attach `cache_control` markers using hardcoded model-id matching instead of the `supportsPromptCache` capability flag the model registries already compute. Models the registry knows are cache-capable therefore silently skip prompt caching, so every request pays full input price with no cache reads.

**1. OpenRouter — `src/core/api/transform/openrouter-stream.ts`**

The `cache_control` envelope was gated by a `switch (baseModelId)` over a fixed Anthropic/MiniMax id list, with `default: break` (no markers). It never consulted `model.info.supportsPromptCache`, which `refreshOpenRouterModels.ts` sets for a broader set of models (e.g. `deepseek/deepseek-chat`, the Claude `:beta` variants). Those models were never sent `cache_control` despite supporting it.

**2. Vercel AI Gateway — `src/core/api/transform/vercel-ai-gateway-stream.ts`**

Caching was gated on `model.id.startsWith("anthropic/")`, while `refreshVercelAiGatewayModels.ts:142` computes the capability dynamically from pricing:

```ts
supportsPromptCache: !!(rawModel.pricing?.input_cache_read && rawModel.pricing?.input_cache_write)
```

Any non-Anthropic model the Gateway prices with cache read/write gets `supportsPromptCache: true` from the registry but never receives `cache_control` from the transform.

**Fix**

Gate the `cache_control` envelope on `model.info.supportsPromptCache` (the same flag the registries set), keeping the Anthropic/MiniMax id checks as a fallback for envelope-honoring families so behavior for models not yet flagged in the registry is unchanged. The OpenRouter `switch` is replaced by a small capability-gated helper; the marker body is unchanged.

### Test Procedure

Extended `src/core/api/transform/__tests__/openrouter-stream.test.ts` and added `src/core/api/transform/__tests__/vercel-ai-gateway-stream.test.ts`:

- a cache-capable non-Anthropic id with `supportsPromptCache: true` (`deepseek/deepseek-chat`, `zai/glm-4.6`) now emits `cache_control` on the system block and last user message;
- a `supportsPromptCache: false` model (`google/gemini-2.5-pro`, `openai/gpt-4o`) does not;
- MiniMax still gets markers via the family fallback even without the flag.

Verified locally on Node 22:

- `mocha` (targeted unit tests): 11 passing, no regressions
- `tsc --noEmit`: clean for the touched files / `src`
- `biome lint` on the touched files: clean

### Notes

The same defect exists upstream in cline, where I've sent the equivalent fix: cline/cline#11595. This PR mirrors it at the flat `src/core/api/transform/...` paths used here.
