### PR TITLE
refactor: use getErrorMessage/toError helpers

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,7 +1,9 @@
 import { DiracWebviewProvider } from "./core/webview"
 import "./utils/path" // necessary to have access to String.prototype.toPosix
 
+import { createRotatingFileLogger, type RotatingFileLogger, resolveLogDirectory } from "@shared/services/file-logger"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import type { StorageContext } from "@/shared/storage/storage-context"
 import { FileContextTracker } from "./core/context/context-tracking/FileContextTracker"
@@ -20,11 +22,9 @@ import { DiracTempManager } from "./services/temp"
 import { cleanupTestMode } from "./services/test/TestMode"
 import { ShowMessageType } from "./shared/proto/host/window"
 import { syncWorker } from "./shared/services/worker/sync"
-
 import { getBlobStoreSettingsFromEnv } from "./shared/services/worker/worker"
 import { getLatestAnnouncementId } from "./utils/announcements"
 import { arePathsEqual } from "./utils/path"
-import { createRotatingFileLogger, resolveLogDirectory, type RotatingFileLogger } from "@shared/services/file-logger"
 
 let persistentFileLogger: RotatingFileLogger | undefined
 let unsubscribeHostLogger: (() => void) | undefined
@@ -159,7 +159,7 @@ async function showVersionUpdateAnnouncement(stateManager: StateManager) {
 			await stateManager.setGlobalState("diracVersion", currentVersion)
 		}
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		Logger.error(`Error during post-update actions: ${errorMessage}, Stack trace: ${error.stack}`)
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { Environment, type EnvironmentConfig } from "./shared/config-types"
 import { Logger } from "./shared/services/Logger"
 
@@ -158,7 +159,7 @@ class DiracEndpoint {
 				data = JSON.parse(fileContent)
 			} catch (parseError) {
 				throw new DiracConfigurationError(
-					`Invalid JSON in bundled endpoints configuration file (${bundledPath}): ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+					`Invalid JSON in bundled endpoints configuration file (${bundledPath}): ${getErrorMessage(parseError)}`,
 				)
 			}
 
@@ -191,7 +192,7 @@ class DiracEndpoint {
 				data = JSON.parse(fileContent)
 			} catch (parseError) {
 				throw new DiracConfigurationError(
-					`Invalid JSON in user endpoints configuration file (${userPath}): ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+					`Invalid JSON in user endpoints configuration file (${userPath}): ${getErrorMessage(parseError)}`,
 				)
 			}
 
@@ -201,7 +202,7 @@ class DiracEndpoint {
 				throw error
 			}
 			throw new DiracConfigurationError(
-				`Failed to read user endpoints configuration file (${userPath}): ${error instanceof Error ? error.message : String(error)}`,
+				`Failed to read user endpoints configuration file (${userPath}): ${getErrorMessage(error)}`,
 			)
 		}
 	}

--- a/src/core/api/openrouter/openrouter-endpoints.ts
+++ b/src/core/api/openrouter/openrouter-endpoints.ts
@@ -1,6 +1,7 @@
 import { stripOpenRouterPreset } from "@shared/api"
 import { normalizeLegacySynthetic1mModelId } from "@shared/storage/legacy-model-id-migration"
 import axios from "axios"
+import { getErrorMessage } from "@/shared/errors"
 import { getAxiosSettings } from "@/shared/net"
 
 export interface OpenRouterEndpoint {
@@ -172,7 +173,7 @@ function parseEndpointPricingValue(price: string): string {
 }
 
 function formatEndpointFetchError(error: unknown): string {
-	if (!axios.isAxiosError(error)) return error instanceof Error ? error.message : String(error)
+	if (!axios.isAxiosError(error)) return getErrorMessage(error)
 	if (error.code === "ECONNABORTED") return "OpenRouter endpoint metadata timed out"
 	const status = error.response?.status
 	if (status === 404) return "Endpoint metadata is unavailable for this custom model or preset"

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -19,6 +19,7 @@ import {
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
 import { ExtensionRegistryInfo } from "@/registry"
+import { getErrorMessage } from "@/shared/errors"
 import type { DiracStorageMessage } from "@/shared/messages/content"
 import { Logger } from "@/shared/services/Logger"
 import type { DiracTool } from "@/shared/tools"
@@ -666,7 +667,7 @@ export class AwsBedrockHandler implements ApiHandler {
 							// Propagate the error by yielding a text response with error information
 							yield {
 								type: "text",
-								text: `[ERROR] Failed to parse Deepseek response: ${error instanceof Error ? error.message : String(error)}`,
+								text: `[ERROR] Failed to parse Deepseek response: ${getErrorMessage(error)}`,
 							}
 						}
 					}
@@ -1046,7 +1047,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			// Return a text content indicating the error instead of null
 			// This ensures users are aware of the issue
 			return {
-				text: `[ERROR: Failed to process image - ${error instanceof Error ? error.message : "Unknown error"}]`,
+				text: `[ERROR: Failed to process image - ${getErrorMessage(error, "Unknown error")}]`,
 			}
 		}
 	}

--- a/src/core/api/providers/openai-codex.ts
+++ b/src/core/api/providers/openai-codex.ts
@@ -16,6 +16,7 @@ import { openAiCodexUsageService } from "@/integrations/openai-codex/OpenAiCodex
 import { openAiCodexOAuthManager } from "@/integrations/openai-codex/oauth"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { featureFlagsService } from "@/services/feature-flags"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracStorageMessage } from "@/shared/messages/content"
 import { fetch } from "@/shared/net"
 import { ApiFormat } from "@/shared/proto/dirac/models"
@@ -220,7 +221,7 @@ export class OpenAiCodexHandler implements ApiHandler {
 					this.closeResponsesWebsocket()
 					return { input: output }
 				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error)
+					const message = getErrorMessage(error)
 					const isAuthFailure = /unauthorized|invalid token|not authenticated|authentication|401/i.test(message)
 					if (!this.options.disableRetries && attempt === 0 && isAuthFailure) {
 						const refreshed = await openAiCodexOAuthManager.forceRefreshAccessToken()
@@ -306,7 +307,7 @@ export class OpenAiCodexHandler implements ApiHandler {
 				}
 				return
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error)
+				const message = getErrorMessage(error)
 				const isAuthFailure = /unauthorized|invalid token|not authenticated|authentication|401/i.test(message)
 				if (!this.options.disableRetries && attempt === 0 && isAuthFailure && !didEmitRequestOutput) {
 					const refreshed = await openAiCodexOAuthManager.forceRefreshAccessToken()

--- a/src/core/api/providers/openai-native.ts
+++ b/src/core/api/providers/openai-native.ts
@@ -9,6 +9,7 @@ import { normalizeOpenaiReasoningEffort } from "@shared/storage/types"
 import OpenAI from "openai"
 import type { ChatCompletionReasoningEffort, ChatCompletionTool } from "openai/resources/chat/completions"
 import { featureFlagsService } from "@/services/feature-flags"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracStorageMessage } from "@/shared/messages/content"
 import { createOpenAIClient } from "@/shared/net"
 import { ApiFormat } from "@/shared/proto/dirac/models"
@@ -16,11 +17,11 @@ import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
 import { isParallelToolCallingEnabled } from "@/utils/model-utils"
 import {
-	ApiHandler,
-	CommonApiHandlerOptions,
 	type ApiConversationCompactionRequest,
 	type ApiConversationCompactionResult,
 	type ApiConversationRequestOptions,
+	ApiHandler,
+	CommonApiHandlerOptions,
 } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -92,7 +93,7 @@ export class OpenAiNativeHandler implements ApiHandler {
 					apiKey: this.options.openAiNativeApiKey,
 				})
 			} catch (error) {
-				throw new Error(`Error creating OpenAI client: ${error instanceof Error ? error.message : String(error)}`)
+				throw new Error(`Error creating OpenAI client: ${getErrorMessage(error)}`)
 			}
 		}
 		return this.client

--- a/src/core/api/providers/openai-responses-compatible.ts
+++ b/src/core/api/providers/openai-responses-compatible.ts
@@ -1,15 +1,16 @@
-import OpenAI from "openai"
 import { ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
+import OpenAI from "openai"
+import { ChatCompletionTool } from "openai/resources/chat/completions"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracStorageMessage } from "@/shared/messages/content"
 import { createOpenAIClient } from "@/shared/net"
+import { isParallelToolCallingEnabled } from "@/utils/model-utils"
 import { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToOpenAIResponsesInput } from "../transform/openai-response-format"
 import { ApiStream } from "../transform/stream"
 import { buildResponseCreateParams, mapResponseTools, processResponsesEvents } from "./openai-responses-utils"
-import { ChatCompletionTool } from "openai/resources/chat/completions"
 
-import { isParallelToolCallingEnabled } from "@/utils/model-utils"
 interface OpenAiResponsesCompatibleHandlerOptions extends CommonApiHandlerOptions {
 	openAiApiKey?: string
 	openAiBaseUrl?: string
@@ -42,7 +43,7 @@ export class OpenAiResponsesCompatibleHandler implements ApiHandler {
 					baseURL: this.options.openAiBaseUrl,
 				})
 			} catch (error) {
-				throw new Error(`Error creating OpenAI client: ${error instanceof Error ? error.message : String(error)}`)
+				throw new Error(`Error creating OpenAI client: ${getErrorMessage(error)}`)
 			}
 		}
 		return this.client

--- a/src/core/api/providers/openai-responses-utils.ts
+++ b/src/core/api/providers/openai-responses-utils.ts
@@ -5,6 +5,7 @@ import OpenAI from "openai"
 import { ChatCompletionReasoningEffort, ChatCompletionTool } from "openai/resources/chat/completions"
 import { MessageEvent as UndiciMessageEvent, WebSocket as UndiciWebSocket } from "undici"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
+import { getErrorMessage } from "@/shared/errors"
 
 // ChatCompletionTool doesn't include web_search; define the shape we use
 interface WebSearchChatTool {
@@ -465,7 +466,7 @@ export class ResponsesWebsocketManager {
 				wake()
 			} catch (error) {
 				const parseError: Error & { code?: string } = new Error(
-					`Failed to parse websocket event: ${error instanceof Error ? error.message : String(error)}`,
+					`Failed to parse websocket event: ${getErrorMessage(error)}`,
 				)
 				parseError.code = "websocket_parse_error"
 				failure = parseError
@@ -545,7 +546,7 @@ export function shouldRetryWithFullContext(error: unknown, hadPreviousResponseId
 			? (error as { status: number }).status
 			: undefined
 
-	const message = error instanceof Error ? error.message : String(error)
+	const message = getErrorMessage(error)
 
 	if (errorCode === "previous_response_not_found" || message.includes("previous_response_not_found")) {
 		return true

--- a/src/core/api/providers/vscode-lm.ts
+++ b/src/core/api/providers/vscode-lm.ts
@@ -2,9 +2,10 @@ import { ModelInfo, openAiModelInfoSaneDefaults } from "@shared/api"
 import { SELECTOR_SEPARATOR, stringifyVsCodeLmModelSelector } from "@shared/vsCodeSelectorUtils"
 import { calculateApiCostAnthropic } from "@utils/cost"
 import * as vscode from "vscode"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracStorageMessage } from "@/shared/messages/content"
-import { DiracTool } from "@/shared/tools"
 import { Logger } from "@/shared/services/Logger"
+import { DiracTool } from "@/shared/tools"
 import { ApiHandler, CommonApiHandlerOptions, SingleCompletionHandler } from "../"
 import { withRetry } from "../retry"
 import { ApiStream } from "../transform/stream"
@@ -70,7 +71,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 			this.dispose()
 
 			throw new Error(
-				`Dirac <Language Model API>: Failed to initialize handler: ${error instanceof Error ? error.message : "Unknown error"}`,
+				`Dirac <Language Model API>: Failed to initialize handler: ${getErrorMessage(error, "Unknown error")}`,
 			)
 		}
 	}
@@ -119,7 +120,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 				countTokens: async () => 0,
 			}
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			throw new Error(`Dirac <Language Model API>: Failed to select model: ${errorMessage}`)
 		}
 	}
@@ -205,7 +206,7 @@ export class VsCodeLmHandler implements ApiHandler, SingleCompletionHandler {
 				Logger.debug("Dirac <Language Model API>: Creating client with selector:", selector)
 				this.client = await this.createClient(selector)
 			} catch (error) {
-				const message = error instanceof Error ? error.message : "Unknown error"
+				const message = getErrorMessage(error, "Unknown error")
 				Logger.error("Dirac <Language Model API>: Client creation failed:", message)
 				throw new Error(`Dirac <Language Model API>: Failed to create client: ${message}`)
 			}

--- a/src/core/api/providers/wandb.ts
+++ b/src/core/api/providers/wandb.ts
@@ -1,6 +1,7 @@
 import { type ModelInfo, type WandbModelId, wandbDefaultModelId, wandbModels } from "@shared/api"
 import OpenAI from "openai"
 import type { ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracStorageMessage } from "@/shared/messages/content"
 import { createOpenAIClient } from "@/shared/net"
 import { ApiHandler, CommonApiHandlerOptions } from "../index"
@@ -30,7 +31,7 @@ export class WandbHandler implements ApiHandler {
 					apiKey: this.options.wandbApiKey,
 				})
 			} catch (error) {
-				throw new Error(`Error creating W&B Inference client: ${error instanceof Error ? error.message : String(error)}`)
+				throw new Error(`Error creating W&B Inference client: ${getErrorMessage(error)}`)
 			}
 		}
 		return this.client

