### PR TITLE
fix(core): catch fire-and-forget promise rejections

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -114,9 +114,13 @@ export class Controller {
 		checkCliInstallation(this)
 
 		// Initialize workspace manager in background
-		this.ensureWorkspaceManager().then(() => {
-			this.postStateToWebview()
-		})
+		this.ensureWorkspaceManager()
+			.then(() => {
+				this.postStateToWebview()
+			})
+			.catch((error) => {
+				Logger.error("Failed to initialize workspace manager:", error)
+			})
 	}
 
 	/*

--- a/src/integrations/editor/detect-omission.ts
+++ b/src/integrations/editor/detect-omission.ts
@@ -1,6 +1,7 @@
 import { HostProvider } from "@hosts/host-provider"
 import { ShowMessageType } from "@shared/proto/host/window"
 import { openExternal } from "@utils/env"
+import { Logger } from "@/shared/services/Logger"
 
 /**
  * Detects potential AI-generated code omissions in the given file content.
@@ -56,6 +57,9 @@ export function showOmissionWarning(originalFileContent: string, newFileContent:
 						"https://github.com/dirac-run/dirac/wiki/Troubleshooting-%E2%80%90-Dirac-Deleting-Code-with-%22Rest-of-Code-Here%22-Comments",
 					)
 				}
+			})
+			.catch((error) => {
+				Logger.error("Failed to show omission warning message:", error)
 			})
 	}
 }

--- a/src/utils/github-url-utils.ts
+++ b/src/utils/github-url-utils.ts
@@ -167,6 +167,9 @@ export async function openUrlInBrowser(url: string): Promise<void> {
 						writeTextToClipboard(url)
 					}
 				})
+				.catch((error) => {
+					Logger.error("Failed to show URL open fallback message:", error)
+				})
 		}
 	}
 }


### PR DESCRIPTION
## What
Add `.catch()` to fire-and-forget `.then()` so rejections don't become unhandled.

- `core/controller/index.ts`: background `ensureWorkspaceManager().then()`
- `integrations/editor/detect-omission.ts`: `showMessage().then()`
- `utils/github-url-utils.ts`: `showMessage().then()`

## Why
Unhandled rejections are a crash vector (same class as the ACP session setup crash). `.then()` without `.catch()` lets errors escape to the process.

## Notes
`file-logging.ts` flagged by the backlog is already handled (`handlePromise` is awaited; the write chain has `.catch`) — no change.

## User test
- Launch the extension. Open a URL that cannot be opened normally (e.g. a malformed/failed link) to hit the fallback — the "Couldn't open the URL automatically" info message should appear, and the extension-host Output → Dirac log should show **no** "unhandled promise rejection".
- Trigger a code-truncation / omission scenario so the "Potential code truncation detected" warning shows — it should display normally with no crash.
- During both, watch the extension-host Output log for any "Unhandled exception"/"unhandled promise rejection" — there should be none.

## Verification
`tsc` + `biome` clean on changed files (controller has only pre-existing infos). No unit tests added (UI callback error boundary isn't meaningfully testable).

Closes FB-2 (FIX-BACKLOG).