### PR TITLE
fix(rules): surface rule/skill load failures instead of silently dropping them

### DIFF
--- a/src/core/context/instructions/user-instructions/RuleContextBuilder.ts
+++ b/src/core/context/instructions/user-instructions/RuleContextBuilder.ts
@@ -1,5 +1,6 @@
-import { HostProvider } from "@/hosts/host-provider"
 import { DiracMessage } from "@shared/ExtensionMessage"
+import { HostProvider } from "@/hosts/host-provider"
+import { Logger } from "@/shared/services/Logger"
 import { extractPathLikeStrings, RuleEvaluationContext, toWorkspaceRelativePosixPath } from "./rule-conditionals"
 
 type WorkspaceRoot = { path: string }
@@ -88,8 +89,9 @@ export class RuleContextBuilder {
 				) {
 					candidates.push(tool.path)
 				}
-			} catch {
-				// ignore parse errors
+			} catch (error) {
+				// Intentional: malformed tool card bodies are not fatal.
+				Logger.debug("Failed to parse tool card body for rule context:", error)
 			}
 		}
 
@@ -111,8 +113,9 @@ export class RuleContextBuilder {
 				if (tool.path) {
 					candidates.push(tool.path)
 				}
-			} catch {
-				// ignore parse errors
+			} catch (error) {
+				// Intentional: malformed tool card bodies are not fatal.
+				Logger.debug("Failed to parse tool card body for rule context:", error)
 			}
 		}
 

--- a/src/core/context/instructions/user-instructions/__tests__/dirac-rules.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/dirac-rules.test.ts
@@ -1,0 +1,92 @@
+import { StateManager } from "@core/storage/StateManager"
+import { workspaceResolver } from "@core/workspace"
+import { expect } from "chai"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import * as sinon from "sinon"
+import { expectLoggerErrors } from "@/test/loggerGuard"
+import { getGlobalDiracRules, getLocalDiracRules } from "../dirac-rules"
+
+describe("dirac-rules error propagation", () => {
+	let sandbox: sinon.SinonSandbox
+	let tempDir: string
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-dirac-rules-test-"))
+		sandbox
+			.stub(workspaceResolver, "resolveWorkspacePath")
+			.callsFake((cwdOrRoots: string | unknown[], relativePath: string) => path.join(cwdOrRoots as string, relativePath))
+		sandbox.stub(StateManager, "get").returns({
+			getGlobalStateKey: () => ({}),
+		} as any)
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	it("getLocalDiracRules propagates per-file errors while loading the rest", async () => {
+		expectLoggerErrors()
+		const rulesDir = path.join(tempDir, ".diracrules")
+		await fs.mkdir(rulesDir, { recursive: true })
+		await fs.writeFile(path.join(rulesDir, "good.md"), "Always on")
+		await fs.writeFile(path.join(rulesDir, "bad.md"), "Bad content")
+
+		const goodPath = path.join(rulesDir, "good.md")
+		const badPath = path.join(rulesDir, "bad.md")
+		const readFileStub = sandbox.stub(fs, "readFile")
+		readFileStub.withArgs(badPath, "utf8").rejects(new Error("forced read failure"))
+		readFileStub.callThrough()
+
+		const toggles: Record<string, boolean> = { [goodPath]: true, [badPath]: true }
+		const result = await getLocalDiracRules(tempDir, toggles)
+
+		expect(result.instructions).to.contain("good.md")
+		expect(result.instructions).to.contain("Always on")
+		expect(result.instructions).to.not.contain("Bad content")
+		expect(result.errors).to.have.lengthOf(1)
+		expect(result.errors![0]).to.include("bad.md")
+	})
+
+	it("getGlobalDiracRules propagates per-file errors while loading the rest", async () => {
+		expectLoggerErrors()
+		const rulesDir = path.join(tempDir, ".diracrules")
+		await fs.mkdir(rulesDir, { recursive: true })
+		await fs.writeFile(path.join(rulesDir, "good.md"), "Always on")
+		await fs.writeFile(path.join(rulesDir, "bad.md"), "Bad content")
+
+		const goodPath = path.join(rulesDir, "good.md")
+		const badPath = path.join(rulesDir, "bad.md")
+		const readFileStub = sandbox.stub(fs, "readFile")
+		readFileStub.withArgs(badPath, "utf8").rejects(new Error("forced read failure"))
+		readFileStub.callThrough()
+
+		const toggles: Record<string, boolean> = { [goodPath]: true, [badPath]: true }
+		const result = await getGlobalDiracRules(rulesDir, toggles)
+
+		expect(result.instructions).to.contain("good.md")
+		expect(result.instructions).to.contain("Always on")
+		expect(result.instructions).to.not.contain("Bad content")
+		expect(result.errors).to.have.lengthOf(1)
+		expect(result.errors![0]).to.include("bad.md")
+	})
+
+	it("getLocalDiracRules propagates a single-file .diracrules read error", async () => {
+		expectLoggerErrors()
+		const rulesFile = path.join(tempDir, ".diracrules")
+		await fs.writeFile(rulesFile, "Always on")
+		const readFileStub = sandbox.stub(fs, "readFile")
+		readFileStub.withArgs(rulesFile, "utf8").rejects(new Error("forced read failure"))
+		readFileStub.callThrough()
+
+		const toggles: Record<string, boolean> = { [rulesFile]: true }
+		const result = await getLocalDiracRules(tempDir, toggles)
+
+		expect(result.instructions).to.be.undefined
+		expect(result.errors).to.have.lengthOf(1)
+		expect(result.errors![0]).to.include(rulesFile)
+	})
+})