--- a/src/core/commands/reconstructTaskHistory.ts
+++ b/src/core/commands/reconstructTaskHistory.ts
@@ -6,6 +6,7 @@ import { ShowMessageType } from "@shared/proto/host/window"
 import { fileExistsAtPath } from "@utils/fs"
 import * as path from "path"
 import { ulid } from "ulid"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 interface TaskReconstructionResult {
@@ -65,7 +66,7 @@ export async function reconstructTaskHistory(showNotifications = true): Promise<
 
 		return result
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		if (showNotifications) {
 			HostProvider.window.showMessage({
 				type: ShowMessageType.ERROR,
@@ -117,7 +118,7 @@ async function performTaskHistoryReconstruction(): Promise<TaskReconstructionRes
 			}
 		} catch (error) {
 			result.skippedTasks++
-			const errorMsg = error instanceof Error ? error.message : String(error)
+			const errorMsg = getErrorMessage(error)
 			result.errors.push(`Task ${taskId}: ${errorMsg}`)
 		}
 	}

--- a/src/core/context/instructions/user-instructions/dirac-rules.ts
+++ b/src/core/context/instructions/user-instructions/dirac-rules.ts
@@ -14,6 +14,7 @@ import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { fileExistsAtPath, isDirectory, readDirectory } from "@utils/fs"
 import fs from "fs/promises"
 import path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { evaluateRuleConditionals, type RuleEvaluationContext } from "./rule-conditionals"
 
@@ -49,7 +50,7 @@ export const getGlobalDiracRules = async (
 					errors.push(...rulesFilesTotal.errors)
 				}
 			} catch (error) {
-				const message = `Failed to read .diracrules directory at ${globalDiracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				const message = `Failed to read .diracrules directory at ${globalDiracRulesFilePath}: ${getErrorMessage(error)}`
 				Logger.error(message, error)
 				errors.push(message)
 			}
@@ -120,7 +121,7 @@ export const getLocalDiracRules = async (
 					errors.push(...rulesFilesTotal.errors)
 				}
 			} catch (error) {
-				const message = `Failed to read .diracrules directory at ${diracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				const message = `Failed to read .diracrules directory at ${diracRulesFilePath}: ${getErrorMessage(error)}`
 				Logger.error(message, error)
 				errors.push(message)
 			}
@@ -154,7 +155,7 @@ export const getLocalDiracRules = async (
 					}
 				}
 			} catch (error) {
-				const message = `Failed to read .diracrules file at ${diracRulesFilePath}: ${error instanceof Error ? error.message : String(error)}`
+				const message = `Failed to read .diracrules file at ${diracRulesFilePath}: ${getErrorMessage(error)}`
 				Logger.error(message, error)
 				errors.push(message)
 			}

--- a/src/core/context/instructions/user-instructions/rule-helpers.ts
+++ b/src/core/context/instructions/user-instructions/rule-helpers.ts
@@ -6,6 +6,7 @@ import { parseYamlFrontmatter } from "@utils/frontmatter"
 import { fileExistsAtPath, isDirectory, readDirectory } from "@utils/fs"
 import fs from "fs/promises"
 import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { evaluateRuleConditionals, RuleEvaluationContext } from "./rule-conditionals"
 
@@ -227,7 +228,7 @@ export const getRuleFilesTotalContentWithMetadata = async (
 
 				return { contentPart: `${ruleFilePathRelative}\n${body.trim()}`, activatedRule }
 			} catch (error) {
-				const message = `Failed to load rule file ${ruleFilePathRelative}: ${error instanceof Error ? error.message : String(error)}`
+				const message = `Failed to load rule file ${ruleFilePathRelative}: ${getErrorMessage(error)}`
 				Logger.error(message, error)
 				return { contentPart: null, activatedRule: null, error: message }
 			}
@@ -284,7 +285,7 @@ export function getRemoteRulesTotalContentWithMetadata(
 			if (combinedContent) combinedContent += "\n\n"
 			combinedContent += `${rule.name}\n${body.trim()}`
 		} catch (error) {
-			const message = `Failed to load remote rule ${rule.name}: ${error instanceof Error ? error.message : String(error)}`
+			const message = `Failed to load remote rule ${rule.name}: ${getErrorMessage(error)}`
 			Logger.error(message, error)
 			errors.push(message)
 		}
@@ -467,7 +468,7 @@ export async function deleteRuleFile(
 			message: `File "${fileName}" deleted successfully`,
 		}
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		Logger.error(`Error deleting file: ${errorMessage}`, error)
 		return {
 			success: false,

--- a/src/core/controller/auth/AuthController.ts
+++ b/src/core/controller/auth/AuthController.ts
@@ -1,13 +1,14 @@
+import { applyApiConfigurationTransaction } from "@core/controller/models/apiConfigurationTransaction"
+import type { StateManager } from "@core/storage/StateManager"
 import type { ApiProvider } from "@shared/api"
+import { ShowMessageType } from "@shared/proto/host/window"
 import axios from "axios"
 import open from "open"
-import { applyApiConfigurationTransaction } from "@core/controller/models/apiConfigurationTransaction"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageType } from "@shared/proto/host/window"
-import { getAxiosSettings } from "@/shared/net"
 import { githubCopilotAuthManager } from "@/integrations/github-copilot/auth"
+import { getErrorMessage } from "@/shared/errors"
+import { getAxiosSettings } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
-import type { StateManager } from "@core/storage/StateManager"
 
 export interface AuthControllerDependencies {
 	stateManager: StateManager
@@ -76,7 +77,7 @@ export class AuthController {
 			Logger.error("GitHub Copilot login failed:", error)
 			HostProvider.window.showMessage({
 				type: ShowMessageType.ERROR,
-				message: `GitHub Copilot login failed: ${error instanceof Error ? error.message : String(error)}`,
+				message: `GitHub Copilot login failed: ${getErrorMessage(error)}`,
 			})
 		}
 	}

--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -2,6 +2,7 @@ import { discoverChromeInstances } from "@services/browser/BrowserDiscovery"
 import { BrowserSession } from "@services/browser/BrowserSession"
 import { BrowserConnection } from "@shared/proto/dirac/browser"
 import { EmptyRequest } from "@shared/proto/dirac/common"
