### PR TITLE
test: extract mockProviderInfo to test-helper

### DIFF
--- a/src/core/prompts/system-prompt/__tests__/PromptBuilder.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/PromptBuilder.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { PromptBuilder } from "../registry/PromptBuilder"
 import type { SystemPromptContext } from "../types"
-import { mockProviderInfo } from "./integration.test"
+import { mockProviderInfo } from "./test-helpers"
 
 describe("PromptBuilder", () => {
 	const mockContext: SystemPromptContext = {

--- a/src/core/prompts/system-prompt/__tests__/PromptRegistry.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/PromptRegistry.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai"
 import { PromptRegistry } from "../registry/PromptRegistry"
 import type { SystemPromptContext } from "../types"
 import type { ToolRequestSnapshot } from "@core/task/tools/runtime/ToolSnapshot"
-import { mockProviderInfo } from "./integration.test"
+import { mockProviderInfo } from "./test-helpers"
 
 function emptyToolSnapshot(): ToolRequestSnapshot {
 	return {

--- a/src/core/prompts/system-prompt/__tests__/TemplateEngine.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/TemplateEngine.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { TemplateEngine } from "../templates/TemplateEngine"
 import type { SystemPromptContext } from "../types"
-import { mockProviderInfo } from "./integration.test"
+import { mockProviderInfo } from "./test-helpers"
 
 describe("TemplateEngine", () => {
 	let templateEngine: TemplateEngine

--- a/src/core/prompts/system-prompt/__tests__/integration.test.ts
+++ b/src/core/prompts/system-prompt/__tests__/integration.test.ts
@@ -28,6 +28,7 @@ import type { ToolRequestSnapshot } from "@core/task/tools/runtime/ToolSnapshot"
 import { ToolDiscoveryService } from "@core/task/tools/discovery/ToolDiscoveryService"
 import { DiracToolSet } from "../registry/DiracToolSet"
 import { toolSpecFunctionDeclarations, toolSpecInputSchema } from "../spec"
+import { mockProviderInfo } from "./test-helpers"
 
 // ============================================================================
 // Configuration
@@ -135,12 +136,6 @@ async function assertJsonSnapshot(name: string, actual: unknown): Promise<void> 
 // ============================================================================
 // Test Context Helpers
 // ============================================================================
-
-export const mockProviderInfo = {
-	providerId: "test",
-	model: { id: "fast", info: { supportsPromptCache: false } },
-	mode: "act" as const,
-}
 
 const makeProviderInfo = (providerId: string, modelId: string) => ({
 	providerId,

--- a/src/core/prompts/system-prompt/__tests__/test-helpers.ts
+++ b/src/core/prompts/system-prompt/__tests__/test-helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared test fixtures for the system-prompt suite. Kept outside of the
+ * `*.test.ts` files so tests never import another test module.
+ */
+export const mockProviderInfo = {
+	providerId: "test",
+	model: { id: "fast", info: { supportsPromptCache: false } },
+	mode: "act" as const,
+}


### PR DESCRIPTION
## What
Move shared test fixture `mockProviderInfo` out of `integration.test.ts` into a dedicated `test-helpers.ts`; update the 3 importing tests (PromptBuilder, PromptRegistry, TemplateEngine).

## Why
Tests were importing another `*.test.ts` module. Extract the shared fixture into a non-test helper so test files stop importing tests.

## Verification
`tsc` clean on changed files. No `*.test.ts` imports another `*.test.ts` (verified via rg). Full suite needs CI (local env lacks `node:sqlite` / vscode `LanguageModelChatSelector` types — pre-existing, unrelated).

## User test
No observable change (test-only refactor). CI test run covers it.

Closes FB-4 (FIX-BACKLOG).