### PR TITLE
refactor: remove mid-fn import() in checkpoints

### DIFF
--- a/src/integrations/checkpoints/CheckpointDiffPresenter.ts
+++ b/src/integrations/checkpoints/CheckpointDiffPresenter.ts
@@ -5,6 +5,7 @@ import { HostProvider } from "@/hosts/host-provider"
 import { ShowMessageType } from "@/shared/proto/host/window"
 import { Logger } from "@/shared/services/Logger"
 import { MessageStateHandler } from "../../core/task/message-state"
+import type { CreateCheckpointTracker } from "./CheckpointRestoreHandler"
 import type { CheckpointStorageManager } from "./CheckpointStorageManager"
 
 interface CheckpointDiffConfig {
@@ -13,6 +14,7 @@ interface CheckpointDiffConfig {
 }
 interface CheckpointDiffServices {
 	readonly messageStateHandler: MessageStateHandler
+	readonly createCheckpointTracker: CreateCheckpointTracker
 }
 
 /**
@@ -74,8 +76,10 @@ export class CheckpointDiffPresenter {
 			if (!this.storage.getTracker() && this.config.enableCheckpoints && !this.storage.getErrorMessage()) {
 				try {
 					const workspacePath = await this.storage.getWorkspacePath()
-					const tracker = await import("@integrations/checkpoints/CheckpointTracker").then((m) =>
-						m.default.create(this.config.taskId, this.config.enableCheckpoints, workspacePath),
+					const tracker = await this.services.createCheckpointTracker(
+						this.config.taskId,
+						this.config.enableCheckpoints,
+						workspacePath,
 					)
 					this.storage.setTracker(tracker)
 					this.services.messageStateHandler.setCheckpointTracker(tracker)

--- a/src/integrations/checkpoints/CheckpointRestoreHandler.ts
+++ b/src/integrations/checkpoints/CheckpointRestoreHandler.ts
@@ -12,15 +12,24 @@ import { MessageStateHandler } from "../../core/task/message-state"
 import { TaskMessenger } from "../../core/task/TaskMessenger"
 import { TaskState } from "../../core/task/TaskState"
 import type { CheckpointStorageManager } from "./CheckpointStorageManager"
+import type CheckpointTracker from "./CheckpointTracker"
 
 interface CheckpointRestoreConfig {
 	readonly enableCheckpoints: boolean
 	readonly taskId: string
 }
+
+/** Factory for creating a `CheckpointTracker` for a task/workspace. */
+export type CreateCheckpointTracker = (
+	taskId: string,
+	enableCheckpoints: boolean,
+	workspacePath: string,
+) => Promise<CheckpointTracker | undefined>
 interface CheckpointRestoreServices {
 	readonly messageStateHandler: MessageStateHandler
 	readonly fileContextTracker: FileContextTracker
 	readonly taskState: TaskState
+	readonly createCheckpointTracker: CreateCheckpointTracker
 }
 interface CheckpointRestoreCallbacks {
 	readonly cancelTask: () => Promise<void>
@@ -104,8 +113,10 @@ export class CheckpointRestoreHandler {
 					if (!this.storage.getTracker() && !this.storage.getErrorMessage()) {
 						try {
 							const workspacePath = await this.storage.getWorkspacePath()
-							const tracker = await import("@integrations/checkpoints/CheckpointTracker").then((m) =>
-								m.default.create(this.config.taskId, this.config.enableCheckpoints, workspacePath),
+							const tracker = await this.services.createCheckpointTracker(
+								this.config.taskId,
+								this.config.enableCheckpoints,
+								workspacePath,
 							)
 							this.storage.setTracker(tracker)
 							this.services.messageStateHandler.setCheckpointTracker(tracker)

--- a/src/integrations/checkpoints/CheckpointTracker.ts
+++ b/src/integrations/checkpoints/CheckpointTracker.ts
@@ -7,8 +7,9 @@ import type { FolderLockWithRetryResult } from "@/core/locks/types"
 import { telemetryService } from "@/services/telemetry"
 import { Logger } from "@/shared/services/Logger"
 import { GitOperations } from "./CheckpointGitOperations"
+import { getDefaultExclusions, getLfsPatterns } from "./CheckpointExclusions"
 import { releaseCheckpointLock, tryAcquireCheckpointLockWithRetry } from "./CheckpointLockUtils"
-import { getShadowGitPath, hashWorkingDir } from "./CheckpointUtils"
+import { getShadowGitPath, hashWorkingDir, validateWorkspacePath } from "./CheckpointUtils"
 
 /**
  * Normalizes whitespace for diff comparison. Collapses all runs of whitespace
@@ -155,7 +156,6 @@ class CheckpointTracker {
 
 			// Validate and normalize workspace paths - for now, we just use the first valid path
 			const pathsToValidate = Array.isArray(workspacePaths) ? workspacePaths : [workspacePaths]
-			const { validateWorkspacePath } = await import("./CheckpointUtils")
 
 			for (const workspacePath of pathsToValidate) {
 				if (!workspacePath) {
@@ -414,8 +414,6 @@ class CheckpointTracker {
 		Logger.info(`Diff range: ${diffRange}`)
 		const diffSummary = await git.diffSummary([diffRange])
 
-		const { getDefaultExclusions } = await import("./CheckpointExclusions")
-		const { getLfsPatterns } = await import("./CheckpointExclusions")
 		const lfsPatterns = await getLfsPatterns(this.cwd)
 		const exclusions = getDefaultExclusions(lfsPatterns)
 

--- a/src/integrations/checkpoints/DiffContentProvider.ts
+++ b/src/integrations/checkpoints/DiffContentProvider.ts
@@ -2,7 +2,6 @@ import fs from "fs/promises"
 import { isBinaryFile } from "isbinaryfile"
 import * as path from "path"
 import type { SimpleGit } from "simple-git"
-import { Logger } from "@/shared/services/Logger"
 
 export interface DiffEntry {
 	relativePath: string
@@ -76,6 +75,9 @@ export class DiffContentProvider {
 	constructor(
 		private cwd: string,
 		private taskId: string,
+		private getDefaultExclusions: (lfsPatterns?: string[]) => string[],
+		private getLfsPatterns: (workspacePath: string) => Promise<string[]>,
+		private captureCheckpointUsage: (ulid: string, action: string, durationMs?: number) => void,
 	) {}
 
 	/** Strips "HEAD " prefix from commit hashes for backward compatibility. */
@@ -93,17 +95,12 @@ export class DiffContentProvider {
 		await git.add(["."])
 		const diffSummary = await git.diffSummary([diffRange])
 
-		const { getDefaultExclusions, getLfsPatterns } = await import("./CheckpointExclusions")
-		const lfsPatterns = await getLfsPatterns(this.cwd)
-		const exclusions = getDefaultExclusions(lfsPatterns)
+		const lfsPatterns = await this.getLfsPatterns(this.cwd)
+		const exclusions = this.getDefaultExclusions(lfsPatterns)
 
 		const captureTelemetry = () => {
 			const durationMs = Math.round(performance.now() - startTime)
-			import("@/services/telemetry")
-				.then(({ telemetryService }) =>
-					telemetryService.captureCheckpointUsage(this.taskId, "diff_generated", durationMs),
-				)
-				.catch(() => Logger.debug("[DiffContentProvider] Telemetry service not available"))
+			this.captureCheckpointUsage(this.taskId, "diff_generated", durationMs)
 		}
 
 		return { cleanLhs, cleanRhs, diffSummary, exclusions, captureTelemetry }

--- a/src/integrations/checkpoints/__tests__/DiffContentProvider.test.ts
+++ b/src/integrations/checkpoints/__tests__/DiffContentProvider.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import type { SimpleGit } from "simple-git"
 import sinon from "sinon"
+import { getDefaultExclusions, getLfsPatterns } from "../CheckpointExclusions"
 import { DiffContentProvider } from "../CheckpointTracker"
 
 // Stubbed subset of SimpleGit used by DiffContentProvider — type-safe on method names, stubs on values
@@ -39,14 +40,14 @@ describe("DiffContentProvider", () => {
 
 	describe("computeDiffSet", () => {
 		it("should return empty array when no files in diff summary", async () => {
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123")
 			expect(result).to.deep.equal([])
 		})
 
 		it("should exclude files matching exclusion patterns (node_modules)", async () => {
 			gitDiffSummaryFiles = [{ file: "node_modules/pkg/index.js" }, { file: "src/app.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			mockGit.show.resolves("old content")
 			const result = await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123")
 
@@ -55,7 +56,7 @@ describe("DiffContentProvider", () => {
 
 		it("should include files with actual content differences", async () => {
 			gitDiffSummaryFiles = [{ file: "src/app.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			mockGit.show.resolves("old content here")
 			const result = await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123")
 
@@ -66,7 +67,7 @@ describe("DiffContentProvider", () => {
 		it("should handle deleted files gracefully (empty after content)", async () => {
 			gitDiffSummaryFiles = [{ file: "deleted.ts" }]
 			mockGit.show.resolves("content that existed")
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 
 			await assertNoThrow(() => provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123"))
 		})
@@ -74,7 +75,7 @@ describe("DiffContentProvider", () => {
 		it("should return diff entries with relativePath, absolutePath, before, after", async () => {
 			gitDiffSummaryFiles = [{ file: "src/app.ts" }]
 			mockGit.show.resolves("old content")
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 
 			await assertNoThrow(() => provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123"))
 		})
@@ -82,53 +83,53 @@ describe("DiffContentProvider", () => {
 
 	describe("computeDiffCount", () => {
 		it("should return 0 when no files in diff summary", async () => {
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123")
 			expect(result).to.equal(0)
 		})
 
 		it("should return count of files in diff summary", async () => {
 			gitDiffSummaryFiles = [{ file: "src/a.ts" }, { file: "src/b.ts" }, { file: "src/c.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123")
 			expect(result).to.equal(3)
 		})
 
 		it("should count only non-excluded files", async () => {
 			gitDiffSummaryFiles = [{ file: "node_modules/pkg/index.js" }, { file: "src/app.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123")
 			expect(result).to.equal(1)
 		})
 
 		it("should clean commit hashes before computing diff range", async () => {
 			gitDiffSummaryFiles = [{ file: "src/app.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			await assertNoThrow(() => provider.computeDiffCount(mockGit as unknown as SimpleGit, "HEAD abc123"))
 		})
 
 		it("should handle rhsHash for commit-to-commit comparison", async () => {
 			gitDiffSummaryFiles = [{ file: "src/app.ts" }]
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			await assertNoThrow(() => provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123", "def456"))
 		})
 	})
 
 	describe("cleanCommitHash", () => {
 		it("should strip HEAD prefix from commit hash", async () => {
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = provider.cleanCommitHash("HEAD abc123def")
 			expect(result).to.equal("abc123def")
 		})
 
 		it("should return hash unchanged if no HEAD prefix", async () => {
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = provider.cleanCommitHash("abc123def")
 			expect(result).to.equal("abc123def")
 		})
 
 		it("should handle empty string", async () => {
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const result = provider.cleanCommitHash("")
 			expect(result).to.equal("")
 		})
@@ -140,7 +141,7 @@ describe("DiffContentProvider", () => {
 		it("computeDiffSet and computeDiffCount call git.add with same args", async () => {
 			gitDiffSummaryFiles = [{ file: "src/a.ts" }, { file: "node_modules/pkg/index.js" }]
 			mockGit.show = sandbox.stub().resolves("content")
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 
 			await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123")
 			await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123")
@@ -154,7 +155,7 @@ describe("DiffContentProvider", () => {
 		it("computeDiffSet and computeDiffCount call diffSummary with same diff range", async () => {
 			gitDiffSummaryFiles = [{ file: "src/a.ts" }]
 			mockGit.show = sandbox.stub().resolves("content")
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 
 			await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123", "def456")
 			await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123", "def456")
@@ -178,7 +179,7 @@ describe("DiffContentProvider", () => {
 				.onCall(3)
 				.resolves("  const y = 1  ") // src/util.ts after (whitespace-only)
 
-			const provider = new DiffContentProvider("/mock/cwd", "task-123")
+			const provider = new DiffContentProvider("/mock/cwd", "task-123", getDefaultExclusions, getLfsPatterns, () => {})
 			const diffSet = await provider.computeDiffSet(mockGit as unknown as SimpleGit, "abc123", "def456")
 			const diffCount = await provider.computeDiffCount(mockGit as unknown as SimpleGit, "abc123", "def456")
 

--- a/src/integrations/checkpoints/index.ts
+++ b/src/integrations/checkpoints/index.ts
@@ -11,9 +11,12 @@ import { MessageStateHandler } from "../../core/task/message-state"
 import { TaskMessenger } from "../../core/task/TaskMessenger"
 import { TaskState } from "../../core/task/TaskState"
 import { CheckpointDiffPresenter } from "./CheckpointDiffPresenter"
-import { CheckpointRestoreHandler } from "./CheckpointRestoreHandler"
+import { CheckpointRestoreHandler, type CreateCheckpointTracker } from "./CheckpointRestoreHandler"
 import { CheckpointStorageManager } from "./CheckpointStorageManager"
 import { ICheckpointManager } from "./types"
+
+const createCheckpointTracker: CreateCheckpointTracker = (taskId, enableCheckpoints, workspacePath) =>
+	CheckpointTracker.create(taskId, enableCheckpoints, workspacePath)
 
 type UpdateTaskHistoryFunction = (historyItem: HistoryItem) => Promise<HistoryItem[]>
 
@@ -99,6 +102,7 @@ export class TaskCheckpointManager implements ICheckpointManager {
 				messageStateHandler: services.messageStateHandler,
 				fileContextTracker: services.fileContextTracker,
 				taskState: services.taskState,
+				createCheckpointTracker,
 			},
 			{
 				cancelTask: callbacks.cancelTask,
@@ -111,7 +115,10 @@ export class TaskCheckpointManager implements ICheckpointManager {
 
 		this.diffPresenter = new CheckpointDiffPresenter(
 			{ taskId: task.taskId, enableCheckpoints: config.enableCheckpoints },
-			{ messageStateHandler: services.messageStateHandler },
+			{
+				messageStateHandler: services.messageStateHandler,
+				createCheckpointTracker,
+			},
 			this.storage,
 		)
 	}


### PR DESCRIPTION
## What
Remove mid-function service-locator `import()` in checkpoints via dependency injection:

- `CheckpointRestoreHandler` / `CheckpointDiffPresenter`: replaced `await import("...CheckpointTracker")` with an injected `createCheckpointTracker` factory.
- `index.ts`: factory wired once (`createCheckpointTracker`) and shared by both handlers (no duplication).
- `CheckpointTracker.ts`: `CheckpointUtils`/`CheckpointExclusions` now static imports (were mid-function `import()` at :158/:417/:418).
- `DiffContentProvider.ts`: exclusions (`getDefaultExclusions`/`getLfsPatterns`) **and** telemetry (`captureCheckpointUsage`) injected via ctor; removed `import("@/services/telemetry")` + now-unused `Logger`.

## Why
Service-locator mid-function `import()` hides dependencies and defeats module mocking. FB-10.

## Notes
`CheckpointTracker.getDiffSet` still duplicates `DiffContentProvider.computeDiffSet` exclusion logic — delegating the former to the latter is a separate, larger refactor (not done; tracked).

## Verification
`tsc` vs baseline: 0 new errors. `biome`: 0 errors on all 6 files. `grep "await import("` in the 4 core files: none. (Local tests blocked by pre-existing `vscode`/`node:sqlite` env issue — CI covers.)

## User test
No observable change (refactor). CI test run covers the checkpoint suites.

Closes FB-10 (FIX-BACKLOG).