+import { getErrorMessage } from "@/shared/errors"
 import { Controller } from "../index"
 
 /**
@@ -37,7 +38,7 @@ export async function discoverBrowser(controller: Controller, _request: EmptyReq
 	} catch (error) {
 		return BrowserConnection.create({
 			success: false,
-			message: `Error discovering browser: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Error discovering browser: ${getErrorMessage(error)}`,
 			endpoint: "",
 		})
 	}

--- a/src/core/controller/browser/relaunchChromeDebugMode.ts
+++ b/src/core/controller/browser/relaunchChromeDebugMode.ts
@@ -1,4 +1,5 @@
 import { EmptyRequest, String as StringMessage } from "@shared/proto/dirac/common"
+import { getErrorMessage } from "@/shared/errors"
 import { BrowserSession } from "../../../services/browser/BrowserSession"
 import { Controller } from "../index"
 
@@ -19,6 +20,6 @@ export async function relaunchChromeDebugMode(controller: Controller, _: EmptyRe
 		// Here we just return a message as a placeholder
 		return { value: "Chrome relaunch initiated" }
 	} catch (error) {
-		throw new Error(`Error relaunching Chrome: ${error instanceof Error ? error.message : globalThis.String(error)}`)
+		throw new Error(`Error relaunching Chrome: ${getErrorMessage(error)}`)
 	}
 }

--- a/src/core/controller/browser/testBrowserConnection.ts
+++ b/src/core/controller/browser/testBrowserConnection.ts
@@ -2,6 +2,7 @@ import { discoverChromeInstances } from "@services/browser/BrowserDiscovery"
 import { BrowserSession } from "@services/browser/BrowserSession"
 import { BrowserConnection } from "@shared/proto/dirac/browser"
 import { StringRequest } from "@shared/proto/dirac/common"
+import { getErrorMessage } from "@/shared/errors"
 import { Controller } from "../index"
 
 /**
@@ -37,7 +38,7 @@ export async function testBrowserConnection(controller: Controller, request: Str
 			} catch (error) {
 				return BrowserConnection.create({
 					success: false,
-					message: `Error during auto-discovery: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error during auto-discovery: ${getErrorMessage(error)}`,
 					endpoint: "",
 				})
 			}
@@ -53,7 +54,7 @@ export async function testBrowserConnection(controller: Controller, request: Str
 	} catch (error) {
 		return BrowserConnection.create({
 			success: false,
-			message: `Error testing connection: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Error testing connection: ${getErrorMessage(error)}`,
 			endpoint: "",
 		})
 	}

--- a/src/core/controller/file/searchFilesHelpers.ts
+++ b/src/core/controller/file/searchFilesHelpers.ts
@@ -5,6 +5,7 @@ import { FileSearchRequest, FileSearchResults, FileSearchType } from "@shared/pr
 import { getWorkspacePath } from "@utils/path"
 import * as path from "path"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -69,7 +70,7 @@ export const captureResultTelemetry = (request: FileSearchRequest, count: number
 // Logs error and captures failure telemetry, returning an empty result set
 export async function handleSearchError(request: FileSearchRequest, error: unknown): Promise<FileSearchResults> {
 	Logger.error("Error in searchFiles:", error)
-	const msg = error instanceof Error ? error.message : String(error)
+	const msg = getErrorMessage(error)
 	const type = error instanceof Error && error.message.includes("permission") ? "permission_denied" : "unknown"
 	await telemetryService.captureMentionFailed(request.selectedType === FileSearchType.FILE ? "file" : "folder", type, msg)
 	return { results: [], mentionsRequestId: request.mentionsRequestId }

--- a/src/core/controller/grpc-handler.ts
+++ b/src/core/controller/grpc-handler.ts
@@ -3,6 +3,7 @@ import { serviceHandlers } from "@generated/hosts/vscode/protobus-services"
 import { GrpcRecorderBuilder } from "@/core/controller/grpc-recorder/grpc-recorder.builder"
 import { GrpcRequestRegistry } from "@/core/controller/grpc-request-registry"
 import { ExtensionMessage } from "@/shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { GrpcCancel, GrpcRequest } from "@/shared/WebviewMessage"
 
@@ -96,7 +97,7 @@ async function handleUnaryRequest(
 		await postMessageToWebview({
 			type: "grpc_response",
 			grpc_response: {
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 				request_id: request.request_id,
 				is_streaming: false,
 			},
@@ -143,7 +144,7 @@ async function handleStreamingRequest(
 		await postMessageToWebview({
 			type: "grpc_response",
 			grpc_response: {
-				error: error instanceof Error ? error.message : String(error),
+				error: getErrorMessage(error),
 				request_id: request.request_id,
 				is_streaming: false,
 			},

--- a/src/core/controller/models/fetchAndCacheModels.ts
+++ b/src/core/controller/models/fetchAndCacheModels.ts
@@ -5,6 +5,7 @@ import { ModelInfo } from "@shared/api"
 import { fileExistsAtPath } from "@utils/fs"
 import axios from "axios"
 import { StateManager } from "@/core/storage/StateManager"
+import { getErrorMessage } from "@/shared/errors"
 import { getAxiosSettings, isRateLimited } from "@/shared/net"
 import { Logger } from "@/shared/services/Logger"
 import type { Controller } from ".."
@@ -130,7 +131,7 @@ async function doFetchAndCacheModels(config: FetchAndCacheModelsConfig): Promise
 }
 
 function buildErrorMessage(error: any, label: string, detailed: boolean): string {
-	if (!detailed) return error instanceof Error ? error.message : "Unknown error occurred"
+	if (!detailed) return getErrorMessage(error, "Unknown error occurred")
 	if (axios.isAxiosError(error)) {
 		const status = error.response?.status ?? 0
 		if (status === 401) return `Invalid ${label} API key. Please check your API key in settings.`
@@ -139,7 +140,7 @@ function buildErrorMessage(error: any, label: string, detailed: boolean): string
 		if (error.code === "ECONNABORTED") return "Request timeout. Please check your internet connection."
 		return `API request failed: ${error.response?.status || error.code || "Unknown error"}`
 	}
-	return error instanceof Error ? error.message : "Unknown error occurred"
+	return getErrorMessage(error, "Unknown error occurred")
 }
 
 async function readCachedModels(cacheFilePath: string): Promise<Record<string, ModelInfo> | undefined> {

--- a/src/core/controller/state/installDiracCli.ts
+++ b/src/core/controller/state/installDiracCli.ts
@@ -2,6 +2,7 @@ import { Empty, EmptyRequest } from "@shared/proto/dirac/common"
 import { ShowMessageType } from "@shared/proto/host/window"
 import { ExecuteCommandInTerminalRequest } from "@shared/proto/host/workspace"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -30,7 +31,7 @@ export async function installDiracCli(_controller: Controller, _request: EmptyRe
 		Logger.error("Error executing CLI installation:", error)
 		await HostProvider.window.showMessage({
 			type: ShowMessageType.ERROR,
-			message: `Failed to start CLI installation: ${error instanceof Error ? error.message : "Unknown error"}`,
+			message: `Failed to start CLI installation: ${getErrorMessage(error, "Unknown error")}`,
 			options: { items: [] },
 		})
 	}

--- a/src/core/controller/state/resetState.ts
+++ b/src/core/controller/state/resetState.ts
@@ -2,6 +2,7 @@ import { Empty } from "@shared/proto/dirac/common"
 import { ResetStateRequest } from "@shared/proto/dirac/state"
 import { resetGlobalState, resetWorkspaceState } from "@/core/storage/utils/state-helpers"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
@@ -47,7 +48,7 @@ export async function resetState(controller: Controller, request: ResetStateRequ
 		Logger.error("Error resetting state:", error)
 		HostProvider.window.showMessage({
 			type: ShowMessageType.ERROR,
-			message: `Failed to reset state: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to reset state: ${getErrorMessage(error)}`,
 		})
 		throw error
 	}

--- a/src/core/controller/state/testOtelConnection.ts
+++ b/src/core/controller/state/testOtelConnection.ts
@@ -4,6 +4,7 @@ import { TestConnectionResult } from "@shared/proto/dirac/state"
 const REMOTE_CONFIG_OTEL_PROVIDER_ID = "remote-config-otel"
 
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -40,7 +41,7 @@ export async function testOtelConnection(_controller: Controller, _: EmptyReques
 			message: "Test log event sent successfully. Check your OTEL collector for the event.",
 		})
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		Logger.error("[TEST_OTEL_CONNECTION] Failed to send test event:", error)
 
 		return TestConnectionResult.create({

--- a/src/core/controller/state/testPromptUploading.ts
+++ b/src/core/controller/state/testPromptUploading.ts
@@ -1,5 +1,6 @@
 import { EmptyRequest } from "@shared/proto/dirac/common"
 import { TestConnectionResult } from "@shared/proto/dirac/state"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { blobStorage } from "@/shared/storage/DiracBlobStorage"
 import { Controller } from ".."
@@ -33,7 +34,7 @@ export async function testPromptUploading(_controller: Controller, _: EmptyReque
 			message: "Test file uploaded and verified successfully.",
 		})
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		Logger.error("[TEST_PROMPT_UPLOADING] Failed to test blob storage:", error)
 
 		return TestConnectionResult.create({

--- a/src/core/controller/task/deleteAllTaskHistory.ts
+++ b/src/core/controller/task/deleteAllTaskHistory.ts
@@ -2,6 +2,7 @@ import { DeleteAllTaskHistoryCount } from "@shared/proto/dirac/task"
 import fs from "fs/promises"
 import path from "path"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageRequest, ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { fileExistsAtPath } from "../../../utils/fs"
@@ -103,7 +104,7 @@ export async function deleteAllTaskHistory(controller: Controller): Promise<Dele
 		} catch (error) {
 			HostProvider.window.showMessage({
 				type: ShowMessageType.ERROR,
-				message: `Encountered error while deleting task history, there may be some files left behind. Error: ${error instanceof Error ? error.message : String(error)}`,
+				message: `Encountered error while deleting task history, there may be some files left behind. Error: ${getErrorMessage(error)}`,
 			})
 		}
 

--- a/src/core/controller/worktree/checkoutBranch.ts
+++ b/src/core/controller/worktree/checkoutBranch.ts
@@ -1,6 +1,7 @@
 import { CheckoutBranchRequest, WorktreeResult } from "@shared/proto/dirac/worktree"
 import { getWorkspacePath } from "@utils/path"
 import simpleGit from "simple-git"
+import { getErrorMessage } from "@/shared/errors"
 import { Controller } from ".."
 
 /**
@@ -36,7 +37,7 @@ export async function checkoutBranch(_controller: Controller, request: CheckoutB
 			message: `Switched to branch '${branch}'`,
 		})
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		return WorktreeResult.create({
 			success: false,
 			message: `Failed to checkout branch: ${errorMessage}`,

--- a/src/core/controller/worktree/createWorktree.ts
+++ b/src/core/controller/worktree/createWorktree.ts
@@ -2,6 +2,7 @@ import { CreateWorktreeRequest, WorktreeResult } from "@shared/proto/dirac/workt
 import { createWorktree as createWorktreeUtil, listWorktrees } from "@utils/git-worktree"
 import { getWorkspacePath } from "@utils/path"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -59,7 +60,7 @@ export async function createWorktree(_controller: Controller, request: CreateWor
 		Logger.error(`Error creating worktree: ${JSON.stringify(error)}`)
 		return WorktreeResult.create({
 			success: false,
-			message: error instanceof Error ? error.message : String(error),
+			message: getErrorMessage(error),
 		})
 	}
 }

--- a/src/core/controller/worktree/createWorktreeInclude.ts
+++ b/src/core/controller/worktree/createWorktreeInclude.ts
@@ -2,6 +2,7 @@ import { CreateWorktreeIncludeRequest, WorktreeResult } from "@shared/proto/dira
 import { getWorkspacePath } from "@utils/path"
 import * as fs from "fs/promises"
 import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { Controller } from ".."
 
 /**
@@ -33,7 +34,7 @@ export async function createWorktreeInclude(
 	} catch (error) {
 		return WorktreeResult.create({
 			success: false,
-			message: `Failed to create .worktreeinclude: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to create .worktreeinclude: ${getErrorMessage(error)}`,
 		})
 	}
 }

--- a/src/core/controller/worktree/deleteWorktree.ts
+++ b/src/core/controller/worktree/deleteWorktree.ts
@@ -6,6 +6,7 @@ import path from "path"
 import simpleGit from "simple-git"
 import { HostProvider } from "@/hosts/host-provider"
 import { hashWorkingDir } from "@/integrations/checkpoints/CheckpointUtils"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -66,7 +67,7 @@ export async function deleteWorktree(_controller: Controller, request: DeleteWor
 		Logger.error(`Error deleting worktree: ${JSON.stringify(error)}`)
 		return WorktreeResult.create({
 			success: false,
-			message: error instanceof Error ? error.message : String(error),
+			message: getErrorMessage(error),
 		})
 	}
 }

--- a/src/core/controller/worktree/listWorktrees.ts
+++ b/src/core/controller/worktree/listWorktrees.ts
@@ -3,6 +3,7 @@ import { WorktreeList } from "@shared/proto/dirac/worktree"
 import { getGitRootPath, listWorktrees as listWorktreesUtil } from "@utils/git-worktree"
 import { arePathsEqual, getWorkspacePath } from "@utils/path"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -83,7 +84,7 @@ export async function listWorktrees(_controller: Controller, _request: EmptyRequ
 			isMultiRoot: false,
 			isSubfolder: false,
 			gitRootPath: "",
-			error: error instanceof Error ? error.message : String(error),
+			error: getErrorMessage(error),
 		})
 	}
 }

--- a/src/core/controller/worktree/mergeWorktree.ts
+++ b/src/core/controller/worktree/mergeWorktree.ts
@@ -3,6 +3,7 @@ import { listWorktrees } from "@utils/git-worktree"
 import { getWorkspacePath } from "@utils/path"
 import simpleGit from "simple-git"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Controller } from ".."
 
 const result = (success: boolean, message: string, extra: Partial<MergeWorktreeResult> = {}): MergeWorktreeResult =>
@@ -52,14 +53,14 @@ export async function mergeWorktree(_controller: Controller, request: MergeWorkt
 				return result(false, `Merge conflict detected. ${conflicts.length} file(s) have conflicts.`, extra)
 			}
 			telemetryService.captureWorktreeMergeAttempted(false, false, deleteAfterMerge)
-			return result(false, `Merge failed: ${error instanceof Error ? error.message : String(error)}`, branchInfo)
+			return result(false, `Merge failed: ${getErrorMessage(error)}`, branchInfo)
 		}
 		// Delete worktree if requested
 		if (deleteAfterMerge) {
 			try {
 				await git.raw(["worktree", "remove", worktreePath, "--force"])
 			} catch (error) {
-				const msg = `failed to delete worktree: ${error instanceof Error ? error.message : String(error)}`
+				const msg = `failed to delete worktree: ${getErrorMessage(error)}`
 				return result(true, `Merged '${sourceBranch}' into '${targetBranch}' successfully, but ${msg}`, branchInfo)
 			}
 			await git.deleteLocalBranch(sourceBranch).catch(() => {})
@@ -70,6 +71,6 @@ export async function mergeWorktree(_controller: Controller, request: MergeWorkt
 			: `Successfully merged '${sourceBranch}' into '${targetBranch}'`
 		return result(true, message, branchInfo)
 	} catch (error) {
-		return result(false, `Unexpected error: ${error instanceof Error ? error.message : String(error)}`)
+		return result(false, `Unexpected error: ${getErrorMessage(error)}`)
 	}
 }

--- a/src/core/controller/worktree/switchWorktree.ts
+++ b/src/core/controller/worktree/switchWorktree.ts
@@ -1,5 +1,6 @@
 import { SwitchWorktreeRequest, WorktreeResult } from "@shared/proto/dirac/worktree"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { Controller } from ".."
 
@@ -40,7 +41,7 @@ export async function switchWorktree(controller: Controller, request: SwitchWork
 		Logger.error(`Error switching worktree: ${JSON.stringify(error)}`)
 		return WorktreeResult.create({
 			success: false,
-			message: error instanceof Error ? error.message : String(error),
+			message: getErrorMessage(error),
 		})
 	}
 }

--- a/src/core/hooks/HookRegistry.ts
+++ b/src/core/hooks/HookRegistry.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { getAllHooksDirs } from "../storage/disk"
 import type { Hooks } from "./hook-factory"
 
@@ -80,9 +81,7 @@ export class HookRegistry {
 	private static handleHookDiscoveryError(error: unknown, hookName: HookName, candidate: string): void {
 		if (!isExpectedHookError(error)) {
 			throw new Error(
-				`Unexpected error while searching for hook '${hookName}' at '${candidate}': ${
-					error instanceof Error ? error.message : String(error)
-				}`,
+				`Unexpected error while searching for hook '${hookName}' at '${candidate}': ${getErrorMessage(error)}`,
 			)
 		}
 	}

--- a/src/core/hooks/HookTelemetryRecorder.ts
+++ b/src/core/hooks/HookTelemetryRecorder.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/shared/errors"
 import { telemetryService } from "../../services/telemetry"
 import type { HookOutput } from "../../shared/proto/dirac/hooks"
 import type { HookExecutionError } from "./HookError"
@@ -124,7 +125,7 @@ export class HookTelemetryRecorder {
 				durationMs,
 				exitCode: exitCode ?? 1,
 				errorType: "execution",
-				errorMessage: error instanceof Error ? error.message : String(error),
+				errorMessage: getErrorMessage(error),
 			},
 			"HookFactory.exec.catch.execution",
 		)

--- a/src/core/slash-commands/PermissionsCommandHandler.ts
+++ b/src/core/slash-commands/PermissionsCommandHandler.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/shared/errors"
 import { CommandPermissionController } from "../permissions/CommandPermissionController"
 import { ToolPermissionRule } from "../permissions/types"
 
@@ -40,7 +41,7 @@ export async function handlePermissionsCommand(
 		}
 	} catch (error) {
 		return {
-			processedText: `Failed to update permissions: ${error instanceof Error ? error.message : String(error)}`,
+			processedText: `Failed to update permissions: ${getErrorMessage(error)}`,
 			success: false,
 		}
 	}

--- a/src/core/task/LifecycleManager.ts
+++ b/src/core/task/LifecycleManager.ts
@@ -1,7 +1,7 @@
+import { formatResponse } from "@core/formatResponse"
 import { executeHook } from "@core/hooks/hook-executor"
 import { getHookModelContext } from "@core/hooks/hook-model-context"
 import { getHooksEnabledSafe } from "@core/hooks/hooks-utils"
-import { formatResponse } from "@core/formatResponse"
 import {
 	ensureTaskDirectoryExists,
 	getSavedApiConversationHistory,
@@ -26,6 +26,7 @@ import { DiracAskResponse } from "@shared/WebviewMessage"
 import { AnchorStateManager } from "@utils/AnchorStateManager"
 import pWaitFor from "p-wait-for"
 import { CardStatus, DiracMessageType, TaskStatus } from "@/shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { releaseTaskLock } from "./TaskLockUtils"
 import { LifecycleManagerDependencies } from "./types/lifecycle-manager"
 import { buildUserFeedbackContent } from "./utils/buildUserFeedbackContent"
@@ -52,7 +53,7 @@ export class LifecycleManager {
 		try {
 			await ensureCheckpointInitialized({ checkpointManager: this.dependencies.checkpointManager })
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error("Failed to initialize checkpoint manager:", errorMessage)
 			this.dependencies.taskState.checkpointManagerErrorMessage = errorMessage // will be displayed right away since we saveDiracMessages next which posts state to webview
 			HostProvider.window.showMessage({

--- a/src/core/task/LocalConversationCompaction.ts
+++ b/src/core/task/LocalConversationCompaction.ts
@@ -21,6 +21,7 @@ import { CardStatus } from "@shared/ExtensionMessage"
 import { DiracIcon } from "@shared/icons"
 import { Logger } from "@shared/services/Logger"
 import { stripHashes } from "@shared/utils/line-hashing"
+import { getErrorMessage } from "@/shared/errors"
 import type { MessageStateHandler } from "./message-state"
 import type { TaskMessenger } from "./TaskMessenger"
 import type { TaskState } from "./TaskState"
@@ -271,7 +272,7 @@ export class LocalConversationCompaction {
 	}
 
 	private buildFailureBody(error: unknown): string {
-		const message = error instanceof Error ? error.message : String(error)
+		const message = getErrorMessage(error)
 		return `Utility-model conversation condensation failed. Fix or change the configured Utility model, then retry.\n\n${message}`
 	}
 

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -18,10 +18,15 @@ import {
 } from "@core/context/instructions/user-instructions/external-rules"
 import { formatResponse } from "@core/formatResponse"
 import { DiracIgnoreController } from "@core/ignore/DiracIgnoreController"
+import { recordSuccessfulModelProviderPreset } from "@core/models/modelProviderPresets"
 import { CommandPermissionController } from "@core/permissions"
 import type { SystemPromptContext } from "@core/prompts/system-prompt"
 import { getSystemPrompt } from "@core/prompts/system-prompt"
+import type { SlashCommandDirectAction } from "@core/slash-commands"
+import { findSlashCommandInTags } from "@core/slash-commands/commandParser"
 import { ensureRulesDirectoryExists, ensureTaskDirectoryExists } from "@core/storage/disk"
+import { createDefaultTextCondensationTemplateRegistry, TASK_HANDOFF_TEMPLATE_ID } from "@core/text-condensation/templates"
+import { isUtilityTextCondensationAvailable } from "@core/text-condensation/UtilityTextCondensationAvailability"
 import { isMultiRootEnabled } from "@core/workspace/multi-root-utils"
 import { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
 import { HostProvider } from "@hosts/host-provider"
@@ -45,7 +50,6 @@ import { UrlContentFetcher } from "@services/browser/UrlContentFetcher"
 import { DiracError, DiracErrorType, ErrorService } from "@services/error"
 import { featureFlagsService } from "@services/feature-flags"
 import { telemetryService } from "@services/telemetry"
-import { recordSuccessfulModelProviderPreset } from "@core/models/modelProviderPresets"
 import { ApiConfiguration } from "@shared/api"
 import { findLastIndex } from "@shared/array"
 import { DiracClient } from "@shared/dirac"
@@ -82,6 +86,7 @@ import Mutex from "p-mutex"
 import pWaitFor from "p-wait-for"
 import * as path from "path"
 import { ulid } from "ulid"
+import { getErrorMessage } from "@/shared/errors"
 import { filterSkillsByProviderCapabilities, SkillMetadata } from "@/shared/skills"
 import { getAvailableCores } from "@/utils/os"
 import { detectBestShell } from "@/utils/shell-detection"
@@ -90,32 +95,28 @@ import { getOrDiscoverSkills } from "../context/instructions/user-instructions/s
 import { Controller } from "../controller"
 import { StateManager } from "../storage/StateManager"
 import { ApiConversationManager } from "./ApiConversationManager"
-import { activateTaskSkill } from "./activateTaskSkill"
-import { LocalConversationCompaction } from "./LocalConversationCompaction"
-import type { SlashCommandDirectAction } from "@core/slash-commands"
-import { findSlashCommandInTags } from "@core/slash-commands/commandParser"
 import { AssistantStreamManager } from "./AssistantStreamManager"
+import { activateTaskSkill } from "./activateTaskSkill"
 import { ContextLoader } from "./ContextLoader"
-import { createDefaultTextCondensationTemplateRegistry, TASK_HANDOFF_TEMPLATE_ID } from "@core/text-condensation/templates"
-import { isUtilityTextCondensationAvailable } from "@core/text-condensation/UtilityTextCondensationAvailability"
 import { EnvironmentManager } from "./EnvironmentManager"
 import { HookManager } from "./HookManager"
 import { LifecycleManager } from "./LifecycleManager"
+import { LocalConversationCompaction } from "./LocalConversationCompaction"
 import { MessageStateHandler } from "./message-state"
 import { ResponseProcessor } from "./ResponseProcessor"
 import { StreamChunkCoordinator } from "./StreamChunkCoordinator"
 import { StreamingMetricsManager } from "./StreamingMetricsManager"
 import { StreamResponseHandler } from "./StreamResponseHandler"
-import { TaskMessenger } from "./TaskMessenger"
-import { TaskState } from "./TaskState"
 import {
 	collectDeliveredSteeringMessageIds,
 	formatSteeringMessages,
 	restoreQueuedSteeringMessages,
-	SteeringDeliveryState,
 	type SteeringClaim,
+	SteeringDeliveryState,
 	type SteeringMessage,
 } from "./steering"
+import { TaskMessenger } from "./TaskMessenger"
+import { TaskState } from "./TaskState"
 import { ToolExecutor } from "./ToolExecutor"
 import { DiracContext } from "./tools/context/DiracContext"
 import type { ToolSnapshotDirtyReason } from "./tools/runtime/ToolSnapshot"
@@ -665,7 +666,7 @@ export class Task {
 			} catch (error) {
 				Logger.error("Failed to initialize checkpoint manager:", error)
 				if (this.stateManager.getGlobalSettingsKey("enableCheckpointsSetting")) {
-					const errorMessage = error instanceof Error ? error.message : "Unknown error"
+					const errorMessage = getErrorMessage(error, "Unknown error")
 					HostProvider.window.showMessage({
 						type: ShowMessageType.ERROR,
 						message: `Failed to initialize checkpoint manager: ${errorMessage}`,

--- a/src/core/task/multifile-diff.ts
+++ b/src/core/task/multifile-diff.ts
@@ -2,9 +2,10 @@ import { HostProvider } from "@/hosts/host-provider"
 import CheckpointTracker from "@/integrations/checkpoints/CheckpointTracker"
 import { findLast } from "@/shared/array"
 import { isTaskCompletionCard } from "@/shared/cardIdentity"
+import { DiracMessageType } from "@/shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageType } from "@/shared/proto/index.host"
 import { Logger } from "@/shared/services/Logger"
-import { DiracMessageType } from "@/shared/ExtensionMessage"
 import { MessageStateHandler } from "./message-state"
 
 export async function showChangedFilesDiff(
@@ -81,7 +82,7 @@ async function getChangedFiles(
 		}
 		return changedFiles
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : "Unknown error"
+		const errorMessage = getErrorMessage(error, "Unknown error")
 		HostProvider.window.showMessage({
 			type: ShowMessageType.ERROR,
 			message: "Failed to retrieve diff set: " + errorMessage,

--- a/src/core/task/tools/discovery/UserToolLoader.ts
+++ b/src/core/task/tools/discovery/UserToolLoader.ts
@@ -2,10 +2,11 @@ import * as crypto from "crypto"
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
-import { pathToFileURL } from "url"
 import * as ts from "typescript"
-import type { DiracToolSpec } from "@/shared/tools"
+import { pathToFileURL } from "url"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
+import type { DiracToolSpec } from "@/shared/tools"
 import type { IDiracTool } from "../interfaces/IDiracTool"
 import { CONFIGURABLE_TOOL_EXPOSURE, type DiscoveredTool, type ToolSource } from "./DiscoveredTool"
 
@@ -82,7 +83,7 @@ export class UserToolLoader {
 				},
 			}
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
+			const message = getErrorMessage(error)
 			Logger.warn(`[UserToolLoader] Skipping invalid user tool at '${toolDir}'.`, error)
 			return { error: message }
 		}

--- a/src/core/task/tools/modules/diagnostics_scan/index.ts
+++ b/src/core/task/tools/modules/diagnostics_scan/index.ts
@@ -1,11 +1,12 @@
+import { getErrorMessage } from "@/shared/errors"
+import { DiracIcon } from "@/shared/icons"
+import { DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.dirac"
+import { arePathsEqual } from "@/utils/path"
+import { CardStatus } from "../../../../../shared/ExtensionMessage"
+import { DiracDefaultTool, DiracToolSpec } from "../../../../../shared/tools"
 import { IDiracTool } from "../../interfaces/IDiracTool"
 import { IToolEnvironment } from "../../interfaces/IToolEnvironment"
 import { SurfaceType } from "../../interfaces/SurfaceType"
-import { DiracToolSpec, DiracDefaultTool } from "../../../../../shared/tools"
-import { CardStatus } from "../../../../../shared/ExtensionMessage"
-import { DiracIcon } from "@/shared/icons"
-import { arePathsEqual } from "@/utils/path"
-import { DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.dirac"
 import { DiagnosticFormatter } from "../../utils/DiagnosticFormatter"
 
 export const diagnostics_scan_spec: DiracToolSpec = {
@@ -70,7 +71,7 @@ export class DiagnosticsScanTool implements IDiracTool<DiagnosticsScanArgs, stri
 							absolutePath,
 							displayPath,
 							content: "",
-							error: error instanceof Error ? error.message : String(error),
+							error: getErrorMessage(error),
 						}
 					}
 				}),
@@ -137,7 +138,7 @@ export class DiagnosticsScanTool implements IDiracTool<DiagnosticsScanArgs, stri
 
 			return finalResult
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error)
+			const errorMessage = getErrorMessage(error)
 			if (card) {
 				await card.update({
 					status: CardStatus.ERROR,

--- a/src/core/task/tools/modules/edit_ast/AstEditApplier.ts
+++ b/src/core/task/tools/modules/edit_ast/AstEditApplier.ts
@@ -1,5 +1,6 @@
-import { DiagnosticSeverity, type FileDiagnostics } from "@shared/proto/index.dirac"
 import type { SourceFileChange, SourceMutationPlan } from "@services/source-ast/types"
+import { DiagnosticSeverity, type FileDiagnostics } from "@shared/proto/index.dirac"
+import { getErrorMessage } from "@/shared/errors"
 import type { IToolEnvironment, SaveResult } from "../../interfaces/IToolEnvironment"
 
 export type AstEditDiagnosticsStatus = "not_run" | "clean" | "problems" | "failed"
@@ -123,6 +124,6 @@ export class AstEditApplier {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/core/task/tools/modules/edit_ast/AstEditApproval.ts
+++ b/src/core/task/tools/modules/edit_ast/AstEditApproval.ts
@@ -1,12 +1,13 @@
 import { formatResponse } from "@core/formatResponse"
 import type { SourceMutationPlan } from "@services/source-ast/types"
-import { CardStatus, type CardDiff } from "@shared/ExtensionMessage"
+import { type CardDiff, CardStatus } from "@shared/ExtensionMessage"
 import { DiracIcon } from "@shared/icons"
 import { DiracDefaultTool } from "@shared/tools"
 import { DiracAskResponse } from "@shared/WebviewMessage"
+import { getErrorMessage } from "@/shared/errors"
 import type { ICardHandle, IToolEnvironment } from "../../interfaces/IToolEnvironment"
-import type { EditAstArgs } from "./EditAstValidator"
 import type { AstEditFormatter } from "./AstEditFormatter"
+import type { EditAstArgs } from "./EditAstValidator"
 
 export interface AstEditApprovalResult {
 	approved: boolean
@@ -224,6 +225,6 @@ export class AstEditApproval {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/core/task/tools/modules/edit_ast/AstEditFormatter.ts
+++ b/src/core/task/tools/modules/edit_ast/AstEditFormatter.ts
@@ -1,6 +1,7 @@
-import { DiagnosticFormatter } from "../../utils/DiagnosticFormatter"
 import type { SourceAstFailure, SourceMutationPlan } from "@services/source-ast/types"
 import type { CardDiff } from "@shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
+import { DiagnosticFormatter } from "../../utils/DiagnosticFormatter"
 import type { AstEditApplyResult, AstEditFileApplyResult } from "./AstEditApplier"
 import type { EditAstArgs } from "./EditAstValidator"
 
@@ -84,7 +85,7 @@ export class AstEditFormatter {
 	}
 
 	public formatFailure(error: unknown): string {
-		return `AST edit failed: ${error instanceof Error ? error.message : String(error)}`
+		return `AST edit failed: ${getErrorMessage(error)}`
 	}
 
 	private formatFileResult(result: AstEditFileApplyResult): string {

--- a/src/core/task/tools/modules/edit_ast/EditAstTool.ts
+++ b/src/core/task/tools/modules/edit_ast/EditAstTool.ts
@@ -3,13 +3,14 @@ import type { SourceMutationPlan } from "@services/source-ast/types"
 import { CardStatus, isFinalStatus } from "@shared/ExtensionMessage"
 import { DiracIcon } from "@shared/icons"
 import { DiracDefaultTool, type DiracToolSpec } from "@shared/tools"
+import { getErrorMessage } from "@/shared/errors"
 import type { IDiracTool } from "../../interfaces/IDiracTool"
 import type { ICardHandle, IToolEnvironment } from "../../interfaces/IToolEnvironment"
 import type { SurfaceType } from "../../interfaces/SurfaceType"
 import { AstEditApplier, type AstEditApplyResult } from "./AstEditApplier"
 import { AstEditApproval } from "./AstEditApproval"
 import { AstEditFormatter } from "./AstEditFormatter"
-import { EditAstValidator, type EditAstArgs } from "./EditAstValidator"
+import { type EditAstArgs, EditAstValidator } from "./EditAstValidator"
 
 export const edit_ast_spec: DiracToolSpec = {
 	id: DiracDefaultTool.EDIT_AST,
@@ -323,6 +324,6 @@ export class EditAstTool implements IDiracTool<EditAstArgs, string> {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/core/task/tools/modules/edit_file/EditFileValidator.ts
+++ b/src/core/task/tools/modules/edit_file/EditFileValidator.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from "@/shared/errors"
 import type { IToolEnvironment } from "../../interfaces/IToolEnvironment"
 import type { Edit, FileEdit } from "./types"
 
@@ -9,7 +10,7 @@ export class EditFileValidator {
 			try {
 				files = JSON.parse(files)
 			} catch (error) {
-				return this.fail(env, `The 'files' parameter contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`)
+				return this.fail(env, `The 'files' parameter contains invalid JSON: ${getErrorMessage(error)}`)
 			}
 		}
 		if (!Array.isArray(files) || files.length === 0) {

--- a/src/core/task/tools/modules/inspect_ast/InspectAstTool.ts
+++ b/src/core/task/tools/modules/inspect_ast/InspectAstTool.ts
@@ -1,6 +1,5 @@
 import { formatResponse } from "@core/formatResponse"
 import { TOOL_EXAMPLES } from "@core/tool-examples"
-import { getDelimiter } from "@utils/line-hashing"
 import type {
 	AstImplementationResult,
 	AstOccurrenceResult,
@@ -9,25 +8,27 @@ import type {
 import { CardStatus } from "@shared/ExtensionMessage"
 import { DiracIcon } from "@shared/icons"
 import { DiracDefaultTool, type DiracToolSpec } from "@shared/tools"
+import { getDelimiter } from "@utils/line-hashing"
+import { getErrorMessage } from "@/shared/errors"
 import type { IDiracTool } from "../../interfaces/IDiracTool"
 import type { ICardHandle, IToolEnvironment } from "../../interfaces/IToolEnvironment"
 import type { SurfaceType } from "../../interfaces/SurfaceType"
 import {
-	InspectAstFormatter,
 	type FormattedInspectAstResult,
 	type ImplementationCacheRecord,
+	InspectAstFormatter,
 } from "./InspectAstFormatter"
 import {
-	InspectAstResultReducer,
 	type InspectAstImplementationGroup,
 	type InspectAstOccurrenceGroup,
 	type InspectAstOutlineGroup,
 	type InspectAstResultGroup,
+	InspectAstResultReducer,
 } from "./InspectAstResultReducer"
 import {
-	InspectAstValidator,
 	type InspectAstArgs,
 	type InspectAstOperation,
+	InspectAstValidator,
 	type NormalizedInspectAstArgs,
 } from "./InspectAstValidator"
 
@@ -413,6 +414,6 @@ export class InspectAstTool implements IDiracTool<InspectAstArgs, string> {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/core/task/tools/modules/list_files/index.ts
+++ b/src/core/task/tools/modules/list_files/index.ts
@@ -1,10 +1,11 @@
+import { formatResponse } from "@core/formatResponse"
+import { getErrorMessage } from "@/shared/errors"
+import { DiracIcon } from "@/shared/icons"
+import { CardStatus } from "../../../../../shared/ExtensionMessage"
+import { DiracDefaultTool, DiracToolSpec } from "../../../../../shared/tools"
 import { IDiracTool } from "../../interfaces/IDiracTool"
 import { IToolEnvironment } from "../../interfaces/IToolEnvironment"
-import { DiracIcon } from "@/shared/icons"
 import { SurfaceType } from "../../interfaces/SurfaceType"
-import { DiracToolSpec, DiracDefaultTool } from "../../../../../shared/tools"
-import { formatResponse } from "@core/formatResponse"
-import { CardStatus } from "../../../../../shared/ExtensionMessage"
 
 export interface ListFilesArgs {
 	paths: string[]
@@ -117,7 +118,7 @@ export class ListFilesTool implements IDiracTool<ListFilesArgs, string> {
 				totalFilesFound += fileInfos.length
 			} catch (error) {
 				hasError = true
-				const errorMessage = error instanceof Error ? error.message : String(error)
+				const errorMessage = getErrorMessage(error)
 				results.push(`Error listing files in ${relPath}: ${errorMessage}`)
 				env.orchestration.setTaskState(
 					"consecutiveMistakeCount",

--- a/src/core/task/tools/modules/new_task/NewTaskTool.ts
+++ b/src/core/task/tools/modules/new_task/NewTaskTool.ts
@@ -5,6 +5,7 @@ import { showSystemNotification } from "@integrations/notifications"
 import { DiracIcon } from "@shared/icons"
 import { telemetryService } from "@/services/telemetry"
 import { CardStatus } from "@/shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracDefaultTool, DiracToolSpec } from "@/shared/tools"
 import { IDiracTool } from "../../interfaces/IDiracTool"
 import {
@@ -71,7 +72,7 @@ export class NewTaskTool implements IDiracTool {
 				utilityModelIdentity = generatedHandoff.modelIdentity
 			} catch (error) {
 				if (signal.aborted) throw error
-				const message = error instanceof Error ? error.message : String(error)
+				const message = getErrorMessage(error)
 				env.logging.warn("Utility task handoff generation failed", error)
 				return formatResponse.toolError(`Utility task-handoff generation failed: ${message}`)
 			}

--- a/src/core/task/tools/modules/read_file/ReadFileTool.ts
+++ b/src/core/task/tools/modules/read_file/ReadFileTool.ts
@@ -1,7 +1,8 @@
+import * as path from "node:path"
 import { formatResponse } from "@core/formatResponse"
 import { contentHash, formatLinesForModel, getDelimiter } from "@utils/line-hashing"
-import * as path from "node:path"
 import { CardStatus } from "@/shared/ExtensionMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { DiracIcon } from "@/shared/icons"
 import { DiracDefaultTool, DiracToolSpec } from "@/shared/tools"
 import { IDiracTool } from "../../interfaces/IDiracTool"
@@ -234,7 +235,7 @@ export class ReadFileTool implements IDiracTool<ReadFileArgs> {
 			this.captureReadTelemetry(relPath, usedWorkspaceHint, env)
 			return { success: true, result }
 		} catch (error: any) {
-			const errorMessage = error instanceof Error ? error.message : String(error)
+			const errorMessage = getErrorMessage(error)
 			const normalizedMessage = errorMessage.startsWith("Error reading file:")
 				? errorMessage
 				: `Error reading file: ${errorMessage}`

--- a/src/core/task/tools/modules/search_files/index.ts
+++ b/src/core/task/tools/modules/search_files/index.ts
@@ -1,13 +1,14 @@
+import { getDelimiter } from "@utils/line-hashing"
+import * as fs from "fs/promises"
+import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
+import { DiracIcon } from "@/shared/icons"
+import { CardStatus } from "../../../../../shared/ExtensionMessage"
+import { DiracDefaultTool, DiracToolSpec } from "../../../../../shared/tools"
+import { WorkspacePathAdapter } from "../../../../workspace/WorkspacePathAdapter"
 import { IDiracTool } from "../../interfaces/IDiracTool"
 import { IToolEnvironment } from "../../interfaces/IToolEnvironment"
 import { SurfaceType } from "../../interfaces/SurfaceType"
-import { DiracToolSpec, DiracDefaultTool } from "../../../../../shared/tools"
-import { CardStatus } from "../../../../../shared/ExtensionMessage"
-import { DiracIcon } from "@/shared/icons"
-import { WorkspacePathAdapter } from "../../../../workspace/WorkspacePathAdapter"
-import * as fs from "fs/promises"
-import * as path from "path"
-import { getDelimiter } from "@utils/line-hashing"
 
 export interface SearchFilesArgs {
 	paths: string[]
@@ -160,7 +161,7 @@ export class SearchFilesTool implements IDiracTool<SearchFilesArgs, string> {
 
 			return finalResult
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error)
+			const errorMessage = getErrorMessage(error)
 			if (card) {
 				await card.update({
 					status: CardStatus.ERROR,
@@ -281,7 +282,7 @@ export class SearchFilesTool implements IDiracTool<SearchFilesArgs, string> {
 					success: true,
 				}
 			} catch (error) {
-				const errorMessage = error instanceof Error ? error.message : String(error)
+				const errorMessage = getErrorMessage(error)
 				if (card) {
 					await card.appendBody(`❌ Search failed in ${workspaceName || absolutePath}: ${errorMessage}\n`)
 				}

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -1,22 +1,23 @@
-import * as fs from "fs/promises"
-import * as path from "path"
-import { IDiracTool } from "../../interfaces/IDiracTool"
-import { IToolEnvironment } from "../../interfaces/IToolEnvironment"
-import { DiracToolSpec } from "@/shared/tools"
-import { UserToolLoader } from "../../discovery/UserToolLoader"
-import { ToolRegistry } from "../../registry/ToolRegistry"
-import { Logger } from "@/shared/services/Logger"
 import { CardStatus } from "@shared/ExtensionMessage"
 import { allocateSubagentIdentity, type SubagentIdentity } from "@shared/subagents"
+import * as fs from "fs/promises"
+import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
+import { Logger } from "@/shared/services/Logger"
+import { DiracToolSpec } from "@/shared/tools"
+import { UserToolLoader } from "../../discovery/UserToolLoader"
+import { IDiracTool } from "../../interfaces/IDiracTool"
+import { IToolEnvironment } from "../../interfaces/IToolEnvironment"
+import { ToolRegistry } from "../../registry/ToolRegistry"
+import { validateStagedTool } from "./builder-validation"
 import {
+	buildManifest,
+	resolveTaskToolDir,
 	ToolScope,
 	upsert_tool_spec,
-	resolveTaskToolDir,
-	buildManifest,
 } from "./constants"
-import { buildToolWithRepairs } from "./subagent-builder"
 import { buildScaffoldedToolSource, writeTestHarness } from "./scaffold-generator"
-import { validateStagedTool } from "./builder-validation"
+import { buildToolWithRepairs } from "./subagent-builder"
 import {
 	commitToolPromotion,
 	createToolStagingDirectory,
@@ -122,7 +123,7 @@ export class UpsertTool implements IDiracTool {
 			const tool = prepared[index]
 			const buildResult = buildResults[index]
 			const buildError = buildResult.status === "rejected"
-				? buildResult.reason instanceof Error ? buildResult.reason.message : String(buildResult.reason)
+				? getErrorMessage(buildResult.reason)
 				: buildResult.value
 
 			if (buildError) {
@@ -183,7 +184,7 @@ async function prepareTool(
 		if (stagingDir) {
 			await discardStagedTool(stagingDir)
 		}
-		const message = error instanceof Error ? error.message : String(error)
+		const message = getErrorMessage(error)
 		await updateProgress(`[${name}] Failed`, `preparation: ${message}`, CardStatus.ERROR)
 		return `preparation failed: ${message}`
 	}
@@ -224,7 +225,7 @@ async function promoteAndActivateTool(
 			throw new Error("loaded but failed to replace the registry entry because of a tool conflict")
 		}
 	} catch (error) {
-		const failure = error instanceof Error ? error.message : String(error)
+		const failure = getErrorMessage(error)
 		if (!promotion) {
 			await discardStagedTool(prepared.stagingDir)
 			return failure
@@ -235,7 +236,7 @@ async function promoteAndActivateTool(
 			await updateProgress(`[${prepared.name}] Rolled back`, "previous tool restored", CardStatus.ERROR)
 			return failure
 		} catch (rollbackError) {
-			const rollbackFailure = rollbackError instanceof Error ? rollbackError.message : String(rollbackError)
+			const rollbackFailure = getErrorMessage(rollbackError)
 			return `${failure}; rollback also failed: ${rollbackFailure}`
 		}
 	}

--- a/src/core/task/tools/modules/upsert_tool/builder-validation.ts
+++ b/src/core/task/tools/modules/upsert_tool/builder-validation.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs/promises"
 import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import type { DiscoveredTool } from "../../discovery/DiscoveredTool"
 import { UserToolLoader } from "../../discovery/UserToolLoader"
 import type { IToolEnvironment } from "../../interfaces/IToolEnvironment"
@@ -95,5 +96,5 @@ function formatOutput(output: unknown): string {
 }
 
 function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : String(error)
+	return getErrorMessage(error)
 }

--- a/src/core/task/tools/modules/use_subagents/UseSubagentsTool.ts
+++ b/src/core/task/tools/modules/use_subagents/UseSubagentsTool.ts
@@ -1,29 +1,29 @@
-import { IDiracTool } from "../../interfaces/IDiracTool"
-import { ICardHandle, IToolEnvironment } from "../../interfaces/IToolEnvironment"
-import { DiracToolSpec, DiracDefaultTool } from "@/shared/tools"
-import { stripHashes } from "../../../../../shared/utils/line-hashing"
 import { formatResponse } from "@core/formatResponse"
-import { AgentConfigLoader } from "../../subagent/AgentConfigLoader"
-import { waitForPresentationOperation } from "../../subagent/PresentationDeadline"
-import { DEFAULT_SUBAGENT_TIMEOUT_SECONDS, resolveSubagentTimeoutSeconds } from "../../subagent/SubagentExecutionPolicy"
-import { SubagentStatusItem } from "@shared/ExtensionMessage"
-import { excerpt } from "../../../utils/excerpt"
-import { CardStatus, SubagentExecutionStatus } from "@shared/ExtensionMessage"
-import { DiracIcon } from "@/shared/icons"
+import { CardStatus, SubagentExecutionStatus, SubagentStatusItem } from "@shared/ExtensionMessage"
 import {
-	appendSubagentTrajectoryEvent,
 	allocateSubagentIdentity,
+	appendSubagentTrajectoryEvent,
 	createSubagentCardInput,
 	createSubagentCardOutput,
 	formatSubagentTrajectory,
 	isTerminalSubagentStatus,
 	recordSubagentProgress,
-	subagentCardStatus,
-	SubagentTrajectoryEventType,
 	SUBAGENT_TASK_TITLE_MAX_CHARS,
 	SUBAGENT_TASK_TITLE_MAX_WORDS,
 	type SubagentTrajectoryEvent,
+	SubagentTrajectoryEventType,
+	subagentCardStatus,
 } from "@shared/subagents"
+import { toError } from "@/shared/errors"
+import { DiracIcon } from "@/shared/icons"
+import { DiracDefaultTool, DiracToolSpec } from "@/shared/tools"
+import { stripHashes } from "../../../../../shared/utils/line-hashing"
+import { excerpt } from "../../../utils/excerpt"
+import { IDiracTool } from "../../interfaces/IDiracTool"
+import { ICardHandle, IToolEnvironment } from "../../interfaces/IToolEnvironment"
+import { AgentConfigLoader } from "../../subagent/AgentConfigLoader"
+import { waitForPresentationOperation } from "../../subagent/PresentationDeadline"
+import { DEFAULT_SUBAGENT_TIMEOUT_SECONDS, resolveSubagentTimeoutSeconds } from "../../subagent/SubagentExecutionPolicy"
 
 interface SubagentRequest {
 	taskTitle: string
@@ -116,7 +116,7 @@ export class UseSubagentsTool implements IDiracTool {
 		let cardsCreated = 0
 		const taskId = env.config.ulid || "unknown"
 		const reportPresentationIssue = (context: PresentationIssueContext, error: unknown) => {
-			const normalizedError = error instanceof Error ? error : new Error(String(error))
+			const normalizedError = toError(error)
 			presentationIssues.push({ ...context, error: normalizedError })
 			const correlation = [
 				`task=${taskId}`,

--- a/src/core/task/tools/subagent/AgentConfigLoader.ts
+++ b/src/core/task/tools/subagent/AgentConfigLoader.ts
@@ -1,12 +1,13 @@
-import { parseYamlFrontmatter } from "@utils/frontmatter"
+import { LEGACY_RESPONSE_TOOLS, RESPOND_TOOL_NAME } from "@shared/responseTool"
 import { Logger } from "@shared/services/Logger"
 import { setDynamicToolUseNames } from "@shared/tools"
+import { parseYamlFrontmatter } from "@utils/frontmatter"
 import chokidar, { type FSWatcher } from "chokidar"
 import fs from "fs/promises"
 import os from "os"
 import * as path from "path"
 import { z } from "zod"
-import { LEGACY_RESPONSE_TOOLS, RESPOND_TOOL_NAME } from "@shared/responseTool"
+import { toError } from "@/shared/errors"
 import { buildSubagentToolName } from "./SubagentToolName"
 
 /** Default Directory for agent configurations: ~/Documents/Dirac/Agents */
