### PR TITLE
feat: support latest Claude Code CLI via structured JSON output

### DIFF
--- a/src/core/api/providers/__tests__/claude-code.test.ts
+++ b/src/core/api/providers/__tests__/claude-code.test.ts
@@ -226,6 +226,83 @@ describe("ClaudeCodeHandler", () => {
         })
     })
 
+    describe("structured output tool calls", () => {
+        async function collectToolCalls(toolUseContent: any) {
+            const runClaudeCodeModule = await import("@/integrations/claude-code/run")
+            const runClaudeCodeStub = sandbox.stub(runClaudeCodeModule, "runClaudeCode")
+
+            async function* mockGenerator() {
+                yield { type: "system", subtype: "init", apiKeySource: "none" }
+                yield {
+                    type: "assistant",
+                    message: {
+                        content: [toolUseContent],
+                        usage: { input_tokens: 10, output_tokens: 5 },
+                        stop_reason: "end_turn",
+                    },
+                }
+                // The CLI echoes a tool_result for the StructuredOutput call; it must be ignored.
+                yield {
+                    type: "user",
+                    message: {
+                        content: [
+                            { type: "tool_result", tool_use_id: "toolu_1", content: "Structured output provided successfully" },
+                        ],
+                    },
+                }
+                // Capping at one turn ends the run with an error_max_turns result (no `result` field),
+                // which still carries final cost and must be processed for usage.
+                yield { type: "result", subtype: "error_max_turns", is_error: true, total_cost_usd: 0 }
+            }
+
+            runClaudeCodeStub.returns(mockGenerator() as any)
+
+            const messages: DiracStorageMessage[] = [{ role: "user", content: "Hi" }]
+            const toolCalls: any[] = []
+            for await (const chunk of handler.createMessage("sys", messages)) {
+                if (chunk.type === "tool_calls") {
+                    toolCalls.push(chunk.tool_call)
+                }
+            }
+            return toolCalls
+        }
+
+        it("unwraps the StructuredOutput array form into native tool_calls", async () => {
+            const toolCalls = await collectToolCalls({
+                type: "tool_use",
+                id: "toolu_1",
+                name: "StructuredOutput",
+                input: {
+                    tool_calls: [
+                        { tool: "read_file", params: { path: "a.ts" } },
+                        { tool: "execute_command", params: { command: "ls" } },
+                    ],
+                },
+            })
+
+            toolCalls.should.have.length(2)
+            toolCalls[0].function.name.should.equal("read_file")
+            JSON.parse(toolCalls[0].function.arguments).should.deepEqual({ path: "a.ts" })
+            toolCalls[1].function.name.should.equal("execute_command")
+            JSON.parse(toolCalls[1].function.arguments).should.deepEqual({ command: "ls" })
+            // Must not surface the raw StructuredOutput wrapper.
+            toolCalls.some((c) => c.function.name === "StructuredOutput").should.equal(false)
+        })
+
+        it("unwraps the StructuredOutput single-object form", async () => {
+            const toolCalls = await collectToolCalls({
+                type: "tool_use",
+                id: "toolu_1",
+                name: "StructuredOutput",
+                input: { tool: "attempt_completion", params: { result: "done" } },
+            })
+
+            toolCalls.should.have.length(1)
+            toolCalls[0].function.name.should.equal("attempt_completion")
+            JSON.parse(toolCalls[0].function.arguments).should.deepEqual({ result: "done" })
+        })
+    })
+
     describe("getModel", () => {
         it("should return the correct model when specified", () => {
             const handler = new ClaudeCodeHandler({

--- a/src/core/api/providers/claude-code.ts
+++ b/src/core/api/providers/claude-code.ts
@@ -1,7 +1,13 @@
 import { filterMessagesForClaudeCode } from "@/integrations/claude-code/message-filter"
 import { runClaudeCode } from "@/integrations/claude-code/run"
+import {
+	buildStructuredToolSchema,
+	extractStructuredToolCalls,
+	STRUCTURED_OUTPUT_TOOL_NAME,
+} from "@/integrations/claude-code/structured-output"
 import { ClaudeCodeModelId, claudeCodeDefaultModelId, claudeCodeModels } from "@/shared/api"
 import { DiracStorageMessage } from "@/shared/messages/content"
+import type { DiracTool } from "@/shared/tools"
 import { type ApiHandler, CommonApiHandlerOptions } from ".."
 import { withRetry } from "../retry"
 import { type ApiStream, ApiStreamUsageChunk } from "../transform/stream"
@@ -24,9 +30,14 @@ export class ClaudeCodeHandler implements ApiHandler {
 		baseDelay: 2000,
 		maxDelay: 15000,
 	})
-	async *createMessage(systemPrompt: string, messages: DiracStorageMessage[]): ApiStream {
+	async *createMessage(systemPrompt: string, messages: DiracStorageMessage[], tools?: DiracTool[]): ApiStream {
 		// Filter out image blocks since Claude Code doesn't support them
 		const filteredMessages = filterMessagesForClaudeCode(messages)
+
+		// The `claude` CLI cannot accept Dirac's tool schemas as a native `tools` payload.
+		// Instead we encode them into a --json-schema structured-output contract, which the
+		// model fulfils by calling the injected StructuredOutput tool (unwrapped below).
+		const jsonSchema = tools && tools.length > 0 ? JSON.stringify(buildStructuredToolSchema(tools)) : undefined
 
 		const claudeProcess = runClaudeCode({
 			systemPrompt,
@@ -34,6 +45,7 @@ export class ClaudeCodeHandler implements ApiHandler {
 			path: this.options.claudeCodePath,
 			modelId: this.getModel().id,
 			thinkingBudgetTokens: this.options.thinkingBudgetTokens,
+			jsonSchema,
 		})
 
 		// Usage is included with assistant messages,
@@ -113,6 +125,29 @@ export class ClaudeCodeHandler implements ApiHandler {
 							}
 							break
 						case "tool_use":
+							// The --json-schema feature surfaces tool choices via an injected
+							// StructuredOutput tool. Unwrap its payload into real tool calls so
+							// they flow through Dirac's native tool pipeline.
+							if (content.name === STRUCTURED_OUTPUT_TOOL_NAME) {
+								const structuredCalls = extractStructuredToolCalls(content.input)
+								for (let idx = 0; idx < structuredCalls.length; idx++) {
+									const structuredCall = structuredCalls[idx]
+									const callId = `${content.id}_${idx}`
+									yield {
+										type: "tool_calls",
+										tool_call: {
+											call_id: callId,
+											function: {
+												id: callId,
+												name: structuredCall.tool,
+												arguments: JSON.stringify(structuredCall.params ?? {}),
+											},
+										},
+									}
+								}
+								break
+							}
+
 							// Yield tool_use blocks to the streaming pipeline for proper tool execution
 							yield {
 								type: "tool_calls",
@@ -141,7 +176,9 @@ export class ClaudeCodeHandler implements ApiHandler {
 				continue
 			}
 
-			if (chunk.type === "result" && "result" in chunk) {
+			if (chunk.type === "result") {
+				// The StructuredOutput tool call is streamed on the assistant turn above; the
+				// result event (success or the expected error_max_turns) only carries final cost.
 				usage.totalCost = isPaidUsage ? chunk.total_cost_usd : 0
 
 				yield usage

--- a/src/integrations/claude-code/run.test.ts
+++ b/src/integrations/claude-code/run.test.ts
@@ -81,6 +81,24 @@ describe("Claude Code Integration", () => {
 		sinon.restore()
 	})
 
+	it("isolates the run from the user's ambient Claude Code environment", async () => {
+		const cProcess = runClaudeCode({
+			systemPrompt: "a",
+			messages: [],
+			modelId: "test",
+			path: scriptPath,
+		})
+
+		for await (const _chunk of cProcess) {
+			// drain the generator so runProcess (and execa) is invoked
+		}
+
+		const params = mockExeca.lastCall.args[1]
+		expect(params).to.include("--strict-mcp-config")
+		expect(params).to.include("--disable-slash-commands")
+		expect(params).to.include("--no-session-persistence")
+	})
+
 	const itCallsTheScriptWithAFile = (systemPrompt: string) => {
 		it("calls the script using with a file", async () => {
 			const cProcess = runClaudeCode({
@@ -159,5 +177,77 @@ describe("Claude Code Integration", () => {
 				expect(params.includes("--system-prompt")).to.be.true
 			})
 		})
+	})
+})
+
+describe("Claude Code Integration - one-turn cap", () => {
+	// The run is capped at one turn, so the CLI streams the StructuredOutput tool call, emits an
+	// error_max_turns result, and exits non-zero. runClaudeCode must treat that as completion.
+	const RESULT_LINE = '{"type":"result","subtype":"error_max_turns","is_error":true,"total_cost_usd":0.01}'
+	const ASSISTANT_LINE =
+		'{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"StructuredOutput","input":{"tool_calls":[{"tool":"read_file","params":{"path":"p"}}]}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}'
+
+	const maxTurnsProcess = () => ({
+		stdin: { write: sinon.fake(), end: sinon.fake() },
+		stdout: { on: sinon.fake(), resume: sinon.fake() },
+		stderr: { on: sinon.fake(() => {}) },
+		on: sinon.fake((event: string, callback: (code: number) => void) => {
+			if (event === "close") {
+				setImmediate(() => callback(1))
+			}
+		}),
+		killed: false,
+		kill: sinon.fake(),
+		exitCode: 1,
+		// execa rejects on a non-zero exit; the `await cProcess` in runClaudeCode must therefore throw.
+		then: (_onResolve: (value: any) => void, onReject: (reason: any) => void) => {
+			setImmediate(() => onReject(new Error("Command failed with exit code 1")))
+			return Promise.resolve()
+		},
+		catch: () => Promise.resolve(),
+		finally: (callback: () => void) => {
+			setImmediate(callback)
+			return Promise.resolve()
+		},
+	})
+
+	const maxTurnsReadline = () => ({
+		async *[Symbol.asyncIterator]() {
+			yield ASSISTANT_LINE
+			yield RESULT_LINE
+			return
+		},
+		close: sinon.fake(),
+	})
+
+	const { runClaudeCode: runWithMaxTurns } = proxyquire("./run", {
+		"@/utils/path": { getCwd: () => Promise.resolve(path.resolve("./")) },
+		"node:os": { platform: () => "darwin" },
+		execa: { execa: sinon.fake(() => maxTurnsProcess()) },
+		readline: { createInterface: maxTurnsReadline },
+	})
+
+	afterEach(() => {
+		sinon.restore()
+	})
+
+	it("completes without throwing and still yields the result chunk", async () => {
+		const cProcess = runWithMaxTurns({
+			systemPrompt: "sys",
+			messages: [],
+			modelId: "test",
+			path: "echo",
+			jsonSchema: "{}",
+		})
+
+		const chunks: any[] = []
+		for await (const chunk of cProcess) {
+			chunks.push(chunk)
+		}
+
+		expect(chunks).to.have.length(2)
+		expect(chunks[1].type).to.equal("result")
+		expect(chunks[1].subtype).to.equal("error_max_turns")
+		expect(chunks[1].total_cost_usd).to.equal(0.01)
 	})
 })

--- a/src/integrations/claude-code/run.ts
+++ b/src/integrations/claude-code/run.ts
@@ -16,6 +16,7 @@ type ClaudeCodeOptions = {
 	modelId: string
 	thinkingBudgetTokens?: number
 	shouldUseFile?: boolean
+	jsonSchema?: string
 }
 
 type ProcessState = {
@@ -23,6 +24,7 @@ type ProcessState = {
 	error: Error | null
 	stderrLogs: string
 	exitCode: number | null
+	reachedMaxTurns: boolean
 }
 
 // The maximum argument length is longer than this,
@@ -53,6 +55,7 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 		stderrLogs: "",
 		exitCode: null,
 		partialData: null,
+		reachedMaxTurns: false,
 	}
 
 	try {
@@ -80,6 +83,13 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 					continue
 				}
 
+				// We cap the run at one turn (see --max-turns below). The CLI reports this with an
+				// error_max_turns result and exits non-zero; record it so the exit is treated as a
+				// normal completion rather than a failure.
+				if (chunk.type === "result" && chunk.subtype === "error_max_turns") {
+					processState.reachedMaxTurns = true
+				}
+
 				yield chunk
 			}
 		}
@@ -98,6 +108,13 @@ export async function* runClaudeCode(options: ClaudeCodeOptions): AsyncGenerator
 			)
 		}
 	} catch (err) {
+		// Hitting the one-turn cap makes the CLI exit non-zero after it has already streamed the
+		// StructuredOutput tool call and a result event. That is the expected end of a run, so we
+		// stop here instead of surfacing it as an error.
+		if (processState.reachedMaxTurns) {
+			return
+		}
+
 		Logger.error(`Error during Claude Code execution:`, err)
 
 		if (processState.stderrLogs.includes("unknown option '--system-prompt-file'")) {
@@ -158,25 +175,6 @@ Anthropic is aware of this issue and is considering a fix: https://github.com/an
 	}
 }
 
-// We want the model to use our custom tool format instead of built-in tools.
-// Disabling built-in tools prevents tool-only responses and ensures text output.
-const claudeCodeTools = [
-	"Task",
-	"Bash",
-	"Glob",
-	"Grep",
-	"LS",
-	"exit_plan_mode",
-	"Read",
-	"Edit",
-	"MultiEdit",
-	"Write",
-	"NotebookRead",
-	"NotebookEdit",
-	"TodoRead",
-	"TodoWrite",
-].join(",")
-
 const CLAUDE_CODE_TIMEOUT = 600000 // 10 minutes
 // https://github.com/sindresorhus/execa/blob/main/docs/api.md#optionsmaxbuffer
 const BUFFER_SIZE = 20_000_000 // 20 MB
@@ -185,7 +183,7 @@ const BUFFER_SIZE = 20_000_000 // 20 MB
 const CLAUDE_CODE_MAX_OUTPUT_TOKENS = "32000"
 
 function runProcess(
-	{ systemPrompt, messages, path, modelId, thinkingBudgetTokens, shouldUseFile }: ClaudeCodeOptions,
+	{ systemPrompt, messages, path, modelId, thinkingBudgetTokens, shouldUseFile, jsonSchema }: ClaudeCodeOptions,
 	cwd: string,
 ) {
 	const claudePath = path?.trim() || "claude"
@@ -196,15 +194,35 @@ function runProcess(
 		"--verbose",
 		"--output-format",
 		"stream-json",
-		"--disallowedTools",
-		claudeCodeTools,
-		// Dirac will handle recursive calls
+		// We use the CLI as a stateless, single-shot inference engine, not an interactive agent.
+		// These flags keep the user's environment from bleeding into the call (token cost is
+		// unchanged; the value is determinism and hygiene):
+		//   --strict-mcp-config:      ignore the user's MCP servers (we never pass --mcp-config),
+		//                             so none are spawned as subprocesses on every call.
+		//   --disable-slash-commands: don't load the user's skills into the session.
+		//   --no-session-persistence: don't write a session file to ~/.claude on every -p run.
+		"--strict-mcp-config",
+		"--disable-slash-commands",
+		"--no-session-persistence",
+		// Disable all built-in tools; tool selection is driven by the --json-schema
+		// structured-output contract instead. ("" disables the entire built-in set.)
+		"--tools",
+		"",
+		// The model satisfies the schema by calling the injected StructuredOutput tool on its
+		// first turn, which is all Dirac needs. Capping at one turn stops the CLI from spending
+		// an extra (and disproportionately expensive) turn on a follow-up message we discard.
+		// Hitting this cap is expected and handled as a normal completion above.
 		"--max-turns",
 		"1",
 		"--model",
 		modelId,
-		"-p",
 	]
+
+	if (jsonSchema) {
+		args.push("--json-schema", jsonSchema)
+	}
+
+	args.push("-p")
 
 	/**
 	 * @see {@link https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables}

--- a/src/integrations/claude-code/structured-output.test.ts
+++ b/src/integrations/claude-code/structured-output.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from "mocha"
+import "should"
+import {
+	buildStructuredToolSchema,
+	extractStructuredToolCalls,
+	STRUCTURED_OUTPUT_TOOL_NAME,
+} from "./structured-output"
+
+describe("claude-code structured-output", () => {
+	describe("buildStructuredToolSchema", () => {
+		it("wraps OpenAI function tools as a tool_calls array of discriminated items", () => {
+			const tools: any[] = [
+				{
+					type: "function",
+					function: {
+						name: "read_file",
+						description: "Read a file",
+						parameters: {
+							type: "object",
+							properties: { path: { type: "string" } },
+							required: ["path"],
+						},
+					},
+				},
+				{
+					type: "function",
+					function: {
+						name: "execute_command",
+						description: "Run a command",
+						parameters: {
+							type: "object",
+							properties: { command: { type: "string" } },
+							required: ["command"],
+						},
+					},
+				},
+			]
+
+			const schema = buildStructuredToolSchema(tools)
+
+			schema.should.have.property("type", "object")
+			schema.required.should.deepEqual(["tool_calls"])
+			schema.properties.tool_calls.should.have.property("type", "array")
+			schema.properties.tool_calls.should.have.property("minItems", 1)
+
+			const items = schema.properties.tool_calls.items.oneOf
+			items.should.have.length(2)
+
+			const readItem = items[0]
+			readItem.properties.tool.should.deepEqual({ const: "read_file" })
+			readItem.properties.params.should.deepEqual({
+				type: "object",
+				properties: { path: { type: "string" } },
+				required: ["path"],
+			})
+			readItem.required.should.deepEqual(["tool", "params"])
+			readItem.should.have.property("description", "Read a file")
+
+			items[1].properties.tool.should.deepEqual({ const: "execute_command" })
+		})
+
+		it("supports Anthropic input_schema tool shape", () => {
+			const tools: any[] = [
+				{
+					name: "write_to_file",
+					description: "Write a file",
+					input_schema: {
+						type: "object",
+						properties: { path: { type: "string" }, content: { type: "string" } },
+						required: ["path", "content"],
+					},
+				},
+			]
+
+			const schema = buildStructuredToolSchema(tools)
+			const item = schema.properties.tool_calls.items.oneOf[0]
+			item.properties.tool.should.deepEqual({ const: "write_to_file" })
+			item.properties.params.should.have.property("type", "object")
+			item.properties.params.required.should.deepEqual(["path", "content"])
+		})
+
+		it("falls back to a generic object item when no tools are provided", () => {
+			const schema = buildStructuredToolSchema([])
+			schema.properties.tool_calls.items.should.deepEqual({ type: "object" })
+		})
+
+		it("skips unrecognised tool definitions", () => {
+			const tools: any[] = [{ totally: "unknown" }, { type: "function", function: { name: "say", parameters: { type: "object" } } }]
+			const schema = buildStructuredToolSchema(tools)
+			schema.properties.tool_calls.items.oneOf.should.have.length(1)
+			schema.properties.tool_calls.items.oneOf[0].properties.tool.should.deepEqual({ const: "say" })
+		})
+	})
+
+	describe("extractStructuredToolCalls", () => {
+		it("unwraps the array form", () => {
+			const calls = extractStructuredToolCalls({
+				tool_calls: [
+					{ tool: "read_file", params: { path: "a.ts" } },
+					{ tool: "execute_command", params: { command: "ls" } },
+				],
+			})
+			calls.should.deepEqual([
+				{ tool: "read_file", params: { path: "a.ts" } },
+				{ tool: "execute_command", params: { command: "ls" } },
+			])
+		})
+
+		it("unwraps the single object form", () => {
+			const calls = extractStructuredToolCalls({ tool: "read_file", params: { path: "a.ts" } })
+			calls.should.deepEqual([{ tool: "read_file", params: { path: "a.ts" } }])
+		})
+
+		it("defaults params to an empty object when missing", () => {
+			const calls = extractStructuredToolCalls({ tool_calls: [{ tool: "list_files" }] })
+			calls.should.deepEqual([{ tool: "list_files", params: {} }])
+		})
+
+		it("ignores malformed entries and non-object input", () => {
+			extractStructuredToolCalls(null).should.deepEqual([])
+			extractStructuredToolCalls("nope").should.deepEqual([])
+			extractStructuredToolCalls({ tool_calls: [{ noTool: true }, { tool: "ok", params: {} }] }).should.deepEqual([
+				{ tool: "ok", params: {} },
+			])
+		})
+	})
+
+	it("exposes the injected CLI tool name", () => {
+		STRUCTURED_OUTPUT_TOOL_NAME.should.equal("StructuredOutput")
+	})
+})

--- a/src/integrations/claude-code/structured-output.ts
+++ b/src/integrations/claude-code/structured-output.ts
@@ -1,0 +1,103 @@
+import type { DiracTool } from "@/shared/tools"
+
+/**
+ * Name of the tool the `claude` CLI injects when `--json-schema` is provided.
+ * The model "calls" this tool with our schema-shaped payload instead of using
+ * any real built-in tool.
+ */
+export const STRUCTURED_OUTPUT_TOOL_NAME = "StructuredOutput"
+
+export interface StructuredToolCall {
+	tool: string
+	params: Record<string, any>
+}
+
+/**
+ * Extracts the tool name and parameters from a single converted tool definition.
+ * Supports the three converter output shapes that `DiracTool` can take
+ * (OpenAI function, Anthropic input_schema, Google function declaration).
+ */
+function readToolDefinition(tool: DiracTool): { name: string; description?: string; params?: Record<string, any> } | null {
+	const anyTool = tool as any
+
+	// OpenAI ChatCompletionTool: { type: "function", function: { name, description, parameters } }
+	if (anyTool.type === "function" && anyTool.function) {
+		const fn = anyTool.function
+		if (!fn.name) {
+			return null
+		}
+		return { name: fn.name, description: fn.description, params: fn.parameters }
+	}
+
+	// Anthropic Tool: { name, description, input_schema }
+	if (anyTool.name && anyTool.input_schema) {
+		return { name: anyTool.name, description: anyTool.description, params: anyTool.input_schema }
+	}
+
+	// Google FunctionDeclaration: { name, description, parameters }
+	if (anyTool.name && anyTool.parameters) {
+		return { name: anyTool.name, description: anyTool.description, params: anyTool.parameters }
+	}
+
+	return null
+}
+
+/**
+ * Builds the JSON schema passed to `claude --json-schema`. The schema constrains
+ * the model's output to one or more tool calls, embedding each tool's name as a
+ * `const` discriminator and its parameter schema so the model sees the full tool
+ * contract (this replaces the native `tools` API payload the CLI cannot accept).
+ */
+export function buildStructuredToolSchema(tools: DiracTool[]): Record<string, any> {
+	const items = tools
+		.map(readToolDefinition)
+		.filter((def): def is NonNullable<ReturnType<typeof readToolDefinition>> => def !== null)
+		.map((def) => ({
+			type: "object",
+			...(def.description ? { description: def.description } : {}),
+			properties: {
+				tool: { const: def.name },
+				params: def.params ?? { type: "object" },
+			},
+			required: ["tool", "params"],
+			additionalProperties: false,
+		}))
+
+	return {
+		type: "object",
+		properties: {
+			tool_calls: {
+				type: "array",
+				minItems: 1,
+				items: items.length > 0 ? { oneOf: items } : { type: "object" },
+			},
+		},
+		required: ["tool_calls"],
+		additionalProperties: false,
+	}
+}
+
+/**
+ * Unwraps the payload the model provided to the injected `StructuredOutput` tool
+ * into a flat list of tool calls. Accepts both the array form
+ * (`{ tool_calls: [{ tool, params }, ...] }`) and the single form
+ * (`{ tool, params }`).
+ */
+export function extractStructuredToolCalls(input: unknown): StructuredToolCall[] {
+	if (!input || typeof input !== "object") {
+		return []
+	}
+	const obj = input as Record<string, any>
+
+	if (Array.isArray(obj.tool_calls)) {
+		return obj.tool_calls
+			.filter((call) => call && typeof call === "object" && typeof call.tool === "string")
+			.map((call) => ({ tool: call.tool, params: call.params ?? {} }))
+	}
+
+	if (typeof obj.tool === "string") {
+		return [{ tool: obj.tool, params: obj.params ?? {} }]
+	}
+
+	return []
+}

--- a/src/integrations/claude-code/types.ts
+++ b/src/integrations/claude-code/types.ts
@@ -20,13 +20,13 @@ type ErrorMessage = {
 
 type ResultMessage = {
 	type: "result"
-	subtype: "success"
+	subtype: "success" | "error_max_turns"
 	total_cost_usd: number
 	is_error: boolean
 	duration_ms: number
 	duration_api_ms: number
 	num_turns: number
-	result: string
+	result?: string
 	session_id: string
 }
 

--- a/src/shared/api/models/claude-code.ts
+++ b/src/shared/api/models/claude-code.ts
@@ -36,4 +36,14 @@ export const claudeCodeModels = {
         supportsImages: false,
         supportsPromptCache: false,
     },
+    "claude-opus-4-8": {
+        ...anthropicModels["claude-opus-4-8"],
+        supportsImages: false,
+        supportsPromptCache: false,
+    },
+    "claude-opus-4-8[1m]": {
+        ...anthropicModels["claude-opus-4-8:1m"],
+        supportsImages: false,
+        supportsPromptCache: false,
+    },
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Description

The latest `claude` CLI no longer accepts Dirac's native `tools` payload. This reworks the Claude Code provider to drive tool use through the CLI's `--json-schema` structured-output contract instead, and hardens the invocation for stateless single-shot inference.

- **Structured output** — Dirac's tools are encoded into a `--json-schema` schema. The model fulfils it by calling the injected `StructuredOutput` tool, which is unwrapped back into native tool calls.
- **Single-shot invocation** — built-in tools are disabled (`--tools ""`) and the run is capped at one turn (`--max-turns 1`); the resulting `error_max_turns` exit is treated as a normal completion.
- **Environment isolation** — adds `--strict-mcp-config`, `--disable-slash-commands`, and `--no-session-persistence` so the user's MCP servers, skills, and session files don't bleed into inference or spawn per-call subprocesses.
- **Models** — adds current model ids (including Opus 4.8) to the Claude Code registry.

## Tests

New/updated unit tests cover schema building, tool-call extraction, the one-turn-cap completion path, and the isolation flags.

## Breaking changes

None.