### PR TITLE
feat: make the Plan/Act toggle shortcut configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -369,7 +369,13 @@
         },
         "configuration": {
             "title": "Dirac",
-            "properties": {}
+            "properties": {
+                "dirac.planActToggleShortcut": {
+                    "type": "string",
+                    "default": "",
+                    "markdownDescription": "Keyboard shortcut for toggling between Plan and Act modes in the chat input, e.g. `Alt+Shift+a` or `Control+Alt+t`. Use the modifier names `Control`, `Alt`, `Meta` (Command), and `Shift` joined with `+`, ending in the key (for example `Meta+Shift+p`). Leave empty to use the built-in default (`Alt+Shift+a`), which avoids clashing with VSCode's `Cmd/Ctrl+Shift+A` Agents command."
+                }
+            }
         }
     },
     "scripts": {

--- a/src/core/webview/WebviewProvider.ts
+++ b/src/core/webview/WebviewProvider.ts
@@ -65,6 +65,38 @@ export abstract class DiracWebviewProvider {
 	abstract isVisible(): boolean
 
 	/**
+	 * Returns host-specific runtime configuration to inject into the webview.
+	 *
+	 * This is the seam through which a host (e.g. VSCode) can forward user
+	 * settings to the webview without going through the gRPC state pipeline.
+	 * The returned object is serialized into `window.__DIRAC_CONFIG__` inside the
+	 * webview HTML. The base implementation injects nothing.
+	 *
+	 * @returns A JSON-serializable config object (empty by default).
+	 */
+	protected getInjectedConfig(): Record<string, unknown> {
+		return {}
+	}
+
+	/**
+	 * Builds a nonce-guarded inline script that exposes the host-injected runtime
+	 * config on `window.__DIRAC_CONFIG__` before the app bundle runs.
+	 *
+	 * @param nonce - The CSP nonce that authorizes inline scripts in the webview.
+	 * @returns An HTML `<script>` tag, or an empty string when there is no config.
+	 */
+	protected getInjectedConfigScript(nonce: string): string {
+		const config = this.getInjectedConfig()
+		if (!config || Object.keys(config).length === 0) {
+			return ""
+		}
+		// JSON.stringify is safe to embed in a script as long as we guard the
+		// closing-tag sequence, which cannot otherwise appear in JSON output.
+		const serialized = JSON.stringify(config).replace(/</g, "\\u003c")
+		return /*html*/ `<script nonce="${nonce}">window.__DIRAC_CONFIG__ = ${serialized};</script>`
+	}
+
+	/**
 	 * Defines and returns the HTML that should be rendered within the webview panel.
 	 *
 	 * @remarks This is also the place where references to the React webview build files
@@ -131,8 +163,9 @@ export abstract class DiracWebviewProvider {
 			<body>
 				<noscript>You need to enable JavaScript to run this app.</noscript>
 				<div id="root"></div>
+				${this.getInjectedConfigScript(nonce)}
 				<script type="module" nonce="${nonce}" src="${scriptUrl}"></script>
-				<script src="http://localhost:8097"></script> 
+				<script src="http://localhost:8097"></script>
 			</body>
 		</html>
 		`
@@ -240,6 +273,7 @@ export abstract class DiracWebviewProvider {
 				<body>
 					<div id="root"></div>
 					${reactRefresh}
+					${this.getInjectedConfigScript(nonce)}
 					<script type="module" src="${scriptUrl}"></script>
 				</body>
 			</html>

--- a/src/hosts/vscode/VscodeWebviewProvider.ts
+++ b/src/hosts/vscode/VscodeWebviewProvider.ts
@@ -36,6 +36,18 @@ export class VscodeDiracWebviewProvider extends DiracWebviewProvider implements 
 		return this.webview.webview.cspSource
 	}
 
+	/**
+	 * Forwards user-configurable VSCode settings to the webview via
+	 * `window.__DIRAC_CONFIG__`. Currently exposes the optional Plan/Act toggle
+	 * shortcut override (see the `dirac.planActToggleShortcut` setting and issue
+	 * #100). When unset, the webview keeps the built-in default.
+	 */
+	protected override getInjectedConfig(): Record<string, unknown> {
+		const config = vscode.workspace.getConfiguration("dirac")
+		const planActToggleShortcut = config.get<string>("planActToggleShortcut")?.trim()
+		return planActToggleShortcut ? { planActToggleShortcut } : {}
+	}
+
 	override isVisible() {
 		return this.webview?.visible || false
 	}
@@ -99,7 +111,21 @@ export class VscodeDiracWebviewProvider extends DiracWebviewProvider implements 
 		)
 
 		// Listen for configuration changes
-		vscode.workspace.onDidChangeConfiguration(async (e) => {}, null, this.disposables)
+		vscode.workspace.onDidChangeConfiguration(
+			async (e) => {
+				// The Plan/Act toggle shortcut is injected into the webview HTML at
+				// render time, so re-render the HTML when it changes to apply the new
+				// binding without requiring a manual reload.
+				if (e.affectsConfiguration("dirac.planActToggleShortcut") && this.webview) {
+					this.webview.webview.html =
+						this.context.extensionMode === vscode.ExtensionMode.Development
+							? await this.getHMRHtmlContent()
+							: this.getHtmlContent()
+				}
+			},
+			null,
+			this.disposables,
+		)
 
 		// if the extension is starting a new session, clear previous task state
 		this.controller.clearTask()

--- a/webview-ui/src/config/__tests__/platform.config.test.ts
+++ b/webview-ui/src/config/__tests__/platform.config.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { resolveTogglePlanActKeys } from "../platform.config"
+
+describe("resolveTogglePlanActKeys", () => {
+	const fallback = "Alt+Shift+a"
+
+	afterEach(() => {
+		// Reset any injected runtime config between tests
+		if (typeof window !== "undefined") {
+			window.__DIRAC_CONFIG__ = undefined
+		}
+	})
+
+	it("returns the fallback when no override is provided", () => {
+		expect(resolveTogglePlanActKeys(undefined, fallback)).toBe(fallback)
+	})
+
+	it("returns the fallback when the override is an empty string", () => {
+		expect(resolveTogglePlanActKeys("", fallback)).toBe(fallback)
+	})
+
+	it("returns the fallback when the override is whitespace only", () => {
+		expect(resolveTogglePlanActKeys("   ", fallback)).toBe(fallback)
+	})
+
+	it("returns the user override when one is provided", () => {
+		expect(resolveTogglePlanActKeys("Meta+Shift+p", fallback)).toBe("Meta+Shift+p")
+	})
+
+	it("trims surrounding whitespace from the override", () => {
+		expect(resolveTogglePlanActKeys("  Control+Alt+t  ", fallback)).toBe("Control+Alt+t")
+	})
+
+	it("ignores a non-string override and falls back", () => {
+		expect(resolveTogglePlanActKeys(42 as unknown as string, fallback)).toBe(fallback)
+		expect(resolveTogglePlanActKeys(null as unknown as string, fallback)).toBe(fallback)
+	})
+})

--- a/webview-ui/src/config/platform-configs.json
+++ b/webview-ui/src/config/platform-configs.json
@@ -3,7 +3,7 @@
 		"messageEncoding": "none",
 		"showNavbar": false,
 		"postMessageHandler": "vscode",
-		"togglePlanActKeys": "Meta+Shift+a",
+		"togglePlanActKeys": "Alt+Shift+a",
 		"supportsTerminalMentions": true
 	},
 	"standalone": {

--- a/webview-ui/src/config/platform.config.ts
+++ b/webview-ui/src/config/platform.config.ts
@@ -40,6 +40,15 @@ type PlatformConfigJson = {
 
 type PlatformConfigs = Record<string, PlatformConfigJson>
 
+// Runtime configuration injected into the webview HTML by the host (see
+// DiracWebviewProvider.getHtmlContent). This lets host-specific user settings
+// (e.g. a custom Plan/Act toggle shortcut from VSCode `dirac.*` settings)
+// override the compile-time defaults baked into platform-configs.json without
+// going through the gRPC state pipeline.
+export interface DiracRuntimeConfig {
+	planActToggleShortcut?: string
+}
+
 // Global type declarations for postMessage and vscode API
 declare global {
 	interface Window {
@@ -47,8 +56,35 @@ declare global {
 		// !! Do not change the name of the handler without updating it on
 		// the JetBrains side as well. !!
 		standalonePostMessage?: (message: string) => void
+		// Host-injected runtime config. Optional: absent in builds/hosts that
+		// do not inject it, in which case compile-time defaults are used.
+		__DIRAC_CONFIG__?: DiracRuntimeConfig
 	}
 	function acquireVsCodeApi(): any
+}
+
+/**
+ * Resolve the effective Plan/Act toggle shortcut.
+ *
+ * Pure function so the resolution rule (user override wins, otherwise the
+ * platform default) is independently testable. A blank/whitespace-only or
+ * non-string override is treated as "unset" and falls back to the default.
+ *
+ * @param override - The user-provided shortcut (e.g. from a VSCode setting), if any.
+ * @param fallback - The platform default shortcut.
+ */
+export function resolveTogglePlanActKeys(override: string | undefined, fallback: string): string {
+	if (typeof override === "string" && override.trim().length > 0) {
+		return override.trim()
+	}
+	return fallback
+}
+
+/**
+ * Reads the host-injected runtime override for the Plan/Act toggle shortcut, if present.
+ */
+function getInjectedTogglePlanActKeys(): string | undefined {
+	return typeof window !== "undefined" ? window.__DIRAC_CONFIG__?.planActToggleShortcut : undefined
 }
 
 // Initialize the vscode API if available
@@ -103,7 +139,10 @@ export const PLATFORM_CONFIG: PlatformConfig = {
 	postMessage: postMessageStrategies[selectedConfig.postMessageHandler],
 	encodeMessage: messageEncoders[selectedConfig.messageEncoding],
 	decodeMessage: messageDecoders[selectedConfig.messageEncoding],
-	togglePlanActKeys: selectedConfig.togglePlanActKeys,
+	// User override (host-injected) wins over the platform default. The default
+	// itself lives in platform-configs.json and is chosen to avoid clashing with
+	// VSCode's Cmd/Ctrl+Shift+A "Agents" command (see issue #100).
+	togglePlanActKeys: resolveTogglePlanActKeys(getInjectedTogglePlanActKeys(), selectedConfig.togglePlanActKeys),
 	supportsTerminalMentions: selectedConfig.supportsTerminalMentions,
 }
 


### PR DESCRIPTION
## Summary

The Plan/Act toggle shortcut was hardcoded to `Meta/Ctrl+Shift+a`, which collides with VSCode's new `Cmd/Ctrl+Shift+A` "Agents" command (#100).

## Fix

- Change the default to `Alt+Shift+a` — the binding the maintainer endorsed in the issue thread — fixing the collision for everyone with zero new surface.
- Add an opt-in `dirac.planActToggleShortcut` setting that overrides the default (empty = unchanged behavior), addressing the "conflicts aren't zero" concern without forcing a broad keybinding-customization pipeline. The setting is injected into the webview (`window.__DIRAC_CONFIG__`) and resolved by a pure `resolveTogglePlanActKeys` helper; changing it re-renders the webview live.

This deliberately avoids the gRPC `ExtensionState` / `state-keys` path (which would auto-regenerate the state proto). Added unit tests for the resolver.

Closes #100