@@ -285,7 +286,7 @@ export class AgentConfigLoader {
 				}
 			})
 			.on("error", (error) => {
-				const watcherError = error instanceof Error ? error : new Error(String(error))
+				const watcherError = toError(error)
 				Logger.error("[AgentConfigLoader] Failed to watch agent configs directory", watcherError)
 				this.notify(this.cachedConfigs, watcherError)
 			})
@@ -309,7 +310,7 @@ export class AgentConfigLoader {
 			await this.load()
 			this.notify(this.cachedConfigs)
 		} catch (error) {
-			const parseError = error instanceof Error ? error : new Error(String(error))
+			const parseError = toError(error)
 			Logger.error("[AgentConfigLoader] Failed to reload agent configs", parseError)
 			this.notify(this.cachedConfigs, parseError)
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { isDev } from "@shared/config/environment"
 import type { ExtensionContext } from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
+import { toError } from "@/shared/errors"
 import { createStorageContext } from "@/shared/storage/storage-context"
 import { readTextFromClipboard, writeTextToClipboard } from "@/utils/env"
 import { initialize, tearDown } from "./common"
@@ -600,7 +601,7 @@ async function setupHostProvider(context: ExtensionContext, globalStorageFsPath:
 	outputChannel.appendLine("[Dirac] Setting up VS Code host...")
 
 	const ripgrep = await resolveWorkingRipgrepBinary(context.extensionUri.fsPath).catch((error: unknown) => {
-		const resolutionError = error instanceof Error ? error : new Error(String(error))
+		const resolutionError = toError(error)
 		Logger.warn(`[Dirac] ${resolutionError.message}`)
 		outputChannel.appendLine(`[Dirac] ${resolutionError.message}`)
 		return resolutionError

--- a/src/hosts/vscode/TabManager.ts
+++ b/src/hosts/vscode/TabManager.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
 import * as vscode from "vscode"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { arePathsEqual } from "@/utils/path"
 import { DIFF_VIEW_URI_SCHEME } from "./diff-view-constants"
@@ -14,7 +15,7 @@ export class TabManager {
 			try {
 				vscode.window.tabGroups.close(tab)
 			} catch (error) {
-				Logger.warn("TabManager: tab close failed:", error instanceof Error ? error.message : String(error))
+				Logger.warn("TabManager: tab close failed:", getErrorMessage(error))
 			}
 		}
 	}

--- a/src/hosts/vscode/commit-message-generator.ts
+++ b/src/hosts/vscode/commit-message-generator.ts
@@ -1,12 +1,13 @@
 import * as api from "@core/api"
-import { getConfiguredUtilityModelSelection } from "@core/utility-model/UtilityModelSelection"
 import * as utilityModel from "@core/utility-model/UtilityModelRunner"
+import { getConfiguredUtilityModelSelection } from "@core/utility-model/UtilityModelSelection"
 import * as path from "path"
 import * as vscode from "vscode"
 import { Controller } from "@/core/controller"
 import { HostProvider } from "@/hosts/host-provider"
-import { ShowMessageType } from "@/shared/proto/host/window"
+import { getErrorMessage } from "@/shared/errors"
 import type { DiracStorageMessage } from "@/shared/messages/content"
+import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { getGitDiff } from "@/utils/git"
 
@@ -66,7 +67,7 @@ export async function generateCommitMsg(controller: Controller, scm?: vscode.Sou
 
 		await orchestrateWorkspaceCommitMsgGeneration(controller, git.repositories)
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		HostProvider.window.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `[Commit Generation Failed] ${errorMessage}`,
@@ -240,7 +241,7 @@ async function performCommitMsgGeneration(controller: Controller, gitDiff: strin
 	} catch (error) {
 		if (requestAbortController?.signal.aborted || error instanceof utilityModel.UtilityModelCancelledError) return
 
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		HostProvider.window.showMessage({
 			type: ShowMessageType.ERROR,
 			message: `Failed to generate commit message: ${errorMessage}`,

--- a/src/hosts/vscode/hostbridge-grpc-handler.ts
+++ b/src/hosts/vscode/hostbridge-grpc-handler.ts
@@ -1,6 +1,7 @@
 import { GrpcRequestRegistry } from "@core/controller/grpc-request-registry"
 import { hostServiceHandlers } from "@generated/hosts/vscode/hostbridge-grpc-service-config"
 import { StreamingCallbacks } from "@/hosts/host-provider-types"
+import { toError } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -54,7 +55,7 @@ export class GrpcHandler {
 			} catch (error) {
 				// If there's an error in the callback, call the onError callback
 				if (streamingCallbacks.onError) {
-					streamingCallbacks.onError(error instanceof Error ? error : new Error(String(error)))
+					streamingCallbacks.onError(toError(error))
 				} else {
 					Logger.error(`[gRPC] Streaming callback error (no onError handler) for ${service}.${method}:`, error)
 				}
@@ -80,7 +81,7 @@ export class GrpcHandler {
 			await this.handleStreamingRequest(service, method, request, requestId)
 		} catch (error) {
 			if (streamingCallbacks.onError) {
-				streamingCallbacks.onError(error instanceof Error ? error : new Error(String(error)))
+				streamingCallbacks.onError(toError(error))
 			}
 		}
 

--- a/src/hosts/vscode/hostbridge/client/host-grpc-client-base.ts
+++ b/src/hosts/vscode/hostbridge/client/host-grpc-client-base.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid"
 import { StreamingCallbacks } from "@/hosts/host-provider-types"
 import { GrpcHandler } from "@/hosts/vscode/hostbridge-grpc-handler"
+import { toError } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 // Generic type for any protobuf service definition
@@ -65,7 +66,7 @@ export function createGrpcClient<T extends ProtoService>(service: T): GrpcClient
 					} catch (error) {
 						Logger.error(`Error in streaming request: ${error}`)
 						if (options.onError) {
-							options.onError(error instanceof Error ? error : new Error(String(error)))
+							options.onError(toError(error))
 						}
 						return () => {}
 					}

--- a/src/hosts/vscode/review/VscodeCommentReplyHandler.ts
+++ b/src/hosts/vscode/review/VscodeCommentReplyHandler.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode"
 import { sendAddToInputEvent } from "@/core/controller/ui/subscribeToAddToInput"
-import { CommentThreadManager } from "./VscodeCommentThreadManager"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
+import { CommentThreadManager } from "./VscodeCommentThreadManager"
 
 export type OnReplyCallback = (
 	filePath: string,
@@ -61,7 +62,7 @@ export class CommentReplyHandler {
 				})
 				.catch((error) => {
 					const errorComment = this.threadManager.createComment(
-						`_Error getting response: ${error instanceof Error ? error.message : "Unknown error"}_`,
+						`_Error getting response: ${getErrorMessage(error, "Unknown error")}_`,
 					)
 					thread.comments = [...thread.comments.slice(0, -1), errorComment]
 				})

--- a/src/integrations/checkpoints/CheckpointDiffPresenter.ts
+++ b/src/integrations/checkpoints/CheckpointDiffPresenter.ts
@@ -2,6 +2,7 @@ import { sendRelinquishControlEvent } from "@core/controller/ui/subscribeToRelin
 import { findLast } from "@shared/array"
 import { isTaskCompletionCard } from "@shared/cardIdentity"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { MessageStateHandler } from "../../core/task/message-state"
@@ -80,7 +81,7 @@ export class CheckpointDiffPresenter {
 					this.storage.setTracker(tracker)
 					this.services.messageStateHandler.setCheckpointTracker(tracker)
 				} catch (error) {
-					const errorMessage = error instanceof Error ? error.message : "Unknown error"
+					const errorMessage = getErrorMessage(error, "Unknown error")
 					Logger.error(
 						`[CheckpointDiffPresenter] Failed to initialize checkpoint tracker for task ${this.config.taskId}:`,
 						errorMessage,
@@ -151,7 +152,7 @@ export class CheckpointDiffPresenter {
 
 			relinquishButton()
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error(
 				`[CheckpointDiffPresenter] Failed to present multifile diff for task ${this.config.taskId}:`,
 				errorMessage,

--- a/src/integrations/checkpoints/CheckpointGitOperations.ts
+++ b/src/integrations/checkpoints/CheckpointGitOperations.ts
@@ -5,6 +5,7 @@ import { globby } from "globby"
 import * as path from "path"
 import simpleGit, { type SimpleGit } from "simple-git"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { getLfsPatterns, writeExcludesFile } from "./CheckpointExclusions"
 
@@ -188,9 +189,7 @@ export class GitOperations {
 						error,
 					)
 					throw new Error(
-						`Failed to ${disable ? "disable" : "enable"} nested git repo ${gitPath}: ${
-							error instanceof Error ? error.message : String(error)
-						}`,
+						`Failed to ${disable ? "disable" : "enable"} nested git repo ${gitPath}: ${getErrorMessage(error)}`,
 					)
 				}
 			}),

--- a/src/integrations/checkpoints/CheckpointRestoreHandler.ts
+++ b/src/integrations/checkpoints/CheckpointRestoreHandler.ts
@@ -5,6 +5,7 @@ import { DiracMessage } from "@shared/ExtensionMessage"
 import { getApiMetrics } from "@shared/getApiMetrics"
 import { DiracCheckpointRestore } from "@shared/WebviewMessage"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { FileContextTracker } from "../../core/context/context-tracking/FileContextTracker"
@@ -110,7 +111,7 @@ export class CheckpointRestoreHandler {
 							this.storage.setTracker(tracker)
 							this.services.messageStateHandler.setCheckpointTracker(tracker)
 						} catch (error) {
-							const errorMessage = error instanceof Error ? error.message : "Unknown error"
+							const errorMessage = getErrorMessage(error, "Unknown error")
 							Logger.error(
 								`[CheckpointRestoreHandler] Failed to initialize checkpoint tracker for task ${this.config.taskId}:`,
 								errorMessage,
@@ -125,7 +126,7 @@ export class CheckpointRestoreHandler {
 						try {
 							await this.storage.getTracker()?.resetHead(message.lastCheckpointHash)
 						} catch (error) {
-							const errorMessage = error instanceof Error ? error.message : "Unknown error"
+							const errorMessage = getErrorMessage(error, "Unknown error")
 							Logger.error(
 								`[CheckpointRestoreHandler] Failed to restore checkpoint for task ${this.config.taskId}:`,
 								errorMessage,
@@ -140,7 +141,7 @@ export class CheckpointRestoreHandler {
 						try {
 							await this.storage.getTracker()?.resetHead(lastMessageWithHash.lastCheckpointHash)
 						} catch (error) {
-							const errorMessage = error instanceof Error ? error.message : "Unknown error"
+							const errorMessage = getErrorMessage(error, "Unknown error")
 							Logger.error(
 								`[CheckpointRestoreHandler] Failed to restore offset checkpoint for task ${this.config.taskId}:`,
 								errorMessage,
@@ -159,7 +160,7 @@ export class CheckpointRestoreHandler {
 						try {
 							await this.storage.getTracker()?.resetHead(lastMessageWithHash.lastCheckpointHash)
 						} catch (error) {
-							const errorMessage = error instanceof Error ? error.message : "Unknown error"
+							const errorMessage = getErrorMessage(error, "Unknown error")
 							Logger.error(
 								`[CheckpointRestoreHandler] Failed to restore fallback checkpoint for task ${this.config.taskId}:`,
 								errorMessage,
@@ -199,7 +200,7 @@ export class CheckpointRestoreHandler {
 
 			return checkpointManagerStateUpdate
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error(`[CheckpointRestoreHandler] Failed to restore checkpoint for task ${this.config.taskId}:`, errorMessage)
 			sendRelinquishControlEvent()
 			return { checkpointManagerErrorMessage: errorMessage }

--- a/src/integrations/checkpoints/CheckpointStorageManager.ts
+++ b/src/integrations/checkpoints/CheckpointStorageManager.ts
@@ -1,6 +1,7 @@
 import { WorkspaceRootManager } from "@core/workspace/WorkspaceRootManager"
 import CheckpointTracker from "@integrations/checkpoints/CheckpointTracker"
 import pTimeout from "p-timeout"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { MessageStateHandler } from "../../core/task/message-state"
 import { TaskState } from "../../core/task/TaskState"
@@ -107,7 +108,7 @@ export class CheckpointStorageManager {
 			this.checkpointTracker = tracker
 			return tracker
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error("Failed to initialize checkpoint tracker:", errorMessage)
 
 			if (errorMessage.includes("Checkpoints taking too long to initialize")) {
@@ -155,7 +156,7 @@ export class CheckpointStorageManager {
 			}
 			return await this.checkpointTracker.commit()
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error(
 				`[CheckpointStorageManager] Failed to create checkpoint commit for task ${this.config.taskId}:`,
 				errorMessage,
@@ -201,7 +202,7 @@ export class CheckpointStorageManager {
 				)
 				this.services.messageStateHandler.setCheckpointTracker(this.checkpointTracker)
 			} catch (error) {
-				const errorMessage = error instanceof Error ? error.message : "Unknown error"
+				const errorMessage = getErrorMessage(error, "Unknown error")
 				Logger.error(
 					`[CheckpointStorageManager] Failed to initialize checkpoint tracker for task ${this.config.taskId}:`,
 					errorMessage,

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -5,6 +5,7 @@ import * as path from "path"
 import simpleGit from "simple-git"
 import type { FolderLockWithRetryResult } from "@/core/locks/types"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { GitOperations } from "./CheckpointGitOperations"
 import { releaseCheckpointLock, tryAcquireCheckpointLockWithRetry } from "./CheckpointLockUtils"
@@ -272,7 +273,7 @@ class CheckpointTracker {
 				taskId: this.taskId,
 				error,
 			})
-			throw new Error(`Failed to create checkpoint: ${error instanceof Error ? error.message : String(error)}`)
+			throw new Error(`Failed to create checkpoint: ${getErrorMessage(error)}`)
 		} finally {
 			if (lockAcquired) {
 				Logger.info("Releasing checkpoint folder lock")

--- a/src/integrations/checkpoints/CheckpointUtils.ts
+++ b/src/integrations/checkpoints/CheckpointUtils.ts
@@ -2,6 +2,7 @@ import { access, constants, mkdir } from "fs/promises"
 import os from "os"
 import * as path from "path"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { getCwd, getDesktopDir } from "@/utils/path"
 
 /**
@@ -47,7 +48,7 @@ export async function validateWorkspacePath(workspacePath: string): Promise<void
 		await access(workspacePath, constants.R_OK)
 	} catch (error) {
 		throw new Error(
-			`Cannot access workspace directory. Please ensure VS Code has permission to access your workspace. Error: ${error instanceof Error ? error.message : String(error)}`,
+			`Cannot access workspace directory. Please ensure VS Code has permission to access your workspace. Error: ${getErrorMessage(error)}`,
 		)
 	}
 

--- a/src/integrations/checkpoints/MultiRootCheckpointManager.ts
+++ b/src/integrations/checkpoints/MultiRootCheckpointManager.ts
@@ -26,6 +26,7 @@ import { showChangedFilesDiff } from "@core/task/multifile-diff"
 import { WorkspaceRootManager } from "@core/workspace"
 import { telemetryService } from "@services/telemetry"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import CheckpointTracker from "./CheckpointTracker"
@@ -298,7 +299,7 @@ export class MultiRootCheckpointManager implements ICheckpointManager {
 
 			await showChangedFilesDiff(this.messageStateHandler, tracker, messageId, seeNewChangesSinceLastTaskCompletion)
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error("[MultiRootCheckpointManager] Failed to present multifile diff:", errorMessage)
 			HostProvider.window.showMessage({
 				type: ShowMessageType.ERROR,

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -6,6 +6,7 @@ import { findLast, findLastIndex } from "@shared/array"
 import { isTaskCompletionCard } from "@shared/cardIdentity"
 import { HistoryItem } from "@shared/HistoryItem"
 import { DiracCheckpointRestore } from "@shared/WebviewMessage"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { MessageStateHandler } from "../../core/task/message-state"
 import { TaskMessenger } from "../../core/task/TaskMessenger"
@@ -203,7 +204,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 				}
 			}
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error(`[TaskCheckpointManager] Failed to save checkpoint for task ${this.task.taskId}:`, errorMessage)
 		}
 	}
@@ -260,7 +261,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 					this.storage.setTracker(tracker)
 					this.services.messageStateHandler.setCheckpointTracker(tracker)
 				} catch (error) {
-					const errorMessage = error instanceof Error ? error.message : "Unknown error"
+					const errorMessage = getErrorMessage(error, "Unknown error")
 					Logger.error(
 						`[TaskCheckpointManager] Failed to initialize checkpoint tracker for task ${this.task.taskId}:`,
 						errorMessage,
@@ -293,7 +294,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 			const changedFilesCount = (await this.storage.getTracker()?.getDiffCount(previousCheckpointHash, hash)) || 0
 			return changedFilesCount > 0
 		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : "Unknown error"
+			const errorMessage = getErrorMessage(error, "Unknown error")
 			Logger.error(`[TaskCheckpointManager] Failed to check for new changes in task ${this.task.taskId}:`, errorMessage)
 			return false
 		}

--- a/src/integrations/misc/extract-file-content.ts
+++ b/src/integrations/misc/extract-file-content.ts
@@ -1,6 +1,7 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import fs from "fs/promises"
 import * as path from "path"
+import { getErrorMessage } from "@/shared/errors"
 import { extractImageContent } from "./extract-images"
 import { callTextExtractionFunctions } from "./extract-text"
 
@@ -46,7 +47,7 @@ export async function extractFileContent(absolutePath: string, modelSupportsImag
 			text: textContent,
 		}
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : "Unknown error"
+		const errorMessage = getErrorMessage(error, "Unknown error")
 		throw new Error(`Error reading file: ${errorMessage}`)
 	}
 }

--- a/src/integrations/misc/extract-images.ts
+++ b/src/integrations/misc/extract-images.ts
@@ -1,6 +1,7 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import fs from "fs/promises"
 import sizeOf from "image-size"
+import { getErrorMessage } from "@/shared/errors"
 import { getMimeType } from "./process-files"
 
 /**
@@ -47,7 +48,7 @@ export async function extractImageContent(
 
 		return { success: true, imageBlock }
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : "Unknown error"
+		const errorMessage = getErrorMessage(error, "Unknown error")
 		return { success: false, error: `Error reading image: ${errorMessage}` }
 	}
 }

--- a/src/integrations/notifications/index.ts
+++ b/src/integrations/notifications/index.ts
@@ -1,5 +1,6 @@
 import { execa } from "execa"
 import { platform } from "os"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 interface NotificationOptions {
@@ -66,7 +67,7 @@ async function showLinuxNotification(options: NotificationOptions): Promise<void
 		await execa("notify-send", [title, fullMessage])
 	} catch (error) {
 		// Only log if it's not a D-Bus error which is common in headless environments
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		if (!errorMessage.includes("Cannot autolaunch D-Bus")) {
 			throw new Error(`Failed to show Linux notification: ${error}`)
 		}

--- a/src/integrations/terminal/CommandOrchestrator.ts
+++ b/src/integrations/terminal/CommandOrchestrator.ts
@@ -6,6 +6,7 @@
  */
 
 import { setTimeout as setTimeoutPromise } from "node:timers/promises"
+import { toError } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { type BuildResultInput, buildResult } from "./buildResult"
 import {
@@ -94,7 +95,7 @@ export async function orchestrateCommandExecution(
 				outputLines.push(line)
 			}
 		} catch (error) {
-			fileLogError = error instanceof Error ? error : new Error(String(error))
+			fileLogError = toError(error)
 		}
 	}
 	process.on("line", onLine)

--- a/src/integrations/terminal/file-logging.ts
+++ b/src/integrations/terminal/file-logging.ts
@@ -3,6 +3,7 @@
  */
 
 import { DiracTempManager } from "@services/temp"
+import { toError } from "@/shared/errors"
 import { MAX_BYTES_BEFORE_FILE, MAX_LINES_BEFORE_FILE, SUMMARY_BYTES_TO_KEEP, SUMMARY_LINES_TO_KEEP } from "./constants"
 
 export interface FileLogState {
@@ -39,7 +40,7 @@ class QueuedFileWriter {
 				await handle.appendFile(output, "utf8")
 			})
 			.catch((error) => {
-				this.firstError ??= error instanceof Error ? error : new Error(String(error))
+				this.firstError ??= toError(error)
 			})
 	}
 

--- a/src/integrations/terminal/standalone/TerminalProcessManager.ts
+++ b/src/integrations/terminal/standalone/TerminalProcessManager.ts
@@ -16,6 +16,7 @@
 
 import { DiracTempManager } from "@services/temp"
 import * as fs from "fs"
+import { getErrorMessage } from "@/shared/errors"
 import { BACKGROUND_COMMAND_TIMEOUT_MS } from "../constants"
 import type { BackgroundCommand, TerminalInfo, TerminalProcessResultPromise } from "../types"
 import { StandaloneTerminalProcess } from "./StandaloneTerminalProcess"
@@ -192,7 +193,7 @@ export class TerminalProcessManager {
 			backgroundLoggingReady = true
 			if (handoffError) {
 				backgroundCommand.status = "error"
-				logStream.write(`\n[LOG_HANDOFF_ERROR] ${handoffError instanceof Error ? handoffError.message : String(handoffError)}\n`)
+				logStream.write(`\n[LOG_HANDOFF_ERROR] ${getErrorMessage(handoffError)}\n`)
 				requestFinalization()
 			}
 			for (const line of pendingLines) logStream.write(`${line}\n`)

--- a/src/services/banner/RemoteBannerService.ts
+++ b/src/services/banner/RemoteBannerService.ts
@@ -4,6 +4,7 @@ import { DiracEnv } from "@/config"
 import { Controller } from "@/core/controller"
 import { StateManager } from "@/core/storage/StateManager"
 import { HostInfo } from "@/registry"
+import { getErrorMessage } from "@/shared/errors"
 import { FeatureFlag } from "@/shared/services/feature-flags/feature-flags"
 import { Logger } from "@/shared/services/Logger"
 import { buildBasicDiracHeaders } from "../EnvUtils"
@@ -283,8 +284,7 @@ export class RemoteBannerService {
 			})
 		} catch (error) {
 			Logger.log(
-				`[RemoteBannerService] Error parsing provider rules for banner ${banner.id}: ` +
-					`${error instanceof Error ? error.message : String(error)}`,
+				`[RemoteBannerService] Error parsing provider rules for banner ${banner.id}: ` + `${getErrorMessage(error)}`,
 			)
 			return true // Fail open
 		}

--- a/src/services/browser/BrowserConnectionManager.ts
+++ b/src/services/browser/BrowserConnectionManager.ts
@@ -9,6 +9,7 @@ import * as path from "path"
 import { Browser, connect, launch, Page } from "puppeteer-core"
 import { StateManager } from "@/core/storage/StateManager"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { discoverChromeInstances, isPortOpen, testBrowserConnection } from "./BrowserDiscovery"
 import { ensureChromiumExists } from "./utils"
@@ -177,7 +178,7 @@ export class BrowserConnectionManager {
 
 			return `Browser successfully launched with debug mode\nUsing: ${installation}`
 		} catch (error) {
-			throw new Error(`Failed to relaunch Chrome: ${error instanceof Error ? error.message : globalThis.String(error)}`)
+			throw new Error(`Failed to relaunch Chrome: ${getErrorMessage(error)}`)
 		}
 	}
 
@@ -207,15 +208,10 @@ export class BrowserConnectionManager {
 			} catch (error) {
 				Logger.error("Failed to launch remote browser, falling back to local mode:", error)
 				if (this.ulid) {
-					telemetryService.captureBrowserError(
-						this.ulid,
-						"remote_browser_launch_error",
-						error instanceof Error ? error.message : String(error),
-						{
-							isRemote: true,
-							remoteBrowserHost: browserSettings.remoteBrowserHost,
-						},
-					)
+					telemetryService.captureBrowserError(this.ulid, "remote_browser_launch_error", getErrorMessage(error), {
+						isRemote: true,
+						remoteBrowserHost: browserSettings.remoteBrowserHost,
+					})
 				}
 				await this.launchLocalBrowser()
 			}
@@ -291,15 +287,10 @@ export class BrowserConnectionManager {
 			} catch (error) {
 				Logger.log(`Failed to connect using cached endpoint: ${error}`)
 				if (this.ulid) {
-					telemetryService.captureBrowserError(
-						this.ulid,
-						"cached_endpoint_connection_error",
-						error instanceof Error ? error.message : String(error),
-						{
-							isRemote: true,
-							endpoint: browserWSEndpoint,
-						},
-					)
+					telemetryService.captureBrowserError(this.ulid, "cached_endpoint_connection_error", getErrorMessage(error), {
+						isRemote: true,
+						endpoint: browserWSEndpoint,
+					})
 				}
 				this.cachedWebSocketEndpoint = undefined
 				if (remoteBrowserHost) {
@@ -342,15 +333,10 @@ export class BrowserConnectionManager {
 			} catch (error) {
 				Logger.log(`Failed to connect to remote browser: ${error}`)
 				if (this.ulid) {
-					telemetryService.captureBrowserError(
-						this.ulid,
-						"remote_host_connection_error",
-						error instanceof Error ? error.message : String(error),
-						{
-							isRemote: true,
-							remoteBrowserHost,
-						},
-					)
+					telemetryService.captureBrowserError(this.ulid, "remote_host_connection_error", getErrorMessage(error), {
+						isRemote: true,
+						remoteBrowserHost,
+					})
 				}
 			}
 		}

--- a/src/services/browser/BrowserDiscovery.ts
+++ b/src/services/browser/BrowserDiscovery.ts
@@ -1,5 +1,6 @@
 import axios from "axios"
 import * as net from "net"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -97,7 +98,7 @@ export async function testBrowserConnection(host: string): Promise<{ success: bo
 		Logger.error(`Failed to connect to remote browser: ${error}`)
 		return {
 			success: false,
-			message: `Failed to connect: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to connect: ${getErrorMessage(error)}`,
 		}
 	}
 }

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -6,6 +6,7 @@ import type { ConsoleMessage, ScreenshotOptions } from "puppeteer-core"
 import { Page, TimeoutError } from "puppeteer-core"
 import { StateManager } from "@/core/storage/StateManager"
 import { telemetryService } from "@/services/telemetry"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { BrowserConnectionInfo, BrowserConnectionManager } from "./BrowserConnectionManager"
 
@@ -109,7 +110,7 @@ export class BrowserSession {
 		try {
 			await action(page)
 		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : String(err)
+			const errorMessage = getErrorMessage(err)
 
 			if (!(err instanceof TimeoutError)) {
 				logs.push(`[Error] ${errorMessage}`)

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -5,6 +5,7 @@ import * as childProcess from "child_process"
 import * as fs from "fs/promises"
 import * as path from "path"
 import * as readline from "readline"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { getBinaryLocation } from "@/utils/fs"
 
@@ -199,10 +200,10 @@ export async function regexSearchFiles(
 	} catch (error) {
 		await debugLog?.({
 			info: "regexSearchFiles execRipgrep error",
-			errorMessage: error instanceof Error ? error.message : String(error),
+			errorMessage: getErrorMessage(error),
 			stack: error instanceof Error ? error.stack : undefined,
 		})
-		const causeMessage = error instanceof Error ? error.message : String(error)
+		const causeMessage = getErrorMessage(error)
 		throw new Error(`Error calling ripgrep: ${causeMessage}`, { cause: error })
 	}
 	const outputDetails = {
@@ -241,7 +242,7 @@ export async function regexSearchFiles(
 				void debugLog?.({
 					info: "regexSearchFiles parse line error",
 					linePreview: line.substring(0, 300),
-					errorMessage: error instanceof Error ? error.message : String(error),
+					errorMessage: getErrorMessage(error),
 				})
 			}
 		}

--- a/src/services/ripgrep/resolve-ripgrep-binary.ts
+++ b/src/services/ripgrep/resolve-ripgrep-binary.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process"
 import path from "node:path"
 import { promisify } from "node:util"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 const execFileAsync = promisify(execFile)
@@ -50,7 +51,7 @@ async function validateRipgrepBinary(binaryPath: string, source: string): Promis
 		})
 		return true
 	} catch (error) {
-		const reason = error instanceof Error ? error.message : String(error)
+		const reason = getErrorMessage(error)
 		Logger.warn(`[Dirac] ${source} rg failed validation at ${binaryPath}: ${reason}`)
 		return false
 	}

--- a/src/services/source-ast/SourceAstService.ts
+++ b/src/services/source-ast/SourceAstService.ts
@@ -217,7 +217,7 @@ export class SourceAstService {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }
 
@@ -232,3 +232,5 @@ export type {
 	AstReplacementRequest,
 	SourceMutationPlan,
 } from "./types"
+
+import { getErrorMessage } from "@/shared/errors"

--- a/src/services/source-ast/SourceDefinitionCatalog.ts
+++ b/src/services/source-ast/SourceDefinitionCatalog.ts
@@ -1,7 +1,8 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
-import type { Node as SyntaxNode, Parser, Query, Tree } from "web-tree-sitter"
 import { loadRequiredLanguageParsers } from "@services/tree-sitter/languageParser"
+import type { Parser, Query, Node as SyntaxNode, Tree } from "web-tree-sitter"
+import { getErrorMessage } from "@/shared/errors"
 import { SymbolContextResolver } from "./SymbolContextResolver"
 import type {
 	SourceDefinition,
@@ -360,6 +361,6 @@ export class SourceDefinitionCatalog {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/services/source-ast/SourceMutationPlanner.ts
+++ b/src/services/source-ast/SourceMutationPlanner.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises"
+import { getErrorMessage } from "@/shared/errors"
 import type { SourceDefinitionCatalog } from "./SourceDefinitionCatalog"
 import type { SourceOccurrenceResolver } from "./SourceOccurrenceResolver"
 import type {
@@ -327,6 +328,6 @@ export class SourceMutationPlanner {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 }

--- a/src/services/source-ast/SourceOccurrenceResolver.ts
+++ b/src/services/source-ast/SourceOccurrenceResolver.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
 import { SymbolIndexService, type SymbolLocation } from "@services/symbol-index/SymbolIndexService"
+import { getErrorMessage } from "@/shared/errors"
 import type { SourceDefinitionCatalog } from "./SourceDefinitionCatalog"
 import type {
 	AstOccurrenceRequest,
@@ -412,7 +413,7 @@ export class SourceOccurrenceResolver {
 	}
 
 	private errorMessage(error: unknown): string {
-		return error instanceof Error ? error.message : String(error)
+		return getErrorMessage(error)
 	}
 
 	private locationKey(location: SymbolLocation): string {

--- a/src/services/telemetry/providers/opentelemetry/otel-exporter-diagnostics.ts
+++ b/src/services/telemetry/providers/opentelemetry/otel-exporter-diagnostics.ts
@@ -5,6 +5,7 @@
  * Enable with: TEL_DEBUG_DIAGNOSTICS=true or IS_DEV=true
  */
 
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -44,7 +45,7 @@ export function wrapMetricsExporterWithDiagnostics(exporter: any, protocol: stri
 		} catch (error) {
 			const elapsed = Date.now() - startTime
 			Logger.error(
-				`[OTEL METRICS] Export #${exportCount} EXCEPTION - elapsed=${elapsed}ms error="${error instanceof Error ? error.message : String(error)}"`,
+				`[OTEL METRICS] Export #${exportCount} EXCEPTION - elapsed=${elapsed}ms error="${getErrorMessage(error)}"`,
 			)
 			throw error
 		}
@@ -87,9 +88,7 @@ export function wrapLogsExporterWithDiagnostics(exporter: any, protocol: string,
 			originalExport(logs, wrappedCallback)
 		} catch (error) {
 			const elapsed = Date.now() - startTime
-			Logger.error(
-				`[OTEL LOGS] Export #${exportCount} EXCEPTION - elapsed=${elapsed}ms error="${error instanceof Error ? error.message : String(error)}"`,
-			)
+			Logger.error(`[OTEL LOGS] Export #${exportCount} EXCEPTION - elapsed=${elapsed}ms error="${getErrorMessage(error)}"`)
 			throw error
 		}
 	}

--- a/src/services/tree-sitter/languageParser.ts
+++ b/src/services/tree-sitter/languageParser.ts
@@ -1,7 +1,8 @@
 import * as fs from "fs"
 import * as path from "path"
-import { Parser, Language, Query } from "web-tree-sitter"
+import { Language, Parser, Query } from "web-tree-sitter"
 import { SymbolIndexTelemetry } from "@/services/symbol-index/SymbolIndexTelemetry"
+import { getErrorMessage } from "@/shared/errors"
 import {
 	cppQuery,
 	cQuery,
@@ -47,7 +48,7 @@ async function loadLanguage(langName: string): Promise<Language> {
 			SymbolIndexTelemetry.recordGrammarLoad()
 			return language
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error)
+			const message = getErrorMessage(error)
 			errors.push(`${wasmPath}: ${message}`)
 		}
 	}

--- a/src/shared/errors.test.ts
+++ b/src/shared/errors.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { getErrorMessage, toError } from "./errors"
+
+describe("getErrorMessage", () => {
+	it("returns the message of an Error", () => {
+		assert.strictEqual(getErrorMessage(new Error("boom")), "boom")
+	})
+
+	it("stringifies a non-Error value", () => {
+		assert.strictEqual(getErrorMessage("oops"), "oops")
+		assert.strictEqual(getErrorMessage(42), "42")
+		assert.strictEqual(getErrorMessage(undefined), "undefined")
+	})
+
+	it("uses the fallback for a non-Error value when provided", () => {
+		assert.strictEqual(getErrorMessage({ code: 1 }, "Unknown error"), "Unknown error")
+		assert.strictEqual(getErrorMessage(undefined, "Unknown error"), "Unknown error")
+	})
+
+	it("ignores the fallback for an Error", () => {
+		assert.strictEqual(getErrorMessage(new Error("boom"), "Unknown error"), "boom")
+	})
+})
+
+describe("toError", () => {
+	it("returns the same Error instance", () => {
+		const error = new Error("boom")
+		assert.strictEqual(toError(error), error)
+	})
+
+	it("wraps a non-Error value in a new Error", () => {
+		const error = toError("oops")
+		assert.ok(error instanceof Error)
+		assert.strictEqual(error.message, "oops")
+	})
+})

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,16 @@
+/**
+ * Return a human-readable message for a thrown value. When the value is an
+ * `Error` its `message` is used; otherwise the value is stringified, or a
+ * caller-provided `fallback` is used when the value is not an `Error`.
+ */
+export function getErrorMessage(error: unknown, fallback?: string): string {
+	return error instanceof Error ? error.message : fallback ?? String(error)
+}
+
+/**
+ * Normalize an unknown thrown value into an `Error`, preserving existing
+ * `Error` instances and wrapping any other value in a new `Error`.
+ */
+export function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/shared/services/file-logger.ts
+++ b/src/shared/services/file-logger.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
+import { toError } from "@/shared/errors"
 
 export const LOG_MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024
 export const LOG_MAX_FILES = 5
@@ -141,7 +142,7 @@ class RotatingFileLoggerImpl implements RotatingFileLogger {
 			})
 		})
 		this.flushChain = this.flushChain.catch((error: unknown) => {
-			this.flushFailure = error instanceof Error ? error : new Error(String(error))
+			this.flushFailure = toError(error)
 			process.stderr.write(`Failed to write ${this.filePath}: ${this.flushFailure.message}\n`)
 		})
 	}

--- a/src/shared/services/worker/backfill.ts
+++ b/src/shared/services/worker/backfill.ts
@@ -8,6 +8,7 @@
 
 import * as fs from "fs/promises"
 import { GlobalFileNames, getSavedApiConversationHistory, getTaskHistoryStateFilePath } from "@/core/storage/disk"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { syncWorker } from "./sync"
 
@@ -107,7 +108,7 @@ export async function backfillTask(taskId: string): Promise<BackfillTaskResult> 
 
 		result.success = result.filesQueued.length > 0
 	} catch (err) {
-		result.error = err instanceof Error ? err.message : String(err)
+		result.error = getErrorMessage(err)
 	}
 
 	return result

--- a/src/shared/services/worker/worker.ts
+++ b/src/shared/services/worker/worker.ts
@@ -1,6 +1,6 @@
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { BlobStoreSettings, blobStorage } from "../../storage/DiracBlobStorage"
-
 import { SyncQueue, SyncQueueItem } from "./queue"
 
 export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
@@ -235,7 +235,7 @@ export class SyncWorker {
 					successCount++
 					this.emit({ type: WorkerEvent.WorkerItemSynced, item })
 				} catch (err) {
-					const errorMsg = err instanceof Error ? err.message : String(err)
+					const errorMsg = getErrorMessage(err)
 					this.queue.markFailed(item.taskId, item.key, errorMsg)
 					failCount++
 					this.emit({ type: WorkerEvent.WorkerItemFailed, item, error: errorMsg })

--- a/src/standalone/utils.ts
+++ b/src/standalone/utils.ts
@@ -2,6 +2,7 @@ import * as protoLoader from "@grpc/proto-loader"
 import * as fs from "fs"
 import * as health from "grpc-health-check"
 import { StreamingCallbacks } from "@/hosts/host-provider-types"
+import { toError } from "@/shared/errors"
 
 const log = (...args: unknown[]) => {
 	const now = new Date()
@@ -42,7 +43,7 @@ async function asyncIteratorToCallbacks<T>(stream: AsyncIterable<T>, callbacks: 
 		// Stream completed successfully
 		callbacks.onComplete && callbacks.onComplete()
 	} catch (err) {
-		const error = err instanceof Error ? err : new Error(String(err))
+		const error = toError(err)
 		if (callbacks.onError) {
 			callbacks.onError(error)
 		} else {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,7 @@
 import { EmptyRequest, StringRequest } from "@shared/proto/dirac/common"
 import { ShowMessageType } from "@shared/proto/host/window"
 import { HostProvider } from "@/hosts/host-provider"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 /**
@@ -13,7 +14,7 @@ export async function writeTextToClipboard(text: string): Promise<void> {
 	try {
 		await HostProvider.env.clipboardWriteText(StringRequest.create({ value: text }))
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		throw new Error(`Failed to write to clipboard: ${errorMessage}`)
 	}
 }
@@ -28,7 +29,7 @@ export async function readTextFromClipboard(): Promise<string> {
 		const response = await HostProvider.env.clipboardReadText(EmptyRequest.create({}))
 		return response.value
 	} catch (error) {
-		const errorMessage = error instanceof Error ? error.message : String(error)
+		const errorMessage = getErrorMessage(error)
 		throw new Error(`Failed to read from clipboard: ${errorMessage}`)
 	}
 }

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,4 +1,5 @@
 import * as yaml from "js-yaml"
+import { getErrorMessage } from "@/shared/errors"
 
 export type FrontmatterParseResult = {
 	data: Record<string, unknown>
@@ -47,7 +48,7 @@ export function parseYamlFrontmatter(markdown: string): FrontmatterParseResult {
 		const data = (yaml.load(yamlContent, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>) || {}
 		return { data, body, hadFrontmatter: true }
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error)
+		const message = getErrorMessage(error)
 		return { data: {}, body: markdown, hadFrontmatter: true, parseError: message }
 	}
 }

--- a/src/utils/git-worktree.ts
+++ b/src/utils/git-worktree.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
 import simpleGit from "simple-git"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 import { copyWorktreeIncludeFiles } from "./worktree-include"
 
@@ -150,7 +151,7 @@ export async function listWorktrees(cwd: string): Promise<{ worktrees: Worktree[
 		return {
 			worktrees: [],
 			isGitRepo: true,
-			error: `Failed to list worktrees: ${error instanceof Error ? error.message : String(error)}`,
+			error: `Failed to list worktrees: ${getErrorMessage(error)}`,
 		}
 	}
 }
@@ -226,7 +227,7 @@ export async function createWorktree(
 	} catch (error) {
 		return {
 			success: false,
-			message: `Failed to create worktree: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to create worktree: ${getErrorMessage(error)}`,
 		}
 	}
 }
@@ -258,7 +259,7 @@ export async function deleteWorktree(cwd: string, path: string, force = false): 
 	} catch (error) {
 		return {
 			success: false,
-			message: `Failed to remove worktree: ${error instanceof Error ? error.message : String(error)}`,
+			message: `Failed to remove worktree: ${getErrorMessage(error)}`,
 		}
 	}
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,5 +1,6 @@
 import { exec } from "child_process"
 import { promisify } from "util"
+import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 const execAsync = promisify(exec)
@@ -146,7 +147,7 @@ export async function getCommitInfo(hash: string, cwd: string): Promise<string> 
 		return truncateOutput(output)
 	} catch (error) {
 		Logger.error("Error getting commit info:", error)
-		return `Failed to get commit info: ${error instanceof Error ? error.message : String(error)}`
+		return `Failed to get commit info: ${getErrorMessage(error)}`
 	}
 }
 
@@ -182,7 +183,7 @@ export async function getWorkingState(cwd: string): Promise<string> {
 		return truncateOutput(output)
 	} catch (error) {
 		Logger.error("Error getting working state:", error)
-		return `Failed to get working state: ${error instanceof Error ? error.message : String(error)}`
+		return `Failed to get working state: ${getErrorMessage(error)}`
 	}
 }
 

--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "mocha"
 import sinon from "sinon"
 import "should"
+import { getErrorMessage } from "@/shared/errors"
 import { retryWithBackoff } from "./retry"
 
 describe("retryWithBackoff", () => {
@@ -76,7 +77,7 @@ describe("retryWithBackoff", () => {
 				shouldRetry,
 			})
 		} catch (error) {
-			errorMessage = error instanceof Error ? error.message : String(error)
+			errorMessage = getErrorMessage(error)
 		}
 
 		operation.callCount.should.equal(1)
@@ -102,7 +103,7 @@ describe("retryWithBackoff", () => {
 				},
 			)
 		} catch (error) {
-			errorMessage = error instanceof Error ? error.message : String(error)
+			errorMessage = getErrorMessage(error)
 		}
 
 		attempt.should.equal(3)

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage, toError } from "@/shared/errors"
 export interface RetryWithBackoffOptions {
 	maxAttempts?: number
 	baseDelayMs?: number
@@ -57,11 +58,7 @@ export async function retryWithBackoff<T>(operation: () => Promise<T>, options: 
 		}
 	}
 
-	throw new Error(
-		`${operationName} failed after ${maxAttempts} attempts: ${
-			lastError instanceof Error ? lastError.message : String(lastError)
-		}`,
-	)
+	throw new Error(`${operationName} failed after ${maxAttempts} attempts: ${getErrorMessage(lastError)}`)
 }
 
 /**
@@ -82,7 +79,7 @@ export async function retryOperation<T>(maxRetries: number, timeoutPerAttempt: n
 			const result = await Promise.race([operation(), timeoutPromise])
 			return result // Success - return result
 		} catch (error) {
-			lastError = error instanceof Error ? error : new Error(String(error))
+			lastError = toError(error)
 
 			if (attempt < maxRetries) {
 				// Brief delay before retry

--- a/src/utils/worktree-include.ts
+++ b/src/utils/worktree-include.ts
@@ -3,6 +3,7 @@ import * as fs from "fs/promises"
 import ignore from "ignore"
 import * as path from "path"
 import { promisify } from "util"
+import { getErrorMessage } from "@/shared/errors"
 
 const execAsync = promisify(exec)
 
@@ -201,7 +202,7 @@ export async function copyWorktreeIncludeFiles(
 			const files = await getAllFiles(sourcePath, sourcePath)
 			copiedCount += files.length
 		} catch (error) {
-			errors.push(`Failed to copy directory ${dir}: ${error instanceof Error ? error.message : String(error)}`)
+			errors.push(`Failed to copy directory ${dir}: ${getErrorMessage(error)}`)
 		}
 	}
 


### PR DESCRIPTION
## What
Add `src/shared/errors.ts` helpers and replace the repeated ad-hoc error ternary idiom across ~100 files:
- `getErrorMessage(error, fallback?)` — for `x instanceof Error ? x.message : String(x)` (~130 sites) and `… : "Unknown error"` (behavior preserved via fallback arg).
- `toError(error)` — for `x instanceof Error ? x : new Error(String(x))` (~13 sites).

## Why
Dedupe the ~130 repeated `instanceof Error ?` branches into one tested source of truth.

## Tests
New `src/shared/errors.test.ts` (6 tests: getErrorMessage + toError).

## Verification
- `tsc` vs baseline: 0 new errors.
- `biome` vs baseline (per file): 0 new errors; import ordering normalized via organize-imports only (pre-existing formatter drift left untouched).
- Only remaining `instanceof Error ?` in non-test `src/`: the 2 helper definitions + 2 intentional special cases (`.stack` and `": {msg}" : ""`).

## Caveats
Mechanical refactor across many files. Full suite needs CI (local env lacks `node:sqlite` / vscode types — pre-existing, unrelated).

Closes FB-6 (FIX-BACKLOG).