### PR TITLE
fix(core/task): replace execSync with spawnSync

### DIFF
--- a/src/core/task/tools/modules/upsert_tool/scaffold-generator.ts
+++ b/src/core/task/tools/modules/upsert_tool/scaffold-generator.ts
@@ -48,7 +48,7 @@ import { create } from "./tool.ts"
 import * as fs from "fs/promises"
 import * as nodePath from "path"
 import { fileURLToPath } from "url"
-import { execSync } from "child_process"
+import { spawnSync } from "child_process"
 
 const noOp = async () => {}
 const noOpObj = async () => ({})
@@ -70,8 +70,10 @@ const env = {
   system: {
     executeCommand: async (cmd: string) => {
       try {
-        const output = execSync(cmd, { encoding: "utf8", timeout: 30000 })
-        return { userRejected: false, output, completed: true, exitCode: 0, signal: null }
+        const [file, ...args] = cmd.split(/s+/)
+        const result = spawnSync(file, args, { encoding: "utf8", timeout: 30000 })
+        if (result.error) throw result.error
+        return { userRejected: false, output: result.stdout || "", completed: true, exitCode: typeof result.status === "number" ? result.status : 1, signal: result.signal }
       } catch (e: any) {
         return {
           userRejected: false,

--- a/src/core/task/utils.test.ts
+++ b/src/core/task/utils.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "mocha"
+import proxyquire from "proxyquire"
+import sinon from "sinon"
+
+describe("detectAvailableCliTools", () => {
+	const sandbox = sinon.createSandbox()
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	function loadWithSpawnSync(spawnSync: sinon.SinonStub) {
+		return proxyquire.noCallThru().load("./utils", { child_process: { spawnSync } }).detectAvailableCliTools as () => Promise<
+			string[]
+		>
+	}
+
+	it("checks each tool with an argument array (no shell interpolation)", async () => {
+		const spawnSync = sandbox.stub().returns({ status: 0, stdout: "", stderr: "", signal: null })
+		const detectAvailableCliTools = loadWithSpawnSync(spawnSync)
+
+		const result = await detectAvailableCliTools()
+
+		assert.ok(spawnSync.called)
+		for (const call of spawnSync.getCalls()) {
+			const checkCommand = call.args[0] as string
+			const args = call.args[1] as string[]
+			assert.ok(checkCommand === "which" || checkCommand === "where")
+			// The tool name must be passed as a separate element of the argument
+			// array — never interpolated into a shell command string.
+			assert.ok(Array.isArray(args))
+			assert.strictEqual(args.length, 1)
+		}
+		assert.ok(result.includes("git"))
+	})
+
+	it("reports only the tools whose availability check succeeds", async () => {
+		const spawnSync = sandbox
+			.stub()
+			.callsFake((_checkCommand: string, args?: ReadonlyArray<string>) => ({ status: args?.[0] === "git" ? 0 : 1 }))
+		const detectAvailableCliTools = loadWithSpawnSync(spawnSync)
+
+		const result = await detectAvailableCliTools()
+
+		assert.deepEqual(result, ["git"])
+	})
+
+	it("skips a tool when its availability check throws", async () => {
+		const spawnSync = sandbox.stub().callsFake((_checkCommand: string, args?: ReadonlyArray<string>) => {
+			if (args?.[0] === "curl") throw new Error("boom")
+			return { status: 0 }
+		})
+		const detectAvailableCliTools = loadWithSpawnSync(spawnSync)
+
+		const result = await detectAvailableCliTools()
+
+		assert.ok(result.includes("git"))
+		assert.ok(!result.includes("curl"))
+	})
+})

--- a/src/core/task/utils.ts
+++ b/src/core/task/utils.ts
@@ -1,10 +1,8 @@
 import { ApiHandler } from "@core/api"
-import { execSync } from "child_process"
+import { spawnSync } from "child_process"
 import { showSystemNotification } from "@/integrations/notifications"
 import { DiracApiReqCancelReason, DiracApiReqInfo, DiracMessageType } from "@/shared/ExtensionMessage"
-
-import { calculateApiCostAnthropic } from "@/utils/cost"
-import { calculateApiCostOpenAI, calculateApiCostQwen } from "@/utils/cost"
+import { calculateApiCostAnthropic, calculateApiCostOpenAI, calculateApiCostQwen } from "@/utils/cost"
 import { MessageStateHandler } from "./message-state"
 
 export const showNotificationForApproval = (message: string, notificationsEnabled: boolean) => {
@@ -178,15 +176,17 @@ export async function detectAvailableCliTools(): Promise<string[]> {
 
 	for (const command of CLI_TOOLS) {
 		try {
-			// Use execSync to check if the command exists
-			execSync(`${checkCommand} ${command}`, {
+			// Use spawnSync to check if the command exists (arg array — no shell interpolation)
+			const result = spawnSync(checkCommand, [command], {
 				stdio: "ignore", // Don't output to console
 				timeout: 1000, // 1 second timeout to avoid hanging
 			})
-			availableCommands.push(command)
-		} catch (error) {
+			if (result.status !== 0) continue
+		} catch {
 			// Command not found, skip it
+			continue
 		}
+		availableCommands.push(command)
 	}
 
 	return availableCommands


### PR DESCRIPTION
## What
Replace `execSync` string interpolation with `spawnSync` arg arrays.

- `detectAvailableCliTools` (core/task/utils.ts): `execSync(\`${checkCommand} ${command}\`)` → `spawnSync(checkCommand, [command])`; availability now gates on `result.status === 0`.
- Generated upsert_tool harness `executeCommand` (scaffold-generator.ts): `execSync(cmd)` → `spawnSync(file, args)`.

## Why
`execSync` runs the interpolated string through a shell — an injection / credential-leak vector. `spawnSync` passes argv directly, no shell.

## Limitation
Harness split handles simple `cmd` only (no pipes/redirects/globs).

## Tests
- New `src/core/task/utils.test.ts`: arg-array usage (no shell string), status filtering, error skip.
- Existing `UpsertToolSupport.test.ts` still green. 9/9 passing; biome + tsc clean.

## User test
- Tool detection: run an agent task that maps environment tools; confirm installed tools (git, npm, …) still list.
- Tool scaffold: run the generated `test-harness.ts`; `executeCommand` with a simple command (e.g. `ls -la`) returns `{output, exitCode}`.
- Unit: `TS_NODE_PROJECT=./tsconfig.unit-test.json npx mocha --node-option no-experimental-strip-types src/core/task/utils.test.ts`

Closes FB-1 (FIX-BACKLOG).