### PR TITLE
refactor: type-only cross-layer imports

### DIFF
--- a/src/services/browser/BrowserConnectionManager.ts
+++ b/src/services/browser/BrowserConnectionManager.ts
@@ -1,4 +1,4 @@
-import { Controller } from "@core/controller"
+import type { Controller } from "@core/controller"
 import { BrowserActionResult } from "@shared/ExtensionMessage"
 import { fileExistsAtPath } from "@utils/fs"
 import axios from "axios"

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -1,5 +1,5 @@
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
-import { Controller } from "@core/controller"
+import type { Controller } from "@core/controller"
 import { BrowserActionResult } from "@shared/ExtensionMessage"
 import pWaitFor from "p-wait-for"
 import type { ConsoleMessage, ScreenshotOptions } from "puppeteer-core"

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -1,4 +1,4 @@
-import { ApiHandlerModel, ApiProviderInfo } from "@core/api"
+import type { ApiHandlerModel, ApiProviderInfo } from "@core/api"
 import { AnthropicModelId, anthropicModels, getProviderForModel } from "@/shared/api"
 
 export { supportsReasoningEffortForModel } from "@shared/utils/reasoning-support"


### PR DESCRIPTION
## What
Convert cross-layer imports that are used only as types to `import type`:

- `services/browser/BrowserSession.ts` — `Controller`
- `services/browser/BrowserConnectionManager.ts` — `Controller`
- `utils/model-utils.ts` — `ApiHandlerModel`, `ApiProviderInfo`

## Why
These names are used only as type annotations, never as runtime values. `import type` removes a runtime `services`/`utils` → `core` dependency, eliminating a circular-import / unwanted-load vector.

## Verification
`tsc` clean on changed files. `biome` clean (only pre-existing warnings unrelated to this change).

## User test
No observable UX change — compile-time-only change. Run the existing unit/compile checks.

Closes FB-3 (FIX-BACKLOG).