### PR TITLE
fix: prevent infinite loop when whitespace text precedes tool_use on stream completion

### DIFF
--- a/src/core/task/__tests__/ResponseProcessor.test.ts
+++ b/src/core/task/__tests__/ResponseProcessor.test.ts
@@ -3,9 +3,9 @@ import { CardStatus, TaskStatus } from "@shared/ExtensionMessage"
 import { DiracAskResponse } from "@shared/WebviewMessage"
 import { expect } from "chai"
 import sinon from "sinon"
+import { expectLoggerErrors } from "@/test/loggerGuard"
 import { ResponseProcessor } from "../ResponseProcessor"
 import { StreamResponseHandler } from "../StreamResponseHandler"
-import { expectLoggerErrors } from "@/test/loggerGuard"
 import { TaskState } from "../TaskState"
 
 const baseMetrics = { inputTokens: 10, outputTokens: 20, cacheWriteTokens: 5, cacheReadTokens: 3, totalCost: 0.01 }
@@ -29,7 +29,7 @@ describe("ResponseProcessor", () => {
 		// Stub Session.updateToolCall
 		sessionModule = require("@shared/services/Session")
 		origUpdateToolCall = sessionModule.Session.get
-		sessionModule.Session.get = () => ({ updateToolCall: () => { } }) as any
+		sessionModule.Session.get = () => ({ updateToolCall: () => {} }) as any
 	})
 
 	afterEach(() => {
@@ -341,7 +341,7 @@ describe("ResponseProcessor", () => {
 
 		it("throws pending presentation error if one occurred during streaming", async () => {
 			// Simulate a pending error
-			; (processor as any).pendingPresentationError = new Error("presentation failed")
+			;(processor as any).pendingPresentationError = new Error("presentation failed")
 			try {
 				await processor.routeAssistantResponse(createRouteParams({ assistantMessage: "x", assistantTextOnly: "x" }))
 				expect.fail("should have thrown")
@@ -358,7 +358,7 @@ describe("ResponseProcessor", () => {
 			// Stub setTimeout to avoid real delay
 			const timersModule = require("node:timers/promises")
 			const origSetTimeout = timersModule.setTimeout
-			timersModule.setTimeout = async () => { }
+			timersModule.setTimeout = async () => {}
 			try {
 				const result = await processor.handleEmptyAssistantResponse(createEmptyParams())
 				result.should.be.false() // retry requested
@@ -372,7 +372,7 @@ describe("ResponseProcessor", () => {
 		it("increments retry attempts exponentially", async () => {
 			const timersModule = require("node:timers/promises")
 			const origSetTimeout = timersModule.setTimeout
-			timersModule.setTimeout = async () => { }
+			timersModule.setTimeout = async () => {}
 			try {
 				await processor.handleEmptyAssistantResponse(createEmptyParams())
 				taskState.emptyResponseRetryAttempts.should.equal(1)
@@ -412,7 +412,7 @@ describe("ResponseProcessor", () => {
 			// Telemetry is fire-and-forget — verify error card was created (proves error path entered)
 			const timersModule = require("node:timers/promises")
 			const origSetTimeout = timersModule.setTimeout
-			timersModule.setTimeout = async () => { }
+			timersModule.setTimeout = async () => {}
 			try {
 				await processor.handleEmptyAssistantResponse(createEmptyParams())
 				const errorCardCall = deps.taskMessenger.createCard.firstCall.args[0]
@@ -427,7 +427,7 @@ describe("ResponseProcessor", () => {
 			deps.getApiRequestIdSafe = () => "req-123"
 			const timersModule = require("node:timers/promises")
 			const origSetTimeout = timersModule.setTimeout
-			timersModule.setTimeout = async () => { }
+			timersModule.setTimeout = async () => {}
 			try {
 				await processor.handleEmptyAssistantResponse(createEmptyParams())
 				const cardCall = deps.taskMessenger.createCard.firstCall.args[0]
@@ -590,7 +590,7 @@ describe("ResponseProcessor", () => {
 			await processor.syncStreamState("hello world")
 			taskState.assistantMessageContent.should.have.length(1)
 			taskState.assistantMessageContent[0].type.should.equal("text")
-				; (taskState.assistantMessageContent[0] as any).content.should.equal("hello world")
+			;(taskState.assistantMessageContent[0] as any).content.should.equal("hello world")
 		})
 
 		it("parses reasoning tags embedded in text", async () => {
@@ -603,8 +603,24 @@ describe("ResponseProcessor", () => {
 
 		it("marks blocks as complete when isStreamComplete is true", async () => {
 			streamHandler.processTextDelta({ id: "t1", text: "hello" })
-			await processor.syncStreamState("hello", [], true)
-				; (taskState.assistantMessageContent[0] as any).isComplete.should.be.true()
+			await processor.syncStreamState("hello") // build during streaming
+			await processor.syncStreamState("hello", [], true) // mark complete
+			;(taskState.assistantMessageContent[0] as any).isComplete.should.be.true()
+		})
+
+		it("preserves tool_use index when whitespace text is dropped on completion", async () => {
+			// Simulate oMLX/Qwen stream: reasoning, whitespace text, tool_use
+			streamHandler.processReasoningDelta({ id: "r1", reasoning: "thinking" })
+			streamHandler.processTextDelta({ id: "t1", text: " " })
+			streamHandler.processToolUseDelta({ id: "tu1", name: "execute_command", input: '{"command":"pwd"}' }, "call-1")
+			await processor.syncStreamState(" ") // streaming build: [reasoning, text(" "), tool_use]
+			const streamingLen = taskState.assistantMessageContent.length
+			streamingLen.should.equal(3)
+			await processor.syncStreamState(" ", [], true) // completion: must not drop the text block
+			taskState.assistantMessageContent.should.have.length(streamingLen) // array structure preserved
+			const toolBlocks = taskState.assistantMessageContent.filter((b: any) => b.type === "tool_use")
+			toolBlocks.should.have.length(1)
+			;(toolBlocks[0] as any).isComplete.should.be.true() // tool marked complete, not lost
 		})
 
 		it("creates tool_use block from tool_use ordered block", async () => {

--- a/src/core/task/response/StreamStateSync.ts
+++ b/src/core/task/response/StreamStateSync.ts
@@ -11,8 +11,16 @@ export class StreamStateSync {
 		private taskState: TaskState,
 	) {}
 
-	// Build AssistantMessageContent from ordered blocks and update taskState
+	// Build AssistantMessageContent from ordered blocks and update taskState.
+	// On completion, mark existing blocks complete without rebuilding —
+	// rebuilding drops whitespace-only text blocks and shifts tool_use indices,
+	// invalidating currentStreamingContentIndex in the presenter.
 	syncStreamState(assistantTextOnly: string, toolBlocks: ParsedToolUseState[] = [], isStreamComplete = false): void {
+		if (isStreamComplete) {
+			this.taskState.assistantMessageContent = this.taskState.assistantMessageContent.map(block => ({ ...block, isComplete: true }))
+			if (toolBlocks.length > 0) this.taskState.userMessageContentReady = false
+			return
+		}
 		const prevLength = this.taskState.assistantMessageContent.length
 		const orderedBlocks = this.streamHandler.getOrderedBlocks()
 		const assistantMessageContent = this.buildContent(orderedBlocks, isStreamComplete)


### PR DESCRIPTION
## Summary

- Fix infinite API request loop with OpenAI-compatible providers (oMLX/Qwen) when a response contains reasoning + whitespace-only text + tool_use blocks
- On stream completion, `syncStreamState(true)` rebuilt the content array via `parseAssistantMessageV2`, which drops whitespace-only text blocks in completion mode. This shifted the `tool_use` block to a lower index, invalidating `currentStreamingContentIndex` in `AssistantMessagePresenter`. The presenter's `while (idx < len)` loop exited without re-processing the tool_use with `isComplete=true`, so the tool never executed, no `tool_result` was ever produced, and the task loop re-requested forever
- Fix: when `isStreamComplete=true`, mark existing blocks complete in place via `.map(block => ({ ...block, isComplete: true }))` instead of rebuilding the array. No new streaming deltas arrive after completion, so the rebuild serves no purpose — and it's the rebuild that causes the index invalidation
- Added regression test reproducing the exact `[reasoning, " ", tool_use]` stream pattern

#### Test plan

- [x] Unit tests: 68 passing in `ResponseProcessor.test.ts` (including new regression test `preserves tool_use index when whitespace text is dropped on completion`)
- [x] Manual reproduction on `master` (without fix): `dirac "Run pwd" --yolo` against oMLX/Qwen3.6 loops indefinitely — 30+ API requests in 60s, no `Executing` line ever appears, never terminates
- [x] Manual reproduction on fix branch (with fix): same command completes in 2 API requests — `Executing 1 of 1: pwd` appears, tool runs, `Task Completed`
- [ ] CI green

Generated with [Devin](https://devin.ai)