--- a/src/core/context/instructions/user-instructions/__tests__/rule-loading.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/rule-loading.test.ts
@@ -2,6 +2,8 @@ import { expect } from "chai"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
+import * as sinon from "sinon"
+import { Logger } from "@/shared/services/Logger"
 import { getRuleFilesTotalContentWithMetadata } from "../rule-helpers"
 
 describe("rule loading with paths frontmatter", () => {
@@ -111,6 +113,43 @@ describe("rule loading with paths frontmatter", () => {
 
 			expect(res.activatedConditionalRules.map((r) => r.name)).to.deep.equal(files.map((f) => `global:${f}`))
 		} finally {
+			await fs.rm(tmp, { recursive: true, force: true })
+		}
+	})
+
+	it("logs and skips a single rule file that fails to read while keeping the rest", async () => {
+		const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-rules-test-"))
+		const errorLog = sinon.stub(Logger, "error")
+		const readFileStub = sinon.stub(fs, "readFile")
+		try {
+			const rulesDir = path.join(tmp, ".diracrules")
+			await fs.mkdir(rulesDir, { recursive: true })
+			await fs.writeFile(path.join(rulesDir, "good.md"), "Always on")
+			await fs.writeFile(path.join(rulesDir, "bad.md"), "Bad content")
+
+			const badFile = path.join(rulesDir, "bad.md")
+			readFileStub.withArgs(badFile, "utf8").rejects(new Error("forced read failure"))
+			readFileStub.callThrough()
+
+			const files = ["good.md", "bad.md"]
+			const toggles: Record<string, boolean> = {
+				[path.join(rulesDir, "good.md")]: true,
+				[badFile]: true,
+			}
+
+			const res = await getRuleFilesTotalContentWithMetadata(files, rulesDir, toggles, {
+				evaluationContext: { paths: ["src/index.ts"] },
+			})
+
+			expect(res.content).to.contain("good.md")
+			expect(res.content).to.contain("Always on")
+			expect(res.content).to.not.contain("Bad content")
+			expect(res.errors).to.have.lengthOf(1)
+			expect(res.errors![0]).to.include("bad.md")
+			expect(errorLog.calledOnce).to.be.true
+		} finally {
+			errorLog.restore()
+			readFileStub.restore()
 			await fs.rm(tmp, { recursive: true, force: true })
 		}
 	})

--- a/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
+++ b/src/core/context/instructions/user-instructions/__tests__/skills.test.ts
@@ -503,5 +503,22 @@ description: Test
 
 			expect(content!.instructions).to.equal("Instructions with whitespace")
 		})
+
+		it("logs and returns null when the skill file cannot be read", async () => {
+			const errorLog = sandbox.stub(Logger, "error")
+			const skillMdPath = path.join(GLOBAL_SKILLS_DIR, "broken-skill", "SKILL.md")
+			readFileStub.withArgs(skillMdPath, "utf-8").rejects(new Error("forced read failure"))
+
+			const skill: import("@shared/skills").SkillMetadata = {
+				name: "broken-skill",
+				description: "A broken skill",
+				path: skillMdPath,
+				source: "global",
+			}
+			const content = await getSkillContent("broken-skill", [skill])
+
+			expect(content).to.be.null
+			expect(errorLog.calledOnce).to.be.true
+		})
 	})
 })

--- a/src/core/context/instructions/user-instructions/dirac-rules.ts
+++ b/src/core/context/instructions/user-instructions/dirac-rules.ts
@@ -10,11 +10,11 @@ import { formatResponse } from "@core/formatResponse"
 import { ensureRulesDirectoryExists, GlobalFileNames } from "@core/storage/disk"
 import { StateManager } from "@core/storage/StateManager"
 import { DiracRulesToggles } from "@shared/dirac-rules"
+import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { fileExistsAtPath, isDirectory, readDirectory } from "@utils/fs"
 import fs from "fs/promises"
 import path from "path"
 import { Logger } from "@/shared/services/Logger"
-import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { evaluateRuleConditionals, type RuleEvaluationContext } from "./rule-conditionals"
 
 export const getGlobalDiracRules = async (
@@ -24,6 +24,7 @@ export const getGlobalDiracRules = async (
 ): Promise<RuleLoadResultWithInstructions> => {
 	let combinedContent = ""
 	const activatedConditionalRules: ActivatedConditionalRule[] = []
+	const errors: string[] = []
 
 	// 1. Get file-based rules
 	if (await fileExistsAtPath(globalDiracRulesFilePath)) {
@@ -44,11 +45,18 @@ export const getGlobalDiracRules = async (
 					combinedContent = rulesFilesTotal.content
 					activatedConditionalRules.push(...rulesFilesTotal.activatedConditionalRules)
 				}
-			} catch {
-				Logger.error(`Failed to read .diracrules directory at ${globalDiracRulesFilePath}`)
+				if (rulesFilesTotal.errors) {
+					errors.push(...rulesFilesTotal.errors)
+				}
+			} catch (error) {
+				const message = `Failed to read .diracrules directory at ${globalDiracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				Logger.error(message, error)
+				errors.push(message)
 			}
 		} else {
-			Logger.error(`${globalDiracRulesFilePath} is not a directory`)
+			const message = `${globalDiracRulesFilePath} is not a directory`
+			Logger.error(message)
+			errors.push(message)
 		}
 	}
 
@@ -64,15 +72,19 @@ export const getGlobalDiracRules = async (
 		combinedContent += remoteResult.content
 		activatedConditionalRules.push(...remoteResult.activatedConditionalRules)
 	}
+	if (remoteResult.errors) {
+		errors.push(...remoteResult.errors)
+	}
 
 	// 3. Return formatted instructions
 	if (!combinedContent) {
-		return { instructions: undefined, activatedConditionalRules: [] }
+		return { instructions: undefined, activatedConditionalRules: [], errors: errors.length > 0 ? errors : undefined }
 	}
 
 	return {
 		instructions: formatResponse.diracRulesGlobalDirectoryInstructions(globalDiracRulesFilePath, combinedContent),
 		activatedConditionalRules,
+		errors: errors.length > 0 ? errors : undefined,
 	}
 }
 
@@ -85,6 +97,7 @@ export const getLocalDiracRules = async (
 
 	let instructions: string | undefined
 	const activatedConditionalRules: ActivatedConditionalRule[] = []
+	const errors: string[] = []
 
 	if (await fileExistsAtPath(diracRulesFilePath)) {
 		if (await isDirectory(diracRulesFilePath)) {
@@ -103,8 +116,13 @@ export const getLocalDiracRules = async (
 					instructions = formatResponse.diracRulesLocalDirectoryInstructions(cwd, rulesFilesTotal.content)
 					activatedConditionalRules.push(...rulesFilesTotal.activatedConditionalRules)
 				}
-			} catch {
-				Logger.error(`Failed to read .diracrules directory at ${diracRulesFilePath}`)
+				if (rulesFilesTotal.errors) {
+					errors.push(...rulesFilesTotal.errors)
+				}
+			} catch (error) {
+				const message = `Failed to read .diracrules directory at ${diracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				Logger.error(message, error)
+				errors.push(message)
 			}
 		} else {
 			try {
@@ -135,13 +153,15 @@ export const getLocalDiracRules = async (
 						}
 					}
 				}
-			} catch {
-				Logger.error(`Failed to read .diracrules file at ${diracRulesFilePath}`)
+			} catch (error) {
+				const message = `Failed to read .diracrules file at ${diracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				Logger.error(message, error)
+				errors.push(message)
 			}
 		}
 	}
 
-	return { instructions, activatedConditionalRules }
+	return { instructions, activatedConditionalRules, errors: errors.length > 0 ? errors : undefined }
 }
 
 export async function refreshDiracRulesToggles(

--- a/src/core/context/instructions/user-instructions/external-rules.ts
+++ b/src/core/context/instructions/user-instructions/external-rules.ts
@@ -75,8 +75,8 @@ export const getLocalWindsurfRules = async (cwd: string, toggles: DiracRulesTogg
 						windsurfRulesFileInstructions = formatResponse.windsurfRulesLocalFileInstructions(cwd, ruleFileContent)
 					}
 				}
-			} catch {
-				Logger.error(`Failed to read .windsurfrules file at ${windsurfRulesFilePath}`)
+			} catch (error) {
+				Logger.error(`Failed to read .windsurfrules file at ${windsurfRulesFilePath}:`, error)
 			}
 		}
 	}
@@ -101,8 +101,8 @@ export const getLocalCursorRules = async (cwd: string, toggles: DiracRulesToggle
 						cursorRulesFileInstructions = formatResponse.cursorRulesLocalFileInstructions(cwd, ruleFileContent)
 					}
 				}
-			} catch {
-				Logger.error(`Failed to read .cursorrules file at ${cursorRulesFilePath}`)
+			} catch (error) {
+				Logger.error(`Failed to read .cursorrules file at ${cursorRulesFilePath}:`, error)
 			}
 		}
 	}
@@ -119,8 +119,8 @@ export const getLocalCursorRules = async (cwd: string, toggles: DiracRulesToggle
 				if (rulesFilesTotalContent) {
 					cursorRulesDirInstructions = formatResponse.cursorRulesLocalDirectoryInstructions(cwd, rulesFilesTotalContent)
 				}
-			} catch {
-				Logger.error(`Failed to read .cursor/rules directory at ${cursorRulesDirPath}`)
+			} catch (error) {
+				Logger.error(`Failed to read .cursor/rules directory at ${cursorRulesDirPath}:`, error)
 			}
 		}
 	}

--- a/src/core/context/instructions/user-instructions/rule-helpers.ts
+++ b/src/core/context/instructions/user-instructions/rule-helpers.ts
@@ -2,11 +2,11 @@ import { ensureRulesDirectoryExists, ensureWorkflowsDirectoryExists, GlobalFileN
 import { StateManager } from "@core/storage/StateManager"
 import { DiracRulesToggles } from "@shared/dirac-rules"
 import { GlobalInstructionsFile } from "@shared/remote-config/schema"
+import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { fileExistsAtPath, isDirectory, readDirectory } from "@utils/fs"
 import fs from "fs/promises"
 import * as path from "path"
 import { Logger } from "@/shared/services/Logger"
-import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { evaluateRuleConditionals, RuleEvaluationContext } from "./rule-conditionals"
 
 /**
@@ -165,6 +165,7 @@ export const RULE_SOURCE_PREFIX = {
 export type RuleLoadResult = {
 	content: string
 	activatedConditionalRules: ActivatedConditionalRule[]
+	errors?: string[]
 }
 
 /**
@@ -174,6 +175,7 @@ export type RuleLoadResult = {
 export type RuleLoadResultWithInstructions = {
 	instructions?: string
 	activatedConditionalRules: ActivatedConditionalRule[]
+	errors?: string[]
 }
 
 export const getRuleFilesTotalContentWithMetadata = async (
@@ -188,6 +190,7 @@ export const getRuleFilesTotalContentWithMetadata = async (
 	type RuleLoadPart = {
 		contentPart: string | null
 		activatedRule: ActivatedConditionalRule | null
+		error?: string
 	}
 
 	const parts = await Promise.all(
@@ -195,35 +198,43 @@ export const getRuleFilesTotalContentWithMetadata = async (
 			const ruleFilePath = path.resolve(basePath, filePath)
 			const ruleFilePathRelative = path.relative(basePath, ruleFilePath)
 
-			if (ruleFilePath in toggles && toggles[ruleFilePath] === false) {
-				return { contentPart: null, activatedRule: null }
-			}
+			try {
+				if (ruleFilePath in toggles && toggles[ruleFilePath] === false) {
+					return { contentPart: null, activatedRule: null }
+				}
 
-			const raw = (await fs.readFile(ruleFilePath, "utf8")).trim()
-			if (!raw) {
-				return { contentPart: null, activatedRule: null }
-			}
-			const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(raw)
-			// YAML parse errors are treated as fail-open.
-			// NOTE: We intentionally preserve the raw frontmatter fence/content here so the LLM can still
-			// see the author's intended scoping (e.g., `paths:`) and reason about it, even if it cannot be
-			// evaluated reliably due to invalid YAML.
-			if (hadFrontmatter && parseError) {
-				return { contentPart: `${ruleFilePathRelative}\n${raw}`, activatedRule: null }
-			}
+				const raw = (await fs.readFile(ruleFilePath, "utf8")).trim()
+				if (!raw) {
+					return { contentPart: null, activatedRule: null }
+				}
+				const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(raw)
+				// YAML parse errors are treated as fail-open.
+				// NOTE: We intentionally preserve the raw frontmatter fence/content here so the LLM can still
+				// see the author's intended scoping (e.g., `paths:`) and reason about it, even if it cannot be
+				// evaluated reliably due to invalid YAML.
+				if (hadFrontmatter && parseError) {
+					return { contentPart: `${ruleFilePathRelative}\n${raw}`, activatedRule: null }
+				}
 
-			const { passed, matchedConditions } = evaluateRuleConditionals(data, evaluationContext)
-			if (!passed) {
-				return { contentPart: null, activatedRule: null }
-			}
-			const activatedRule =
-				hadFrontmatter && Object.keys(matchedConditions).length > 0
-					? { name: `${prefix}:${ruleFilePathRelative}`, matchedConditions }
-					: null
+				const { passed, matchedConditions } = evaluateRuleConditionals(data, evaluationContext)
+				if (!passed) {
+					return { contentPart: null, activatedRule: null }
+				}
+				const activatedRule =
+					hadFrontmatter && Object.keys(matchedConditions).length > 0
+						? { name: `${prefix}:${ruleFilePathRelative}`, matchedConditions }
+						: null
 
-			return { contentPart: `${ruleFilePathRelative}\n${body.trim()}`, activatedRule }
+				return { contentPart: `${ruleFilePathRelative}\n${body.trim()}`, activatedRule }
+			} catch (error) {
+				const message = `Failed to load rule file ${ruleFilePathRelative}: ${error instanceof Error ? error.message : String(error)}`
+				Logger.error(message, error)
+				return { contentPart: null, activatedRule: null, error: message }
+			}
 		}),
 	)
+
+	const errors = parts.map((p) => p.error).filter((e): e is string => e !== undefined)
 
 	return {
 		content: parts
@@ -233,6 +244,7 @@ export const getRuleFilesTotalContentWithMetadata = async (
 		activatedConditionalRules: parts
 			.map((p) => p.activatedRule)
 			.filter((rule): rule is ActivatedConditionalRule => rule !== null),
+		errors: errors.length > 0 ? errors : undefined,
 	}
 }
 
@@ -243,35 +255,42 @@ export function getRemoteRulesTotalContentWithMetadata(
 ): RuleLoadResult {
 	const activatedConditionalRules: ActivatedConditionalRule[] = []
 	const evaluationContext = opts?.evaluationContext ?? {}
+	const errors: string[] = []
 	let combinedContent = ""
 
 	for (const rule of remoteRules) {
-		const isEnabled = rule.alwaysEnabled || remoteToggles[rule.name] !== false
-		if (!isEnabled) continue
+		try {
+			const isEnabled = rule.alwaysEnabled || remoteToggles[rule.name] !== false
+			if (!isEnabled) continue
 
-		const raw = (rule.contents || "").trim()
-		if (!raw) continue
+			const raw = (rule.contents || "").trim()
+			if (!raw) continue
 
-		const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(raw)
-		if (hadFrontmatter && parseError) {
-			// Fail open: include entire raw contents
+			const { data, body, hadFrontmatter, parseError } = parseYamlFrontmatter(raw)
+			if (hadFrontmatter && parseError) {
+				// Fail open: include entire raw contents
+				if (combinedContent) combinedContent += "\n\n"
+				combinedContent += `${rule.name}\n${raw}`
+				continue
+			}
+
+			const { passed, matchedConditions } = evaluateRuleConditionals(data, evaluationContext)
+			if (!passed) continue
+
+			if (hadFrontmatter && Object.keys(matchedConditions).length > 0) {
+				activatedConditionalRules.push({ name: `${RULE_SOURCE_PREFIX.remote}:${rule.name}`, matchedConditions })
+			}
+
 			if (combinedContent) combinedContent += "\n\n"
-			combinedContent += `${rule.name}\n${raw}`
-			continue
+			combinedContent += `${rule.name}\n${body.trim()}`
+		} catch (error) {
+			const message = `Failed to load remote rule ${rule.name}: ${error instanceof Error ? error.message : String(error)}`
+			Logger.error(message, error)
+			errors.push(message)
 		}
-
-		const { passed, matchedConditions } = evaluateRuleConditionals(data, evaluationContext)
-		if (!passed) continue
-
-		if (hadFrontmatter && Object.keys(matchedConditions).length > 0) {
-			activatedConditionalRules.push({ name: `${RULE_SOURCE_PREFIX.remote}:${rule.name}`, matchedConditions })
-		}
-
-		if (combinedContent) combinedContent += "\n\n"
-		combinedContent += `${rule.name}\n${body.trim()}`
 	}
 
-	return { content: combinedContent, activatedConditionalRules }
+	return { content: combinedContent, activatedConditionalRules, errors: errors.length > 0 ? errors : undefined }
 }
 
 /**
@@ -321,7 +340,8 @@ export async function ensureLocalDiracDirExists(diracrulePath: string, defaultRu
 		}
 		// exists and is a dir or doesn't exist, either of these cases we dont need to handle here
 		return false
-	} catch (_error) {
+	} catch (error) {
+		Logger.error(`Failed to ensure .diracrules directory exists at ${diracrulePath}:`, error)
 		return true
 	}
 }
@@ -376,7 +396,8 @@ export const createRuleFile = async (isGlobal: boolean, filename: string, cwd: s
 		await fs.writeFile(filePath, "", "utf8")
 
 		return { filePath, fileExists: false }
-	} catch (_error) {
+	} catch (error) {
+		Logger.error("Failed to create rule file:", error)
 		return { filePath: null, fileExists: false }
 	}
 }

--- a/src/core/context/instructions/user-instructions/skills.ts
+++ b/src/core/context/instructions/user-instructions/skills.ts
@@ -1,10 +1,10 @@
 import { getSkillsDirectoriesForScan } from "@core/storage/disk"
 import type { SkillContent, SkillMetadata } from "@shared/skills"
+import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { fileExistsAtPath, isDirectory } from "@utils/fs"
 import * as fs from "fs/promises"
 import * as path from "path"
 import { Logger } from "@/shared/services/Logger"
-import { parseYamlFrontmatter } from "@utils/frontmatter"
 
 /**
  * Built-in skills that ship with the product.
@@ -344,7 +344,8 @@ export async function getSkillContent(skillName: string, availableSkills: SkillM
 			...skill,
 			instructions: body.trim(),
 		}
-	} catch {
+	} catch (error) {
+		Logger.error(`Failed to load skill ${skillName} from ${skill.path}:`, error)
 		return null
 	}
 }

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1373,7 +1373,7 @@ export class Task {
 			}
 			// Ensure the artifact dir is git-ignored so debug dumps don't get committed.
 			const gitignorePath = path.join(writeDir, ".gitignore")
-			await fs.writeFile(gitignorePath, "*\n!.gitignore\n", "utf8").catch(() => { })
+			await fs.writeFile(gitignorePath, "*\n!.gitignore\n", "utf8").catch(() => {})
 
 			const debugPath = path.join(writeDir, `task-${this.taskId}-debug.md`)
 
@@ -1579,6 +1579,11 @@ export class Task {
 		if (activatedConditionalRules.length > 0) {
 			await this.taskMessenger.upsertText(JSON.stringify({ rules: activatedConditionalRules }))
 		}
+		// Surface rule-file load failures so silently-dropped rules are visible to the user.
+		const ruleLoadErrors = [...(globalRules.errors ?? []), ...(localRules.errors ?? [])]
+		if (ruleLoadErrors.length > 0) {
+			await this.taskMessenger.upsertText(JSON.stringify({ ruleLoadErrors }))
+		}
 		const toolSnapshot = await this.toolExecutor.getSnapshotForRequest(promptContext)
 		const { systemPrompt } = await getSystemPrompt(promptContext, toolSnapshot)
 		this.toolExecutor.activateSnapshot(toolSnapshot)
@@ -1620,7 +1625,7 @@ export class Task {
 		if (!useAutoCondense) {
 			const lastMessage =
 				contextManagementMetadata.truncatedConversationHistory[
-				contextManagementMetadata.truncatedConversationHistory.length - 1
+					contextManagementMetadata.truncatedConversationHistory.length - 1
 				]
 			if (lastMessage && lastMessage.role === "user") {
 				const notice = formatResponse.contextTruncationNotice()
@@ -2046,7 +2051,9 @@ export class Task {
 		if (providerId && model.id) {
 			try {
 				await this.modelContextTracker.recordModelUsage(providerId, model.id, mode)
-			} catch { }
+			} catch (error) {
+				Logger.error("Failed to record model usage:", error)
+			}
 		}
 
 		const modelInfo: DiracMessageModelInfo = {
@@ -2202,9 +2209,10 @@ export class Task {
 							type: "text",
 							text:
 								assistantMessage +
-								`\n\n[${cancelReason === "streaming_failed"
-									? "Response interrupted by API Error"
-									: "Response interrupted by user"
+								`\n\n[${
+									cancelReason === "streaming_failed"
+										? "Response interrupted by API Error"
+										: "Response interrupted by user"
 								}]`,
 						},
 					],


### PR DESCRIPTION
Per-file rule, agent, cursor, windsurf, and skill loaders now isolate
single-file failures so a broken file no longer drops an entire rule
directory. Caught errors are logged with the actual Error object instead
of being swallowed, and RuleContextBuilder parse failures are logged at
debug level. Add an errors field to the rule load result and surface
rule-load failures to the user alongside activated conditional rules.
