### PR TITLE
docs(providers): document Eden AI (EU OpenAI-compatible gateway)

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -43,3 +43,25 @@ Dirac uses the default Google Cloud authentication chain. Ensure you have authen
 ```bash
 gcloud auth application-default login
 ```
+
+## Eden AI (EU, OpenAI-compatible)
+
+[Eden AI](https://www.edenai.co/) is a French, EU-based OpenAI-compatible gateway that reaches many upstream vendors through one key. Use it through Dirac's OpenAI-compatible support by pointing the base URL at Eden AI. Model ids are vendor-prefixed (`<vendor>/<model>`), e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `mistral/mistral-small-latest`.
+
+### Environment Variables
+
+- `OPENAI_API_BASE` — `https://api.edenai.run/v3` (or `https://api.eu.edenai.run/v3` for EU data residency)
+- `OPENAI_API_KEY` — your Eden AI API key
+
+### Usage Example
+
+```bash
+export OPENAI_API_BASE="https://api.edenai.run/v3"
+export OPENAI_API_KEY="your-edenai-key"
+
+dirac "your task" --model "openai/gpt-4o-mini"
+```
+
+### EU data residency & GDPR
+
+Eden AI's EU endpoint (`https://api.eu.edenai.run/v3`) processes and routes prompts and outputs within the European Union (non-EU models are rejected), with zero data retention by default — prompts and outputs are not stored and are removed within 24 hours. Eden AI is SOC 2 and ISO 27001, with a DPA as standard, designed around GDPR and the EU AI Act. Point `OPENAI_API_BASE` at the EU endpoint to keep traffic in-region. See [Eden AI data compliance](https://www.edenai.co/data-compliancy).


### PR DESCRIPTION
## What

Documents Eden AI as a provider in the Provider Settings guide. No code change is needed: Dirac already supports any OpenAI-compatible endpoint via `OPENAI_API_BASE` / the `--provider` flag, so this documents Eden AI (a French, EU-based gateway) plus the EU data-residency angle.

```bash
export OPENAI_API_BASE="https://api.edenai.run/v3"   # or https://api.eu.edenai.run/v3 for EU data residency
export OPENAI_API_KEY="your-edenai-key"

dirac "your task" --model "openai/gpt-4o-mini"
```

Model ids are vendor-prefixed (`<vendor>/<model>`), e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `mistral/mistral-small-latest`.

## Why Eden AI (EU / GDPR / data residency)

- **EU data residency**: a dedicated EU endpoint (`https://api.eu.edenai.run/v3`) that processes and routes prompts and outputs within the European Union (non-EU models are rejected).
- **Zero data retention**: prompts and outputs are not stored by default and are removed within 24 hours.
- **Compliance**: SOC 2 and ISO 27001, DPA as standard, designed around GDPR and the EU AI Act.

Refs: https://www.edenai.co/post/eu-ai-endpoint-how-to-keep-ai-requests-and-data-in-europe and https://www.edenai.co/data-compliancy

## Changes

- `docs/providers/README.md`: an "Eden AI (EU, OpenAI-compatible)" section mirroring the existing AWS Bedrock / Vertex sections (Environment Variables + Usage Example + an EU data-residency & GDPR note).

## Testing

- The documented path is verified: Dirac's OpenAI-compatible client (the `openai` provider with `openAiBaseUrl`) uses the OpenAI SDK with the configured base URL, sending the model id verbatim. I confirmed against the real Eden AI API with a real key using that exact adapter (OpenAI SDK, `baseURL: https://api.edenai.run/v3`), which returns completions for `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, and `mistral/mistral-small-latest`.

If you'd prefer a dedicated first-class provider (a `providers/edenai.ts` handler + settings UI) rather than docs, I'm happy to open a discussion and put that together — I kept this to docs since Eden AI already works through the existing OpenAI-compatible path.
