### PR TITLE
fix(vscode): icon for commit message almost invisible in dark mode

### DIFF
--- a/assets/icons/icon-dark.svg
+++ b/assets/icons/icon-dark.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <!-- Delta character -->
+  <text x="12" y="15" text-anchor="middle" font-size="16"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-style="italic" fill="#e1e4e8">δ</text>
+        
+  <!-- Underline -->
+  <line x1="2" y1="21" x2="22" y2="21" stroke="#e1e4e8" stroke-opacity="0.4"
+        stroke-width="1.5" stroke-linecap="round"/>
+        
+  <!-- Vertical line -->
+  <line x1="12" y1="21" x2="12" y2="18" stroke="#e1e4e8"
+        stroke-width="1.5" stroke-linecap="round"/>
+        
+  <!-- Glowing dot -->
+  <circle cx="12" cy="17.5" r="1" fill="#e1e4e8"/>
+</svg>

--- a/assets/icons/icon-light.svg
+++ b/assets/icons/icon-light.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <!-- Delta character -->
+  <text x="12" y="15" text-anchor="middle" font-size="16"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-style="italic" fill="#24292e">δ</text>
+        
+  <!-- Underline -->
+  <line x1="2" y1="21" x2="22" y2="21" stroke="#24292e" stroke-opacity="0.4"
+        stroke-width="1.5" stroke-linecap="round"/>
+        
+  <!-- Vertical line -->
+  <line x1="12" y1="21" x2="12" y2="18" stroke="#24292e"
+        stroke-width="1.5" stroke-linecap="round"/>
+        
+  <!-- Glowing dot -->
+  <circle cx="12" cy="17.5" r="1" fill="#24292e"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -164,8 +164,8 @@
                 "title": "Generate Commit Message with Dirac",
                 "category": "Dirac",
                 "icon": {
-                    "light": "assets/icons/icon.svg",
-                    "dark": "assets/icons/icon.svg"
+                    "light": "assets/icons/icon-light.svg",
+                    "dark": "assets/icons/icon-dark.svg"
                 }
             },
             {


### PR DESCRIPTION
Fixes #139. The Generate Commit icon was almost invisible in VSCode dark mode.

The CSV file `icon.svg` already appears to be theming-friendly, because it doesn't specify a concrete color but instead uses `currentColor`. Alas, that didn't work, at least in my VSCode (version 1.131.0, dated 2026-07-28, on Linux).

I looked at what [Commit Sage](https://github.com/VizzleTF/CommitSage) does because it also adds an icon to the same toolbar that **does** adapt to the theme color properly. It uses one SVG for light mode, another for dark mode. And those SVGs use concrete colors, not `currentColor`. So I copied that approach: I created versions of `icon.svg` called `icon-light.svg` and `icon-dark.svg` for light and dark mode, respectively, using concrete colors (dark gray, light gray). Then I changed `package.json` to use those SVGs.

Result in dark mode:

<img width="412" height="148" alt="image" src="https://github.com/user-attachments/assets/2724ad2c-9024-4c87-82e8-9eb6b16dacd8" />

Result in light mode:

<img width="412" height="148" alt="image" src="https://github.com/user-attachments/assets/599700c5-6a65-4dbb-b430-7956174a51ff" />
