### PR TITLE
refactor: hoist inline config to consts

### DIFF
--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -27,6 +27,8 @@ import { withRetry } from "../retry"
 import { convertToR1Format } from "../transform/r1-format"
 import type { ApiStream } from "../transform/stream"
 
+const BEDROCK_USER_AGENT_APP_ID = `dirac#${ExtensionRegistryInfo.version}`
+
 export interface AwsBedrockHandlerOptions extends CommonApiHandlerOptions {
 	apiModelId?: string
 	awsAccessKey?: string
@@ -463,7 +465,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		const providerOptions: ProviderChainOptions = {
 			clientConfig: {
 				// set the inner sts client userAgentAppId
-				userAgentAppId: `dirac#${ExtensionRegistryInfo.version}`,
+				userAgentAppId: BEDROCK_USER_AGENT_APP_ID,
 			},
 		}
 		const useProfile =
@@ -523,7 +525,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		// AWS SDK uses a different architecture than fetch-based SDKs.
 		// To add proxy support, we need to provide a custom requestHandler.
 		return new BedrockRuntimeClient({
-			userAgentAppId: `dirac#${ExtensionRegistryInfo.version}`,
+			userAgentAppId: BEDROCK_USER_AGENT_APP_ID,
 			region: this.getRegion(),
 			...auth,
 			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),

--- a/src/integrations/misc/link-preview.ts
+++ b/src/integrations/misc/link-preview.ts
@@ -3,6 +3,19 @@ import ogs from "open-graph-scraper"
 import { fetch, getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 
+const BROWSER_USER_AGENT = "Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://dirac.run)"
+const OPEN_GRAPH_BASE_OPTIONS = {
+	timeout: 5000,
+	headers: {
+		"user-agent": BROWSER_USER_AGENT,
+	},
+	onlyGetOpenGraphInfo: false, // Get all metadata, not just Open Graph
+	fetchOptions: {
+		redirect: "follow", // Follow redirects
+	} as any,
+	fetch, // Use configured fetch with proxy support
+}
+
 export interface OpenGraphData {
 	title?: string
 	description?: string
@@ -20,16 +33,8 @@ export interface OpenGraphData {
 export async function fetchOpenGraphData(url: string): Promise<OpenGraphData> {
 	try {
 		const options = {
-			url: url,
-			timeout: 5000,
-			headers: {
-				"user-agent": "Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://dirac.run)",
-			},
-			onlyGetOpenGraphInfo: false, // Get all metadata, not just Open Graph
-			fetchOptions: {
-				redirect: "follow", // Follow redirects
-			} as any,
-			fetch, // Use configured fetch with proxy support
+			url,
+			...OPEN_GRAPH_BASE_OPTIONS,
 		}
 
 		const { result } = await ogs(options)
@@ -94,7 +99,7 @@ export async function detectImageUrl(url: string): Promise<boolean> {
 	try {
 		const response = await axios.head(url, {
 			headers: {
-				"User-Agent": "Mozilla/5.0 (compatible; VSCodeExtension/1.0; +https://dirac.run)",
+				"User-Agent": BROWSER_USER_AGENT,
 			},
 			timeout: 3000,
 			...getAxiosSettings(),


### PR DESCRIPTION
## What
Extract inline config objects to named module constants:

- `link-preview.ts`: hoist static `ogs` options into `OPEN_GRAPH_BASE_OPTIONS` + `BROWSER_USER_AGENT`; reuse the UA in `detectImageUrl` (was duplicated).
- `bedrock.ts`: hoist repeated `dirac#${ExtensionRegistryInfo.version}` into `BEDROCK_USER_AGENT_APP_ID`.

## Why
Named provider/scraper defaults; dedupe the repeated user-agent string.

## Verification
`tsc` clean; `biome` 0 errors on both files (remaining warnings/infos pre-existing).

## User test
No observable behavior change. Run existing API/link-preview flows.

Closes FB-5 (FIX-BACKLOG).