### PR TITLE
Add gemini 3.5 flash

### DIFF
--- a/src/shared/api/models/capabilities.ts
+++ b/src/shared/api/models/capabilities.ts
@@ -224,6 +224,16 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 			supportsThinkingLevel: true,
 		},
 	},
+	"gemini-3.5-flash": {
+		maxTokens: 65536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "high",
+			supportsThinkingLevel: true,
+		},
+	},
 	"gemini-3-pro-preview": {
 		maxTokens: 8192,
 		contextWindow: 1_048_576,

--- a/src/shared/api/models/gemini.ts
+++ b/src/shared/api/models/gemini.ts
@@ -82,7 +82,7 @@ export const geminiModels = {
 		outputPrice: 9.0,
 		cacheReadsPrice: 0.15,
 		cacheWritesPrice: 0.0,
-		temperature: 0.35,
+		temperature: 1.0,
 		thinkingConfig: {
 			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,

--- a/src/shared/api/models/gemini.ts
+++ b/src/shared/api/models/gemini.ts
@@ -78,9 +78,9 @@ export const geminiModels = {
 		...MODEL_CAPABILITIES["gemini-3.5-flash"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.3,
-		outputPrice: 2.5,
-		cacheReadsPrice: 0.075,
+		inputPrice: 1.5,
+		outputPrice: 9.0,
+		cacheReadsPrice: 0.15,
 		cacheWritesPrice: 0.0,
 		temperature: 0.35,
 		thinkingConfig: {

--- a/src/shared/api/models/gemini.ts
+++ b/src/shared/api/models/gemini.ts
@@ -74,6 +74,20 @@ export const geminiModels = {
 			supportsThinkingLevel: true,
 		},
 	},
+	"gemini-3.5-flash": {
+		...MODEL_CAPABILITIES["gemini-3.5-flash"],
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.075,
+		cacheWritesPrice: 0.0,
+		temperature: 0.35,
+		thinkingConfig: {
+			geminiThinkingLevel: "high" as const,
+			supportsThinkingLevel: true,
+		},
+	},
 	"gemini-2.5-pro": {
 		...MODEL_CAPABILITIES["gemini-2.5-pro"],
 		supportsPromptCache: true,

--- a/src/shared/api/models/vertex.ts
+++ b/src/shared/api/models/vertex.ts
@@ -53,7 +53,7 @@ export const vertexModels = {
 		outputPrice: 9.0,
 		cacheReadsPrice: 0.15,
 		cacheWritesPrice: 0.0,
-		temperature: 0.35,
+		temperature: 1.0,
 		thinkingConfig: {
 			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,

--- a/src/shared/api/models/vertex.ts
+++ b/src/shared/api/models/vertex.ts
@@ -45,6 +45,20 @@ export const vertexModels = {
 			supportsThinkingLevel: true,
 		},
 	},
+	"gemini-3.5-flash": {
+		...MODEL_CAPABILITIES["gemini-3.5-flash"],
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.075,
+		cacheWritesPrice: 0.0,
+		temperature: 0.35,
+		thinkingConfig: {
+			geminiThinkingLevel: "high" as const,
+			supportsThinkingLevel: true,
+		},
+	},
 	"claude-sonnet-4-6": {
 		...MODEL_CAPABILITIES["claude-sonnet-4-6"],
 		supportsPromptCache: true,

--- a/src/shared/api/models/vertex.ts
+++ b/src/shared/api/models/vertex.ts
@@ -49,9 +49,9 @@ export const vertexModels = {
 		...MODEL_CAPABILITIES["gemini-3.5-flash"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.3,
-		outputPrice: 2.5,
-		cacheReadsPrice: 0.075,
+		inputPrice: 1.5,
+		outputPrice: 9.0,
+		cacheReadsPrice: 0.15,
 		cacheWritesPrice: 0.0,
 		temperature: 0.35,
 		thinkingConfig: {


### PR DESCRIPTION
### Overview
This PR adds support for the new stable model **Gemini 3.5 Flash** to both the Google Gemini and Google Vertex AI provider configurations.

### Changes
1. **Model Capabilities (`src/shared/api/models/capabilities.ts`)**:
   - Added `"gemini-3.5-flash"` configuration.
   - Defined `maxTokens: 65536` and `contextWindow: 1048576` (1M tokens).
   - Enabled image support (`supportsImages: true`) and reasoning support (`supportsReasoning: true` with `"high"` thinking level capability).

2. **Gemini Configuration (`src/shared/api/models/gemini.ts`)**:
   - Registered `"gemini-3.5-flash"` model identifier.
   - Configured Agent Platform pricing:
     - `inputPrice: 1.5` ($1.50 / 1M tokens)
     - `outputPrice: 9.0` ($9.00 / 1M tokens)
     - `cacheReadsPrice: 0.15` ($0.15 / 1M tokens)
   - Set the default model `temperature: 1.0`.
   - Enabled prompt caching and global endpoints.

3. **Vertex AI Configuration (`src/shared/api/models/vertex.ts`)**:
   - Registered `"gemini-3.5-flash"` with matching pricing, default temperature, and metadata to ensure correct request delegation to the Gemini handler.

### References
- Model Details: https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-5-flash
- Pricing Details: https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing