### PR TITLE
fix(cli/acp): keep ACP session alive when journal persistence fails

### DIFF
--- a/cli/src/acp/AcpAgent.ts
+++ b/cli/src/acp/AcpAgent.ts
@@ -253,7 +253,9 @@ export class AcpAgent implements acp.Agent {
 
 	private scheduleSessionSetupUpdates(sessionId: string): void {
 		setImmediate(() => {
-			void this.ensureSessionSetupUpdates(sessionId)
+			this.ensureSessionSetupUpdates(sessionId).catch((error) =>
+				Logger.error("[AcpAgent] session setup update error:", error),
+			)
 		})
 	}
 

--- a/cli/src/acp/acp-session-updates.ts
+++ b/cli/src/acp/acp-session-updates.ts
@@ -7,7 +7,7 @@ import { DIRAC_CLI_DIR } from "../utils/path.js"
 const LEGACY_SESSION_UPDATES_FILE = path.join(DIRAC_CLI_DIR.data, "acp-session-updates.json")
 const SESSION_UPDATES_DIRECTORY = path.join(DIRAC_CLI_DIR.data, "acp-session-updates")
 const MIGRATION_LOCK_DIRECTORY = path.join(DIRAC_CLI_DIR.data, "acp-session-updates.migration.lock")
-const SEQUENCE_META_KEY = "dev.dirac/seq"
+export const SEQUENCE_META_KEY = "dev.dirac/seq"
 const JOURNAL_VERSION = 1
 const DEFAULT_MAX_JOURNAL_BYTES = 32 * 1024 * 1024
 const LOCK_WAIT_TIMEOUT_MS = 15_000

--- a/cli/src/agent/DiracAgent.ts
+++ b/cli/src/agent/DiracAgent.ts
@@ -63,6 +63,7 @@ import {
 	getSessionUpdates,
 	recordClientAnnotation,
 	recordSessionUpdate,
+	SEQUENCE_META_KEY,
 } from "../acp/acp-session-updates.js"
 import {
 	deleteSessionWorktree,
@@ -448,7 +449,11 @@ export class DiracAgent implements acp.Agent {
 			return
 		}
 
-		recordClientAnnotation(sessionId, annotation as Record<string, unknown>)
+		try {
+			recordClientAnnotation(sessionId, annotation as Record<string, unknown>)
+		} catch (error) {
+			Logger.error("[DiracAgent] ACP journal persistence failed for client annotation:", error)
+		}
 	}
 
 
@@ -615,6 +620,13 @@ export class DiracAgent implements acp.Agent {
 
 	/** Config mutations are serialized independently from prompt lifecycle state. */
 	private readonly configuringSessions: Set<string> = new Set()
+
+	/**
+	 * Highest persisted journal sequence per session for this process, used to
+	 * synthesize a monotonic sequence when journal persistence fails so the live
+	 * ACP emit can continue without crashing the session.
+	 */
+	private readonly lastJournalSequence = new Map<string, number>()
 
 	/**
 	 * In-flight prompt resolvers, keyed by session id. {@link cancel} uses these
@@ -2125,13 +2137,47 @@ export class DiracAgent implements acp.Agent {
 
 	private async emitSessionUpdate(sessionId: string, update: acp.SessionUpdate): Promise<void> {
 		const emitter = this.emitterForSession(sessionId)
-		const persistedUpdate = recordSessionUpdate(sessionId, update)
+		const persistedUpdate = this.persistSessionUpdate(sessionId, update)
 
 		try {
 			emitter.emit(persistedUpdate.sessionUpdate, persistedUpdate)
 		} catch (error) {
 			Logger.debug("[DiracAgent] Error emitting session update:", error)
 			emitter.emit("error", error instanceof Error ? error : new Error(String(error)))
+		}
+	}
+
+	/**
+	 * Persist a session update, falling back to an ephemeral, in-process sequence
+	 * when the journal cannot be written. A persistence failure must not take down
+	 * the live ACP session, so the caller can still emit the update to the client.
+	 *
+	 * NOTE: the fallback sequence is a best-effort degradation, not durable
+	 * ordering. It is only seeded from a successful write, so when persistence
+	 * fails from the very first call (e.g. an already over-cap journal) it starts
+	 * at 1 and counts up in memory — colliding with the sequence numbers already
+	 * persisted in the journal, and resetting on process restart. Acceptable as an
+	 * immediate unblock; Step 2 (append-only journal) removes this entirely.
+	 */
+	private persistSessionUpdate(sessionId: string, update: acp.SessionUpdate): ReturnType<typeof recordSessionUpdate> {
+		try {
+			const persisted = recordSessionUpdate(sessionId, update)
+			const sequence = persisted._meta?.[SEQUENCE_META_KEY]
+			if (typeof sequence === "number") {
+				this.lastJournalSequence.set(sessionId, sequence)
+			}
+			return persisted
+		} catch (error) {
+			Logger.error("[DiracAgent] ACP journal persistence failed; emitting session update ephemerally:", error)
+			const sequence = (this.lastJournalSequence.get(sessionId) ?? 0) + 1
+			this.lastJournalSequence.set(sessionId, sequence)
+			return {
+				...update,
+				_meta: {
+					...(update as acp.SessionUpdate & { _meta?: Record<string, unknown> })._meta,
+					[SEQUENCE_META_KEY]: sequence,
+				},
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fixes the "Remote ACP is disconnected" / `exit code 1` crash when opening Dirac through ACP.

## RCA
`DiracAgent.emitSessionUpdate` called `recordSessionUpdate` **before** its `try/catch`. When the per-session ACP journal exceeds `DIRAC_ACP_SESSION_UPDATES_MAX_BYTES` (32 MB) or is corrupt, `recordSessionUpdate` throws. That error propagated `emitConfigOptionsUpdate -> publishSessionSetupUpdates -> ensureSessionSetupUpdates`, and — after the fire-and-forget `scheduleSessionSetupUpdates` rejected unhandled — the `unhandledRejection` handler called `process.exit(1)`.

## Fix (two commits)
1. **`f92957a`** — catch the rejected `ensureSessionSetupUpdates` promise in `scheduleSessionSetupUpdates` so the process no longer exits.
2. **`0a698f4`** — decouple persistence from the live emit. `persistSessionUpdate` now logs a failed journal write and emits the update with an **ephemeral in-process sequence** instead of throwing, so an over-cap/corrupt journal no longer takes down the active session. Same boundary added to `recordClientAnnotation`.

## Notes
- The fallback sequence is **non-durable by design** (documented in `persistSessionUpdate`): it is only seeded from a successful write, so on a fully-failing journal it starts at 1 and resets on restart, and will collide with already-persisted sequences. Acceptable as an immediate unblock.
- The proper fix — replacing the whole-file re-serializing JSON journal with an append-only/rotating design — is a **follow-up PR**.
- No new type/lint errors in the edited regions (the repo's ~128 pre-existing `tsc` errors are unrelated SDK type-noise).

## Evidence
See `docs/RCA-ACP-JOURNAL.md`.