### PR TITLE
fix(cli/acp): replace fatal journal with append-only JSONL and compaction

### DIFF
--- a/cli/src/acp/acp-session-updates.test.ts
+++ b/cli/src/acp/acp-session-updates.test.ts
@@ -16,7 +16,23 @@ function setupDataDirectory(): string {
 
 function journalFilePath(dataDirectory: string, sessionId: string): string {
 	const digest = crypto.createHash("sha256").update(sessionId).digest("hex")
+	return path.join(dataDirectory, "acp-session-updates", `${digest}.jsonl`)
+}
+
+function legacyIsolatedJournalPath(dataDirectory: string, sessionId: string): string {
+	const digest = crypto.createHash("sha256").update(sessionId).digest("hex")
 	return path.join(dataDirectory, "acp-session-updates", `${digest}.json`)
+}
+
+function isWellFormedJournal(filePath: string): boolean {
+	const contents = fs.readFileSync(filePath, "utf8")
+	const lines = contents.split("\n")
+	if (lines[lines.length - 1] !== "") return false
+	for (const line of lines) {
+		if (line === "") continue
+		JSON.parse(line)
+	}
+	return true
 }
 
 async function workerBundle(): Promise<string> {
@@ -35,7 +51,13 @@ async function workerBundle(): Promise<string> {
 	return workerPath
 }
 
-function spawnWriter(workerPath: string, dataDirectory: string, sessionId: string, writerId: number, count: number): Promise<void> {
+function spawnWriter(
+	workerPath: string,
+	dataDirectory: string,
+	sessionId: string,
+	writerId: number,
+	count: number,
+): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const source = `
 			const { recordSessionUpdate } = require(${JSON.stringify(workerPath)});
@@ -107,9 +129,10 @@ describe("ACP session update journal", () => {
 			{ kind: "client_annotation", sequenceNumber: 3, annotation },
 			{ kind: "session_update", sequenceNumber: 4, update: second },
 		])
+		expect(isWellFormedJournal(journalFilePath(process.env.DIRAC_DATA_DIR!, "session-1"))).toBe(true)
 	})
 
-	it("keeps committed JSON valid and retains updates written by separate processes", async () => {
+	it("keeps committed JSONL valid and retains updates written by separate processes", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const sessionId = "concurrent-session"
 		const writerPath = await workerBundle()
@@ -121,8 +144,7 @@ describe("ACP session update journal", () => {
 		const reader = (async () => {
 			while (!readerStopped) {
 				try {
-					const contents = fs.readFileSync(committedPath, "utf8")
-					JSON.parse(contents)
+					isWellFormedJournal(committedPath)
 				} catch (error) {
 					if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 						readerError = error
@@ -158,37 +180,96 @@ describe("ACP session update journal", () => {
 				expect(texts).toContain(`writer-${writerId}-${index}`)
 			}
 		}
-		expect(() => JSON.parse(fs.readFileSync(committedPath, "utf8"))).not.toThrow()
+		expect(() => isWellFormedJournal(committedPath)).not.toThrow()
 	})
 
-	it("preserves the prior committed journal when replacement is interrupted", async () => {
+	it("ignores a torn trailing line from an interrupted append and keeps committed entries", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
-		const sessionId = "interrupted-session"
+		const sessionId = "torn-session"
 		const journal = await import("./acp-session-updates.js")
 		journal.recordSessionUpdate(sessionId, {
 			sessionUpdate: "agent_message_chunk",
-			content: { type: "text", text: "committed" },
+			content: { type: "text", text: "committed-1" },
+		} as any)
+		journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "agent_message_chunk",
+			content: { type: "text", text: "committed-2" },
 		} as any)
 		const committedPath = journalFilePath(dataDirectory, sessionId)
-		const before = fs.readFileSync(committedPath)
+		fs.appendFileSync(committedPath, '{"kind":"session_update","sequenceNumber":3,"update":{"content":"torn')
+
+		expect(journal.getSessionUpdates(sessionId).map((entry) => entry.sequenceNumber)).toEqual([1, 2])
+	})
+
+	it("tolerates a failed compaction rewrite without losing the appended update", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "compaction-session"
+		process.env.DIRAC_ACP_SESSION_UPDATES_MAX_BYTES = "600"
+		const journal = await import("./acp-session-updates.js")
+		for (let index = 0; index < 3; index += 1) {
+			journal.recordSessionUpdate(sessionId, {
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: `u-${index}` },
+			} as any)
+		}
+		const committedPath = journalFilePath(dataDirectory, sessionId)
 
 		const rename = vi.spyOn(fs, "renameSync").mockImplementationOnce(() => {
-			throw new Error("simulated interruption before rename")
+			throw new Error("simulated interruption during compaction")
 		})
 		expect(() =>
 			journal.recordSessionUpdate(sessionId, {
 				sessionUpdate: "agent_message_chunk",
-				content: { type: "text", text: "uncommitted" },
+				content: { type: "text", text: "m".repeat(2_000) },
 			} as any),
-		).toThrow("simulated interruption before rename")
+		).not.toThrow()
 		rename.mockRestore()
 
-		expect(fs.readFileSync(committedPath)).toEqual(before)
-		expect(JSON.parse(before.toString("utf8"))).toMatchObject({ sessionId })
+		const updates = journal.getSessionUpdates(sessionId)
+		expect(updates).toHaveLength(4)
+		expect(updates.at(-1)?.sequenceNumber).toBe(4)
+		expect(() => isWellFormedJournal(committedPath)).not.toThrow()
 		expect(fs.readdirSync(path.dirname(committedPath)).filter((entry) => entry.endsWith(".tmp"))).toEqual([])
 	})
 
-	it("reports malformed legacy data and never overwrites it", async () => {
+	it("migrates a legacy per-session JSON journal into JSONL and archives the original", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "legacy-isolated-session"
+		const legacyPath = legacyIsolatedJournalPath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(legacyPath), { recursive: true })
+		fs.writeFileSync(
+			legacyPath,
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				updates: [
+					{
+						kind: "session_update",
+						sequenceNumber: 1,
+						update: {
+							sessionUpdate: "agent_message_chunk",
+							content: { type: "text", text: "legacy" },
+							_meta: { "dev.dirac/seq": 1 },
+						},
+					},
+				],
+			}),
+		)
+		const journal = await import("./acp-session-updates.js")
+
+		expect(journal.getSessionUpdates(sessionId)).toHaveLength(1)
+		expect(fs.existsSync(legacyPath)).toBe(false)
+		expect(isWellFormedJournal(journalFilePath(dataDirectory, sessionId))).toBe(true)
+		expect(
+			fs
+				.readdirSync(path.dirname(legacyPath))
+				.some((entry) =>
+					entry.startsWith(`${crypto.createHash("sha256").update(sessionId).digest("hex")}.json.migrated`),
+				),
+		).toBe(true)
+	})
+
+	it("reports malformed legacy flat data and never overwrites it", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const legacyPath = path.join(dataDirectory, "acp-session-updates.json")
 		const malformed = '{"session-1":[{"kind":"session_update","update":{"content":"unterminated'
@@ -204,8 +285,7 @@ describe("ACP session update journal", () => {
 		expect(fs.readFileSync(legacyPath, "utf8")).toBe(malformed)
 	})
 
-
-	it("recovers a complete legacy map with trailing corruption and archives the original bytes", async () => {
+	it("recovers a complete legacy flat map with trailing corruption and archives the original bytes", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const legacyPath = path.join(dataDirectory, "acp-session-updates.json")
 		const sessionId = "recoverable-session"
@@ -253,17 +333,10 @@ describe("ACP session update journal", () => {
 			.filter((entry) => entry.startsWith("acp-session-updates.json.recovery-"))
 		expect(recoveryFiles).toHaveLength(1)
 		expect(fs.readFileSync(path.join(dataDirectory, recoveryFiles[0]), "utf8")).toBe(legacyContents)
-		expect(JSON.parse(fs.readFileSync(journalFilePath(dataDirectory, sessionId), "utf8"))).toMatchObject({
-			version: 1,
-			sessionId,
-			updates: [
-				{ kind: "session_update", sequenceNumber: 1 },
-				{ kind: "client_annotation", sequenceNumber: 3 },
-			],
-		})
+		expect(journal.getSessionUpdates(sessionId).map((entry) => entry.sequenceNumber)).toEqual([1, 3])
 	})
 
-	it("migrates valid legacy data into an isolated session journal", async () => {
+	it("migrates valid legacy flat data into an isolated JSONL journal", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const legacyPath = path.join(dataDirectory, "acp-session-updates.json")
 		fs.writeFileSync(
@@ -285,13 +358,10 @@ describe("ACP session update journal", () => {
 		const journal = await import("./acp-session-updates.js")
 		expect(journal.getSessionUpdates("session-1")).toHaveLength(1)
 		expect(fs.existsSync(legacyPath)).toBe(false)
-		expect(JSON.parse(fs.readFileSync(journalFilePath(dataDirectory, "session-1"), "utf8"))).toMatchObject({
-			version: 1,
-			sessionId: "session-1",
-		})
+		expect(isWellFormedJournal(journalFilePath(dataDirectory, "session-1"))).toBe(true)
 	})
 
-	it("preserves a newer isolated journal when a stale legacy file reappears", async () => {
+	it("keeps the isolated journal when a stale legacy flat file reappears", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const sessionId = "mixed-version-session"
 		const legacyPath = path.join(dataDirectory, "acp-session-updates.json")
@@ -313,54 +383,280 @@ describe("ACP session update journal", () => {
 		expect(fs.existsSync(legacyPath)).toBe(false)
 	})
 
-	it("reports conflicting legacy and isolated histories without overwriting either", async () => {
-		const dataDirectory = process.env.DIRAC_DATA_DIR!
-		const sessionId = "conflicting-session"
-		const legacyPath = path.join(dataDirectory, "acp-session-updates.json")
-		const journal = await import("./acp-session-updates.js")
-		journal.recordSessionUpdate(sessionId, {
-			sessionUpdate: "agent_message_chunk",
-			content: { type: "text", text: "isolated" },
-		} as any)
-		const isolatedPath = journalFilePath(dataDirectory, sessionId)
-		const isolatedBefore = fs.readFileSync(isolatedPath)
-		const conflictingUpdate = {
-			kind: "session_update",
-			sequenceNumber: 1,
-			update: {
-				sessionUpdate: "agent_message_chunk",
-				content: { type: "text", text: "legacy" },
-				_meta: { "dev.dirac/seq": 1 },
-			},
-		}
-		const legacyContents = JSON.stringify({ [sessionId]: [conflictingUpdate] })
-		fs.writeFileSync(legacyPath, legacyContents)
-
-		expect(() => journal.getSessionUpdates(sessionId)).toThrow("Conflicting ACP session update histories")
-		expect(fs.readFileSync(isolatedPath)).toEqual(isolatedBefore)
-		expect(fs.readFileSync(legacyPath, "utf8")).toBe(legacyContents)
-	})
-
-
-	it("enforces a per-session size limit without changing the prior valid state", async () => {
+	it("sheds oldest entries instead of failing once the journal exceeds its budget", async () => {
 		const dataDirectory = process.env.DIRAC_DATA_DIR!
 		const sessionId = "bounded-session"
 		process.env.DIRAC_ACP_SESSION_UPDATES_MAX_BYTES = "600"
 		const journal = await import("./acp-session-updates.js")
-		journal.recordSessionUpdate(sessionId, {
-			sessionUpdate: "agent_message_chunk",
-			content: { type: "text", text: "small" },
-		} as any)
+		for (let index = 0; index < 3; index += 1) {
+			journal.recordSessionUpdate(sessionId, {
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: `small-${index}` },
+			} as any)
+		}
 		const committedPath = journalFilePath(dataDirectory, sessionId)
-		const before = fs.readFileSync(committedPath)
 
 		expect(() =>
 			journal.recordSessionUpdate(sessionId, {
 				sessionUpdate: "agent_message_chunk",
 				content: { type: "text", text: "x".repeat(2_000) },
 			} as any),
-		).toThrow("exceeding the 600-byte limit")
-		expect(fs.readFileSync(committedPath)).toEqual(before)
-		expect(() => JSON.parse(before.toString("utf8"))).not.toThrow()
+		).not.toThrow()
+
+		const updates = journal.getSessionUpdates(sessionId)
+		expect(updates).toHaveLength(1)
+		expect(updates[0].sequenceNumber).toBe(4)
+		expect(() => isWellFormedJournal(committedPath)).not.toThrow()
+	})
+
+	it("keeps a single entry whole even when it alone exceeds the budget", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "single-overshoot-session"
+		process.env.DIRAC_ACP_SESSION_UPDATES_MAX_BYTES = "100"
+		const journal = await import("./acp-session-updates.js")
+
+		expect(() =>
+			journal.recordSessionUpdate(sessionId, {
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: "x".repeat(2_000) },
+			} as any),
+		).not.toThrow()
+		expect(journal.getSessionUpdates(sessionId)).toHaveLength(1)
+	})
+
+	it("derives the next sequence from the journal tail when the file exceeds the read window", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "tail-session"
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(filePath), { recursive: true })
+		const padding = "p".repeat(80)
+		let contents = ""
+		for (let sequenceNumber = 1; sequenceNumber <= 2_000; sequenceNumber += 1) {
+			contents +=
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber,
+					update: {
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: `${padding}-${sequenceNumber}` },
+					},
+				}) + "\n"
+		}
+		fs.writeFileSync(filePath, contents)
+		expect(fs.statSync(filePath).size).toBeGreaterThan(64 * 1024)
+
+		const journal = await import("./acp-session-updates.js")
+		const next = journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "agent_message_chunk",
+			content: { type: "text", text: "after-tail" },
+		} as any)
+		expect(next._meta).toEqual({ "dev.dirac/seq": 2_001 })
+		expect(journal.getSessionUpdates(sessionId)).toHaveLength(2_001)
+	})
+
+	it("discovers the sequence across a torn tail in an oversized journal", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "tail-torn-session"
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(filePath), { recursive: true })
+		const padding = "p".repeat(80)
+		let contents = ""
+		for (let sequenceNumber = 1; sequenceNumber <= 2_000; sequenceNumber += 1) {
+			contents +=
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber,
+					update: {
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: `${padding}-${sequenceNumber}` },
+					},
+				}) + "\n"
+		}
+		contents += '{"kind":"session_update","sequenceNumber":2001,"update":{"torn'
+		fs.writeFileSync(filePath, contents)
+		expect(fs.statSync(filePath).size).toBeGreaterThan(64 * 1024)
+
+		const journal = await import("./acp-session-updates.js")
+		const next = journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "agent_message_chunk",
+			content: { type: "text", text: "after-torn" },
+		} as any)
+		expect(next._meta).toEqual({ "dev.dirac/seq": 2_001 })
+	})
+
+	it("reports corruption in the middle of a JSONL journal", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "corrupt-middle-session"
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(filePath), { recursive: true })
+		fs.writeFileSync(
+			filePath,
+			[
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 1,
+					update: { sessionUpdate: "current_mode_update" },
+				}),
+				'{"broken":',
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 3,
+					update: { sessionUpdate: "current_mode_update" },
+				}),
+			].join("\n") + "\n",
+		)
+
+		const journal = await import("./acp-session-updates.js")
+		expect(() => journal.getSessionUpdates(sessionId)).toThrow(/Malformed ACP session update journal/)
+	})
+
+	it("rejects a journal row with a non-monotonic sequence number", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "nonmonotonic-session"
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(filePath), { recursive: true })
+		fs.writeFileSync(
+			filePath,
+			[
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 1,
+					update: { sessionUpdate: "current_mode_update" },
+				}),
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 1,
+					update: { sessionUpdate: "current_mode_update" },
+				}),
+			].join("\n") + "\n",
+		)
+
+		const journal = await import("./acp-session-updates.js")
+		expect(() => journal.getSessionUpdates(sessionId)).toThrow(/non-monotonic sequenceNumber/)
+	})
+
+	it("continues the sequence after a trailing journal row larger than the read window", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "huge-row-session"
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(filePath), { recursive: true })
+		const huge = "h".repeat(300 * 1024)
+		fs.writeFileSync(
+			filePath,
+			[
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 1,
+					update: {
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: "prior" },
+					},
+				}),
+				JSON.stringify({
+					kind: "session_update",
+					sequenceNumber: 2,
+					update: {
+						sessionUpdate: "agent_message_chunk",
+						content: { type: "text", text: huge },
+					},
+				}),
+			].join("\n") + "\n",
+		)
+		expect(fs.statSync(filePath).size).toBeGreaterThan(64 * 1024)
+
+		const journal = await import("./acp-session-updates.js")
+		const next = journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "current_mode_update",
+		} as any)
+		expect(next._meta).toEqual({ "dev.dirac/seq": 3 })
+	})
+
+	it("archives a corrupt legacy per-session JSON instead of retrying it on every write", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "corrupt-legacy-session"
+		const legacyPath = legacyIsolatedJournalPath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(legacyPath), { recursive: true })
+		fs.writeFileSync(
+			legacyPath,
+			'{"version":1,"updates":[{"kind":"session_update","update":{"content":"untermina',
+		)
+		const journal = await import("./acp-session-updates.js")
+
+		expect(() =>
+			journal.recordSessionUpdate(sessionId, {
+				sessionUpdate: "current_mode_update",
+			} as any),
+		).not.toThrow()
+		expect(() =>
+			journal.recordSessionUpdate(sessionId, {
+				sessionUpdate: "current_mode_update",
+			} as any),
+		).not.toThrow()
+		expect(fs.existsSync(legacyPath)).toBe(false)
+		expect(journal.getSessionUpdates(sessionId).length).toBeGreaterThan(0)
+	})
+
+	it("returns an empty journal for a session that has never been written", async () => {
+		const journal = await import("./acp-session-updates.js")
+		expect(journal.getSessionUpdates("never-accessed")).toEqual([])
+	})
+
+	it("keeps the JSONL journal and archives a legacy per-session JSON when both exist", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "both-formats-session"
+		const journal = await import("./acp-session-updates.js")
+		journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "current_mode_update",
+		} as any)
+		const jsonlPath = journalFilePath(dataDirectory, sessionId)
+		const jsonlBefore = fs.readFileSync(jsonlPath)
+		const legacyPath = legacyIsolatedJournalPath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(legacyPath), { recursive: true })
+		fs.writeFileSync(
+			legacyPath,
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				updates: [
+					{
+						kind: "session_update",
+						sequenceNumber: 1,
+						update: { sessionUpdate: "current_mode_update" },
+					},
+				],
+			}),
+		)
+
+		expect(journal.getSessionUpdates(sessionId).map((entry) => entry.sequenceNumber)).toEqual([1])
+		expect(fs.readFileSync(jsonlPath)).toEqual(jsonlBefore)
+		expect(fs.existsSync(legacyPath)).toBe(false)
+	})
+
+	it("deletes both the JSONL journal and any stale legacy per-session JSON", async () => {
+		const dataDirectory = process.env.DIRAC_DATA_DIR!
+		const sessionId = "delete-session"
+		const journal = await import("./acp-session-updates.js")
+		journal.recordSessionUpdate(sessionId, {
+			sessionUpdate: "current_mode_update",
+		} as any)
+		const filePath = journalFilePath(dataDirectory, sessionId)
+		const legacyPath = legacyIsolatedJournalPath(dataDirectory, sessionId)
+		fs.mkdirSync(path.dirname(legacyPath), { recursive: true })
+		fs.writeFileSync(legacyPath, JSON.stringify({ version: 1, sessionId, updates: [] }))
+		expect(fs.existsSync(filePath)).toBe(true)
+
+		journal.deleteSessionUpdates(sessionId)
+		expect(fs.existsSync(filePath)).toBe(false)
+		expect(fs.existsSync(legacyPath)).toBe(false)
+	})
+
+	it("rejects a non-positive DIRAC_ACP_SESSION_UPDATES_MAX_BYTES", async () => {
+		process.env.DIRAC_ACP_SESSION_UPDATES_MAX_BYTES = "abc"
+		const journal = await import("./acp-session-updates.js")
+		expect(() =>
+			journal.recordSessionUpdate("bad-env-session", {
+				sessionUpdate: "current_mode_update",
+			} as any),
+		).toThrow(/DIRAC_ACP_SESSION_UPDATES_MAX_BYTES must be a positive integer/)
 	})
 })

--- a/cli/src/acp/acp-session-updates.ts
+++ b/cli/src/acp/acp-session-updates.ts
@@ -2,14 +2,18 @@ import crypto from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
 import type * as acp from "@agentclientprotocol/sdk"
+import { Logger } from "@/shared/services/Logger.js"
 import { DIRAC_CLI_DIR } from "../utils/path.js"
 
 const LEGACY_SESSION_UPDATES_FILE = path.join(DIRAC_CLI_DIR.data, "acp-session-updates.json")
 const SESSION_UPDATES_DIRECTORY = path.join(DIRAC_CLI_DIR.data, "acp-session-updates")
 const MIGRATION_LOCK_DIRECTORY = path.join(DIRAC_CLI_DIR.data, "acp-session-updates.migration.lock")
 export const SEQUENCE_META_KEY = "dev.dirac/seq"
-const JOURNAL_VERSION = 1
+const JOURNAL_EXTENSION = ".jsonl"
+const LEGACY_ISOLATED_EXTENSION = ".json"
+const ARCHIVE_EXTENSION = ".migrated"
 const DEFAULT_MAX_JOURNAL_BYTES = 32 * 1024 * 1024
+const TAIL_READ_BYTES = 64 * 1024
 const LOCK_WAIT_TIMEOUT_MS = 15_000
 const LOCK_ORPHAN_GRACE_MS = 30_000
 const LOCK_RETRY_INTERVAL_MS = 10
@@ -19,32 +23,25 @@ type SessionUpdateWithMeta = acp.SessionUpdate & { _meta?: Record<string, unknow
 
 export type PersistedSessionUpdate =
 	| {
-		kind: "session_update"
-		sequenceNumber: number
-		update: SessionUpdateWithMeta
-	}
+			kind: "session_update"
+			sequenceNumber: number
+			update: SessionUpdateWithMeta
+	  }
 	| {
-		kind: "client_annotation"
-		sequenceNumber: number
-		annotation: Record<string, unknown>
-	}
-
+			kind: "client_annotation"
+			sequenceNumber: number
+			annotation: Record<string, unknown>
+	  }
 
 type LegacyPersistedSessionUpdate =
 	| PersistedSessionUpdate
 	| {
-		kind: "usage_update"
-		sequenceNumber: number
-		usage: Record<string, unknown>
-	}
+			kind: "usage_update"
+			sequenceNumber: number
+			usage: Record<string, unknown>
+	  }
 
 type LegacySessionUpdatesMap = Record<string, LegacyPersistedSessionUpdate[]>
-
-type SessionUpdatesJournal = {
-	version: typeof JOURNAL_VERSION
-	sessionId: string
-	updates: PersistedSessionUpdate[]
-}
 
 type LockOwner = {
 	pid: number
@@ -62,9 +59,16 @@ function maximumJournalBytes(): number {
 	return parsed
 }
 
+function digestFor(sessionId: string): string {
+	return crypto.createHash("sha256").update(sessionId).digest("hex")
+}
+
 function journalFilePath(sessionId: string): string {
-	const digest = crypto.createHash("sha256").update(sessionId).digest("hex")
-	return path.join(SESSION_UPDATES_DIRECTORY, `${digest}.json`)
+	return path.join(SESSION_UPDATES_DIRECTORY, `${digestFor(sessionId)}${JOURNAL_EXTENSION}`)
+}
+
+function legacyIsolatedJournalPath(sessionId: string): string {
+	return path.join(SESSION_UPDATES_DIRECTORY, `${digestFor(sessionId)}${LEGACY_ISOLATED_EXTENSION}`)
 }
 
 function sessionLockDirectory(sessionId: string): string {
@@ -73,6 +77,33 @@ function sessionLockDirectory(sessionId: string): string {
 
 function isObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function malformedJournalError(filePath: string, error: unknown): Error {
+	const detail = error instanceof Error ? error.message : String(error)
+	return new Error(
+		`Malformed ACP session update journal at ${filePath}: ${detail}. ` +
+			"Dirac will not overwrite or reset this file; move it aside for recovery or repair the JSON before retrying.",
+	)
+}
+
+function validatePersistedUpdate(value: unknown, previousSequenceNumber: number, filePath: string): PersistedSessionUpdate {
+	if (!isObject(value)) throw malformedJournalError(filePath, new Error("expected an object"))
+	if (!Number.isSafeInteger(value.sequenceNumber) || (value.sequenceNumber as number) <= previousSequenceNumber) {
+		throw malformedJournalError(filePath, new Error(`non-monotonic sequenceNumber ${JSON.stringify(value.sequenceNumber)}`))
+	}
+
+	if (value.kind === "session_update") {
+		if (!isObject(value.update)) throw malformedJournalError(filePath, new Error("session update has no update payload"))
+		return value as unknown as PersistedSessionUpdate
+	}
+	if (value.kind === "client_annotation") {
+		if (!isObject(value.annotation)) {
+			throw malformedJournalError(filePath, new Error("client annotation has no annotation payload"))
+		}
+		return value as unknown as PersistedSessionUpdate
+	}
+	throw malformedJournalError(filePath, new Error(`unknown kind ${JSON.stringify(value.kind)}`))
 }
 
 function validateUpdateArray(updates: unknown, allowLegacyUsageUpdates: boolean): void {
@@ -106,49 +137,13 @@ function validateUpdateArray(updates: unknown, allowLegacyUsageUpdates: boolean)
 	}
 }
 
-function validateUpdates(updates: unknown): asserts updates is PersistedSessionUpdate[] {
-	validateUpdateArray(updates, false)
-}
-
 function validateLegacyUpdates(updates: unknown): asserts updates is LegacyPersistedSessionUpdate[] {
 	validateUpdateArray(updates, true)
-}
-
-function malformedJournalError(filePath: string, error: unknown): Error {
-	const detail = error instanceof Error ? error.message : String(error)
-	return new Error(
-		`Malformed ACP session update journal at ${filePath}: ${detail}. ` +
-		"Dirac will not overwrite or reset this file; move it aside for recovery or repair the JSON before retrying.",
-	)
 }
 
 function parseJournalJson(filePath: string, contents: string): unknown {
 	try {
 		return JSON.parse(contents)
-	} catch (error) {
-		throw malformedJournalError(filePath, error)
-	}
-}
-
-function readSessionJournal(sessionId: string): SessionUpdatesJournal {
-	const filePath = journalFilePath(sessionId)
-	let contents: string
-	try {
-		contents = fs.readFileSync(filePath, "utf8")
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			return { version: JOURNAL_VERSION, sessionId, updates: [] }
-		}
-		throw error
-	}
-
-	const parsed = parseJournalJson(filePath, contents)
-	try {
-		if (!isObject(parsed)) throw new Error("expected a JSON object")
-		if (parsed.version !== JOURNAL_VERSION) throw new Error(`unsupported journal version ${JSON.stringify(parsed.version)}`)
-		if (parsed.sessionId !== sessionId) throw new Error(`journal belongs to session ${JSON.stringify(parsed.sessionId)}`)
-		validateUpdates(parsed.updates)
-		return parsed as SessionUpdatesJournal
 	} catch (error) {
 		throw malformedJournalError(filePath, error)
 	}
@@ -213,80 +208,7 @@ function parseLegacyJournalJson(contents: string): { parsed: unknown; hadTrailin
 	}
 }
 
-function readLegacySessionUpdatesMap(): { sessionUpdates: LegacySessionUpdatesMap; hadTrailingData: boolean } {
-	const contents = fs.readFileSync(LEGACY_SESSION_UPDATES_FILE, "utf8")
-	const { parsed, hadTrailingData } = parseLegacyJournalJson(contents)
-	try {
-		if (!isObject(parsed)) throw new Error("expected a JSON object keyed by session ID")
-		for (const [sessionId, updates] of Object.entries(parsed)) {
-			try {
-				validateLegacyUpdates(updates)
-			} catch (error) {
-				const detail = error instanceof Error ? error.message : String(error)
-				throw new Error(`session ${JSON.stringify(sessionId)}: ${detail}`)
-			}
-		}
-		return { sessionUpdates: parsed as LegacySessionUpdatesMap, hadTrailingData }
-	} catch (error) {
-		throw malformedJournalError(LEGACY_SESSION_UPDATES_FILE, error)
-	}
-}
-
-function fsyncDirectory(directoryPath: string): void {
-	let descriptor: number | undefined
-	try {
-		descriptor = fs.openSync(directoryPath, "r")
-		fs.fsyncSync(descriptor)
-	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code
-		if (process.platform === "win32" && (code === "EINVAL" || code === "EPERM" || code === "EISDIR")) return
-		throw error
-	} finally {
-		if (descriptor !== undefined) fs.closeSync(descriptor)
-	}
-}
-
-function serializeJournal(journal: SessionUpdatesJournal, filePath: string): string {
-	const serialized = JSON.stringify(journal)
-	const byteLength = Buffer.byteLength(serialized)
-	const maximumBytes = maximumJournalBytes()
-	if (byteLength > maximumBytes) {
-		throw new Error(
-			`ACP session update journal for session ${JSON.stringify(journal.sessionId)} would grow to ${byteLength} bytes, ` +
-			`exceeding the ${maximumBytes}-byte limit at ${filePath}. The previous journal remains intact. ` +
-			"Delete the session to remove its replay history or raise DIRAC_ACP_SESSION_UPDATES_MAX_BYTES explicitly.",
-		)
-	}
-	return serialized
-}
-
-function atomicWriteJournal(journal: SessionUpdatesJournal): void {
-	fs.mkdirSync(SESSION_UPDATES_DIRECTORY, { recursive: true })
-	const filePath = journalFilePath(journal.sessionId)
-	const serialized = serializeJournal(journal, filePath)
-	const temporaryPath = path.join(
-		SESSION_UPDATES_DIRECTORY,
-		`.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
-	)
-	let descriptor: number | undefined
-	try {
-		descriptor = fs.openSync(temporaryPath, "wx", 0o600)
-		fs.writeFileSync(descriptor, serialized, "utf8")
-		fs.fsyncSync(descriptor)
-		fs.closeSync(descriptor)
-		descriptor = undefined
-		fs.renameSync(temporaryPath, filePath)
-		fsyncDirectory(SESSION_UPDATES_DIRECTORY)
-	} catch (error) {
-		if (descriptor !== undefined) fs.closeSync(descriptor)
-		try {
-			fs.unlinkSync(temporaryPath)
-		} catch (cleanupError) {
-			if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") throw cleanupError
-		}
-		throw error
-	}
-}
+// ---------------------------------------------------------------- locking
 
 function processIsAlive(pid: number): boolean {
 	try {
@@ -363,6 +285,221 @@ function withLock<T>(lockDirectory: string, action: () => T): T {
 	}
 }
 
+// ------------------------------------------------------------- JSONL I/O
+
+function serializeRow(entry: PersistedSessionUpdate): string {
+	return `${JSON.stringify(entry)}\n`
+}
+
+/**
+ * Read every committed journal entry. The final line is tolerated if it is not
+ * newline-terminated and does not parse — that is a torn append from a crashed
+ * writer, not file corruption. Any other malformed line is real corruption.
+ */
+function readJournalEntries(filePath: string): PersistedSessionUpdate[] {
+	let contents: string
+	try {
+		contents = fs.readFileSync(filePath, "utf8")
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+		throw error
+	}
+
+	const entries: PersistedSessionUpdate[] = []
+	const lines = contents.split("\n")
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index].trim()
+		if (line === "") continue
+
+		let parsed: unknown
+		try {
+			parsed = JSON.parse(line)
+		} catch (error) {
+			if (index === lines.length - 1) {
+				// A final line without a trailing newline that does not parse is a
+				// torn append from a crashed writer, not file corruption.
+				continue
+			}
+			throw malformedJournalError(filePath, error)
+		}
+		const previousSequenceNumber = entries.at(-1)?.sequenceNumber ?? 0
+		entries.push(validatePersistedUpdate(parsed, previousSequenceNumber, filePath))
+	}
+	return entries
+}
+
+/**
+ * Return the highest committed sequence number by reading only the end of the
+ * file, so appends stay O(1) regardless of journal size. The window grows only
+ * enough to delimit a full trailing line, so a single row larger than the
+ * window (e.g. a huge message) is still read correctly. Returns 0 for absent,
+ * empty, or entirely-torn journals.
+ */
+function readLastSequence(filePath: string): number {
+	let size: number
+	try {
+		size = fs.statSync(filePath).size
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0
+		throw error
+	}
+	if (size === 0) return 0
+
+	const descriptor = fs.openSync(filePath, "r")
+	try {
+		let windowBytes = Math.min(TAIL_READ_BYTES, size)
+		while (true) {
+			const readStart = size - windowBytes
+			const buffer = Buffer.alloc(windowBytes)
+			fs.readSync(descriptor, buffer, 0, windowBytes, readStart)
+
+			// Slicing at newline byte boundaries avoids splitting a multibyte
+			// UTF-8 character when the window opens mid-line.
+			const lastNewline = buffer.lastIndexOf(0x0a)
+			const secondToLastNewline = lastNewline === -1 ? -1 : buffer.lastIndexOf(0x0a, lastNewline - 1)
+			if (readStart > 0 && secondToLastNewline === -1) {
+				// The window cannot yet delimit a full trailing line (either it
+				// is entirely inside one oversized row, or only its final newline
+				// is captured). Grow the window until the previous line is reachable.
+				windowBytes = Math.min(windowBytes * 2, size)
+				continue
+			}
+
+			const lineStart = secondToLastNewline === -1 ? 0 : secondToLastNewline + 1
+			// The region after the previous line's newline holds the last complete
+			// line plus any torn tail; scan its lines from the end.
+			const lines = buffer.subarray(lineStart).toString("utf8").split("\n")
+			for (let index = lines.length - 1; index >= 0; index -= 1) {
+				const line = lines[index].trim()
+				if (line === "") continue
+				try {
+					const parsed = JSON.parse(line) as PersistedSessionUpdate
+					if (isObject(parsed) && Number.isSafeInteger(parsed.sequenceNumber)) {
+						return parsed.sequenceNumber
+					}
+				} catch {
+					// torn or truncated tail line; scan backwards
+				}
+			}
+			return 0
+		}
+	} finally {
+		fs.closeSync(descriptor)
+	}
+}
+
+function fsyncDirectory(directoryPath: string): void {
+	let descriptor: number | undefined
+	try {
+		descriptor = fs.openSync(directoryPath, "r")
+		fs.fsyncSync(descriptor)
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code
+		if (process.platform === "win32" && (code === "EINVAL" || code === "EPERM" || code === "EISDIR")) return
+		throw error
+	} finally {
+		if (descriptor !== undefined) fs.closeSync(descriptor)
+	}
+}
+
+function atomicWriteRows(filePath: string, entries: PersistedSessionUpdate[]): void {
+	fs.mkdirSync(SESSION_UPDATES_DIRECTORY, { recursive: true })
+	const serialized = entries.map(serializeRow).join("")
+	const temporaryPath = path.join(
+		SESSION_UPDATES_DIRECTORY,
+		`.${path.basename(filePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+	)
+	let descriptor: number | undefined
+	try {
+		descriptor = fs.openSync(temporaryPath, "wx", 0o600)
+		fs.writeFileSync(descriptor, serialized, "utf8")
+		fs.fsyncSync(descriptor)
+		fs.closeSync(descriptor)
+		descriptor = undefined
+		fs.renameSync(temporaryPath, filePath)
+		fsyncDirectory(SESSION_UPDATES_DIRECTORY)
+	} catch (error) {
+		if (descriptor !== undefined) fs.closeSync(descriptor)
+		try {
+			fs.unlinkSync(temporaryPath)
+		} catch (cleanupError) {
+			if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") throw cleanupError
+		}
+		throw error
+	}
+}
+
+/**
+ * Append one newline-terminated row and return the resulting file size.
+ * Opening with "a" positions the write at the end, so appends never rewrite
+ * the existing content.
+ */
+function appendRow(filePath: string, row: string): number {
+	fs.mkdirSync(SESSION_UPDATES_DIRECTORY, { recursive: true })
+	const descriptor = fs.openSync(filePath, "a", 0o600)
+	try {
+		fs.writeFileSync(descriptor, row, "utf8")
+		fs.fsyncSync(descriptor)
+		return fs.fstatSync(descriptor).size
+	} finally {
+		fs.closeSync(descriptor)
+	}
+}
+
+/**
+ * When the journal exceeds its size budget, drop the oldest entries — never
+ * failing the live write — and rewrite the retained tail atomically. Sequence
+ * numbers are preserved on the retained entries. A single entry larger than the
+ * budget is kept whole, accepting a one-entry overshoot.
+ *
+ * Compaction is best-effort size maintenance, deliberately run after the append
+ * has already been durably written: a failure here only leaves the journal over
+ * budget and must not fail the write that already succeeded.
+ */
+function compactIfNeeded(filePath: string, size: number): void {
+	const maximumBytes = maximumJournalBytes()
+	if (size <= maximumBytes) return
+
+	const entries = readJournalEntries(filePath)
+	if (entries.length <= 1) return
+
+	const lengths = entries.map((entry) => Buffer.byteLength(serializeRow(entry)))
+	let total = lengths.reduce((sum, length) => sum + length, 0)
+	let drop = 0
+	while (drop < entries.length - 1 && total > maximumBytes) {
+		total -= lengths[drop]
+		drop += 1
+	}
+	if (drop === 0) return
+
+	try {
+		atomicWriteRows(filePath, entries.slice(drop))
+	} catch (error) {
+		Logger.error(`[acp-session-updates] failed to compact journal ${filePath}:`, error)
+	}
+}
+
+// ------------------------------------------------------------- migration
+
+function readLegacySessionUpdatesMap(): { sessionUpdates: LegacySessionUpdatesMap; hadTrailingData: boolean } {
+	const contents = fs.readFileSync(LEGACY_SESSION_UPDATES_FILE, "utf8")
+	const { parsed, hadTrailingData } = parseLegacyJournalJson(contents)
+	try {
+		if (!isObject(parsed)) throw new Error("expected a JSON object keyed by session ID")
+		for (const [sessionId, updates] of Object.entries(parsed)) {
+			try {
+				validateLegacyUpdates(updates)
+			} catch (error) {
+				const detail = error instanceof Error ? error.message : String(error)
+				throw new Error(`session ${JSON.stringify(sessionId)}: ${detail}`)
+			}
+		}
+		return { sessionUpdates: parsed as LegacySessionUpdatesMap, hadTrailingData }
+	} catch (error) {
+		throw malformedJournalError(LEGACY_SESSION_UPDATES_FILE, error)
+	}
+}
+
 function finalizeLegacyJournalMigration(hadTrailingData: boolean): void {
 	if (hadTrailingData) {
 		const recoveryPath = `${LEGACY_SESSION_UPDATES_FILE}.recovery-${Date.now()}-${crypto.randomUUID()}`
@@ -373,30 +510,60 @@ function finalizeLegacyJournalMigration(hadTrailingData: boolean): void {
 	fsyncDirectory(path.dirname(LEGACY_SESSION_UPDATES_FILE))
 }
 
-function updateJsonEquals(left: PersistedSessionUpdate, right: PersistedSessionUpdate): boolean {
-	return JSON.stringify(left) === JSON.stringify(right)
+function currentUpdatesFromLegacy(updates: LegacyPersistedSessionUpdate[]): PersistedSessionUpdate[] {
+	return updates.filter((update): update is PersistedSessionUpdate => update.kind !== "usage_update")
+}
+
+/**
+ * Convert an old per-session object journal (`{version, sessionId, updates}`,
+ * written by the previous design) into the newline-delimited journal. A missing
+ * journal is a no-op; when the newline journal already exists it wins and the
+ * legacy file is archived. A corrupt or invalid legacy journal is archived
+ * (bytes preserved for recovery) rather than thrown on every write, so it cannot
+ * stall the session or spam error logs.
+ */
+function migrateLegacyIsolatedJournal(sessionId: string): void {
+	const legacyPath = legacyIsolatedJournalPath(sessionId)
+	if (!fs.existsSync(legacyPath)) return
+
+	if (fs.existsSync(journalFilePath(sessionId))) {
+		archiveLegacyIsolatedJournal(sessionId)
+		return
+	}
+
+	try {
+		const parsed = parseJournalJson(legacyPath, fs.readFileSync(legacyPath, "utf8"))
+		if (!isObject(parsed) || !Array.isArray(parsed.updates)) {
+			throw new Error("expected a JSON object with an updates array")
+		}
+		const entries: PersistedSessionUpdate[] = []
+		let previousSequenceNumber = 0
+		for (const update of parsed.updates) {
+			entries.push(validatePersistedUpdate(update, previousSequenceNumber, legacyPath))
+			previousSequenceNumber = (update as PersistedSessionUpdate).sequenceNumber
+		}
+		atomicWriteRows(journalFilePath(sessionId), entries)
+	} catch (error) {
+		Logger.error(`[acp-session-updates] discarding unreadable legacy journal ${legacyPath}:`, error)
+	}
+	archiveLegacyIsolatedJournal(sessionId)
+}
+
+function archiveLegacyIsolatedJournal(sessionId: string): void {
+	const legacyPath = legacyIsolatedJournalPath(sessionId)
+	fs.renameSync(legacyPath, `${legacyPath}${ARCHIVE_EXTENSION}.${Date.now()}-${crypto.randomUUID()}`)
+	fsyncDirectory(SESSION_UPDATES_DIRECTORY)
 }
 
 function migrateLegacySession(sessionId: string, legacyUpdates: PersistedSessionUpdate[]): void {
 	withLock(sessionLockDirectory(sessionId), () => {
-		const existing = readSessionJournal(sessionId)
-		const sharedLength = Math.min(existing.updates.length, legacyUpdates.length)
-		for (let index = 0; index < sharedLength; index += 1) {
-			if (updateJsonEquals(existing.updates[index], legacyUpdates[index])) continue
-			throw new Error(
-				`Conflicting ACP session update histories for session ${JSON.stringify(sessionId)} in ` +
-				`${LEGACY_SESSION_UPDATES_FILE} and ${journalFilePath(sessionId)} at sequence ${index + 1}. ` +
-				"Dirac preserved both files; repair or move one history aside before retrying.",
-			)
-		}
-
-		if (existing.updates.length >= legacyUpdates.length) return
-		atomicWriteJournal({ version: JOURNAL_VERSION, sessionId, updates: legacyUpdates })
+		if (fs.existsSync(journalFilePath(sessionId))) return
+		// A per-session isolated journal (current format) takes precedence over the stale flat file.
+		if (fs.existsSync(legacyIsolatedJournalPath(sessionId))) return
+		const updates = currentUpdatesFromLegacy(legacyUpdates)
+		if (updates.length === 0) return
+		atomicWriteRows(journalFilePath(sessionId), updates)
 	})
-}
-
-function currentUpdatesFromLegacy(updates: LegacyPersistedSessionUpdate[]): PersistedSessionUpdate[] {
-	return updates.filter((update): update is PersistedSessionUpdate => update.kind !== "usage_update")
 }
 
 function migrateLegacyJournal(): void {
@@ -412,24 +579,36 @@ function migrateLegacyJournal(): void {
 	})
 }
 
-function updateSessionJournal<T>(sessionId: string, update: (journal: SessionUpdatesJournal) => T): T {
+// ------------------------------------------------------------- public API
+
+/**
+ * Append one entry to a session's journal under its cross-process lock:
+ * compute the next durable sequence from the file tail, write the single row,
+ * and compact if over budget. `build` receives the sequence so the caller can
+ * stamp it consistently on both the persisted entry and its returned value.
+ */
+function appendSessionEntry<T>(
+	sessionId: string,
+	build: (sequenceNumber: number) => { entry: PersistedSessionUpdate; result: T },
+): T {
 	migrateLegacyJournal()
 	return withLock(sessionLockDirectory(sessionId), () => {
-		const journal = readSessionJournal(sessionId)
-		const result = update(journal)
-		atomicWriteJournal(journal)
+		const filePath = journalFilePath(sessionId)
+		migrateLegacyIsolatedJournal(sessionId)
+		const sequenceNumber = readLastSequence(filePath) + 1
+		const { entry, result } = build(sequenceNumber)
+		const size = appendRow(filePath, serializeRow(entry))
+		compactIfNeeded(filePath, size)
 		return result
 	})
 }
 
-function nextSequenceNumber(updates: PersistedSessionUpdate[]): number {
-	return (updates.at(-1)?.sequenceNumber ?? 0) + 1
-}
-
-/** Persist one ACP session update with its stable, per-session sequence number. */
+/**
+ * Persist one ACP session update with its stable, per-session sequence number.
+ * Appends a single line; the previous journal is never re-read or re-written.
+ */
 export function recordSessionUpdate(sessionId: string, update: acp.SessionUpdate): SessionUpdateWithMeta {
-	return updateSessionJournal(sessionId, (journal) => {
-		const sequenceNumber = nextSequenceNumber(journal.updates)
+	return appendSessionEntry(sessionId, (sequenceNumber) => {
 		const updateWithSequence: SessionUpdateWithMeta = {
 			...update,
 			_meta: {
@@ -437,15 +616,16 @@ export function recordSessionUpdate(sessionId: string, update: acp.SessionUpdate
 				[SEQUENCE_META_KEY]: sequenceNumber,
 			},
 		}
-		journal.updates.push({ kind: "session_update", sequenceNumber, update: updateWithSequence })
-		return updateWithSequence
+		return {
+			entry: { kind: "session_update", sequenceNumber, update: updateWithSequence },
+			result: updateWithSequence,
+		}
 	})
 }
 
 /** Persist one client control-plane annotation with its stable, per-session sequence number. */
 export function recordClientAnnotation(sessionId: string, annotation: Record<string, unknown>): Record<string, unknown> {
-	return updateSessionJournal(sessionId, (journal) => {
-		const sequenceNumber = nextSequenceNumber(journal.updates)
+	return appendSessionEntry(sessionId, (sequenceNumber) => {
 		const annotationWithSequence = {
 			...annotation,
 			_meta: {
@@ -453,26 +633,35 @@ export function recordClientAnnotation(sessionId: string, annotation: Record<str
 				[SEQUENCE_META_KEY]: sequenceNumber,
 			},
 		}
-		journal.updates.push({ kind: "client_annotation", sequenceNumber, annotation: annotationWithSequence })
-		return annotationWithSequence
+		return {
+			entry: { kind: "client_annotation", sequenceNumber, annotation: annotationWithSequence },
+			result: annotationWithSequence,
+		}
 	})
 }
 
 /** Return the immutable ordered ACP update journal for a persisted session. */
 export function getSessionUpdates(sessionId: string): PersistedSessionUpdate[] {
 	migrateLegacyJournal()
-	return readSessionJournal(sessionId).updates
+	return withLock(sessionLockDirectory(sessionId), () => {
+		const filePath = journalFilePath(sessionId)
+		migrateLegacyIsolatedJournal(sessionId)
+		return readJournalEntries(filePath)
+	})
 }
 
 /** Remove the complete ACP update journal for a deleted session. */
 export function deleteSessionUpdates(sessionId: string): void {
 	migrateLegacyJournal()
 	withLock(sessionLockDirectory(sessionId), () => {
-		try {
-			fs.unlinkSync(journalFilePath(sessionId))
-			fsyncDirectory(SESSION_UPDATES_DIRECTORY)
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+		const filePath = journalFilePath(sessionId)
+		for (const candidate of [filePath, legacyIsolatedJournalPath(sessionId)]) {
+			try {
+				fs.unlinkSync(candidate)
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+			}
 		}
+		fsyncDirectory(SESSION_UPDATES_DIRECTORY)
 	})
 }


### PR DESCRIPTION
## Summary
Permanent fix for the ACP journal that caused "Remote ACP is disconnected" / `exit code 1`. Follow-up to #144 (which keeps the session alive when persistence fails); this removes the *cause* so the failure never occurs again.

## The defect
`cli/src/acp/acp-session-updates.ts` stored the journal as one JSON object and **re-read / re-parsed / re-stringified the whole file on every update** (O(n²)), then **threw fatally** once it exceeded `DIRAC_ACP_SESSION_UPDATES_MAX_BYTES` (32 MB). A long/verbose session hit the 64 MB crash exactly this way.

## The fix
Replace the whole-file journal with an **append-only JSONL** design (`acp-session-updates.ts`):

- **O(1) appends** — each update is one newline-terminated row appended via `fs.openSync(fd, "a")`; prior content is never read or rewritten.
- **Durable monotonic sequence** — read from the file *tail* via a growing window (stays near O(1), and correctly handles a single row larger than the 64 KB window).
- **Non-fatal cap** — on overflow the **oldest** entries are compacted away (best-effort, logged); the latest history and live write are preserved. No throw.
- **Torn-tail tolerance** — a crashed writer's partial final line is ignored; real mid-file corruption still surfaces.
- **Migration** — legacy per-session `.json` and flat journals migrate to `.jsonl` and are archived; a corrupt legacy `.json` is now **archived once** instead of throwing on every write (was an ERROR-log storm).

## Verification
- 21 unit tests: monotonic replay, 4-process concurrency, migration (both legacy formats), compaction (success/failure/single-entry), torn tails, corrupt/mid-file corruption, oversized rows (> window), empty session, delete, invalid env.
- `esbuild` CLI bundle builds; typecheck + biome clean in edited regions.
- Realistic smoke: a 40 MB over-cap journal — 200 live appends **without throwing**, sequence continues, file bounded back to ~32 MB, replay readable. (Pre-fix this crashed the process.)

## Coverage notes
- Compaction is a full-file rewrite, but only at threshold-crossing and capped at 32 MB — acceptable; a rotated/append-log could be a later optimization.
- The 6 pre-existing failures in `protocolConformance`/`streamUtils` are unrelated (verified present on `master`).

Follows #144: #144 (immediate boundary) + this (root-cause) together fully resolve the crash.