### PR TITLE
refactor: inject factories over hardcoded new

### DIFF
--- a/src/core/controller/browser/discoverBrowser.ts
+++ b/src/core/controller/browser/discoverBrowser.ts
@@ -1,5 +1,6 @@
 import { discoverChromeInstances } from "@services/browser/BrowserDiscovery"
 import { BrowserSession } from "@services/browser/BrowserSession"
+import type { StateManager } from "@/core/storage/StateManager"
 import { BrowserConnection } from "@shared/proto/dirac/browser"
 import { EmptyRequest } from "@shared/proto/dirac/common"
 import { Controller } from "../index"
@@ -8,9 +9,14 @@ import { Controller } from "../index"
  * Discover Chrome instances
  * @param controller The controller instance
  * @param request The request message
+ * @param createBrowserSession Factory for creating a browser session (injectable)
  * @returns The browser connection result
  */
-export async function discoverBrowser(controller: Controller, _request: EmptyRequest): Promise<BrowserConnection> {
+export async function discoverBrowser(
+	controller: Controller,
+	_request: EmptyRequest,
+	createBrowserSession: (stateManager: StateManager) => BrowserSession = (stateManager) => new BrowserSession(stateManager),
+): Promise<BrowserConnection> {
 	try {
 		const discoveredHost = await discoverChromeInstances()
 
@@ -19,7 +25,7 @@ export async function discoverBrowser(controller: Controller, _request: EmptyReq
 			// This way we don't override the user's preference
 
 			// Test the connection to get the endpoint
-			const browserSession = new BrowserSession(controller.stateManager)
+			const browserSession = createBrowserSession(controller.stateManager)
 			const result = await browserSession.testConnection(discoveredHost)
 
 			return BrowserConnection.create({

--- a/src/core/controller/grpc-service.ts
+++ b/src/core/controller/grpc-service.ts
@@ -131,8 +131,11 @@ export class ServiceRegistry {
  * @param serviceName The name of the service
  * @returns An object with register and handle functions
  */
-export function createServiceRegistry(serviceName: string) {
-	const registry = new ServiceRegistry(serviceName)
+export function createServiceRegistry(
+	serviceName: string,
+	createRegistry: (name: string) => ServiceRegistry = (name) => new ServiceRegistry(name),
+) {
+	const registry = createRegistry(serviceName)
 
 	return {
 		registerMethod: (methodName: string, handler: ServiceMethodHandler | StreamingMethodHandler, metadata?: MethodMetadata) =>

--- a/src/core/workspace/WorkspaceResolver.ts
+++ b/src/core/workspace/WorkspaceResolver.ts
@@ -22,6 +22,11 @@ const MAX_EXAMPLE_PATHS = 5
 export class WorkspaceResolver {
 	private usageMap = new Map<string, UsageStats>()
 	private traceEnabled = process.env.MULTI_ROOT_TRACE === "true" || process.env.NODE_ENV === "development"
+	private readonly migrationReporter: MigrationReporter
+
+	constructor(migrationReporter: MigrationReporter = new MigrationReporter()) {
+		this.migrationReporter = migrationReporter
+	}
 
 	/**
 	 * Track usage statistics for a given context and path
@@ -198,8 +203,7 @@ export class WorkspaceResolver {
 	 * Currently this function is mainly called by the vscode debugger
 	 */
 	getMigrationReport(): string {
-		const reporter = new MigrationReporter()
-		return reporter.generateReport(this.usageMap, this.traceEnabled)
+		return this.migrationReporter.generateReport(this.usageMap, this.traceEnabled)
 	}
 
 	/**
@@ -250,8 +254,11 @@ export class WorkspaceResolver {
 	}
 }
 
-// Export singleton instance
-export const workspaceResolver = new WorkspaceResolver()
+// Export singleton instance (built via the factory so the construction path is single)
+export function createWorkspaceResolver(migrationReporter?: MigrationReporter): WorkspaceResolver {
+	return new WorkspaceResolver(migrationReporter)
+}
+export const workspaceResolver = createWorkspaceResolver()
 
 /**
  * Result type for multi-root workspace path resolution

--- a/src/core/workspace/__tests__/WorkspaceResolver.test.ts
+++ b/src/core/workspace/__tests__/WorkspaceResolver.test.ts
@@ -10,6 +10,7 @@ import * as path from "path"
 import * as sinon from "sinon"
 import { Logger } from "@/shared/services/Logger"
 import { WorkspaceResolver } from "../WorkspaceResolver"
+import type { MigrationReporter } from "../MigrationReporter"
 
 describe("WorkspaceResolver", () => {
 	let resolver: WorkspaceResolver
@@ -26,6 +27,13 @@ describe("WorkspaceResolver", () => {
 		loggerStub.restore()
 		process.env.MULTI_ROOT_TRACE = originalEnv
 		resolver.clearUsageStats()
+	})
+
+	it("uses the injected MigrationReporter for migration reports", () => {
+		const generateReport = sinon.stub().returns("injected report")
+		const resolverWithReporter = new WorkspaceResolver({ generateReport } as unknown as MigrationReporter)
+		expect(resolverWithReporter.getMigrationReport()).to.equal("injected report")
+		expect(generateReport.calledOnce).to.equal(true)
 	})
 
 	describe("resolveWorkspacePath - Single Root Mode", () => {

--- a/src/hosts/vscode/hostbridge-grpc-handler.ts
+++ b/src/hosts/vscode/hostbridge-grpc-handler.ts
@@ -9,13 +9,13 @@ import { Logger } from "@/shared/services/Logger"
 export type StreamingResponseHandler = (response: any, isLast?: boolean, sequenceNumber?: number) => Promise<void>
 
 // Registry to track active gRPC requests and their cleanup functions
-const requestRegistry = new GrpcRequestRegistry()
+const appRequestRegistry = new GrpcRequestRegistry()
 
 /**
  * Handles gRPC requests for the host bridge.
  */
 export class GrpcHandler {
-	constructor() {}
+	constructor(private readonly requestRegistry: GrpcRequestRegistry = appRequestRegistry) {}
 
 	/**
 	 * Handle a gRPC request for the host bridge.
@@ -62,7 +62,7 @@ export class GrpcHandler {
 		}
 
 		// Register the response handler with the registry
-		requestRegistry.registerRequest(
+		this.requestRegistry.registerRequest(
 			requestId,
 			() => {
 				Logger.log(`[DEBUG] Cleaning up streaming request: ${requestId}`)
@@ -103,12 +103,12 @@ export class GrpcHandler {
 	 * @returns True if the request was found and cancelled, false otherwise
 	 */
 	public async cancelRequest(requestId: string): Promise<boolean> {
-		const requestInfo = requestRegistry.getRequestInfo(requestId)
+		const requestInfo = this.requestRegistry.getRequestInfo(requestId)
 		if (!requestInfo) {
 			return false
 		}
 
-		const cancelled = requestRegistry.cancelRequest(requestId)
+		const cancelled = this.requestRegistry.cancelRequest(requestId)
 		if (!cancelled) {
 			Logger.log(`[DEBUG] Request not found for cancellation: ${requestId}`)
 			return false
@@ -140,7 +140,7 @@ export class GrpcHandler {
 		}
 
 		// Get the registered response handler from the registry
-		const requestInfo = requestRegistry.getRequestInfo(requestId)
+		const requestInfo = this.requestRegistry.getRequestInfo(requestId)
 		if (!requestInfo || !requestInfo.responseStream) {
 			throw new Error(`No response handler registered for request: ${requestId}`)
 		}
@@ -181,5 +181,5 @@ export interface HostServiceHandlerConfig {
  * This allows other parts of the code to access the registry
  */
 export function getRequestRegistry(): GrpcRequestRegistry {
-	return requestRegistry
+	return appRequestRegistry
 }

--- a/src/hosts/vscode/hostbridge-grpc-service.ts
+++ b/src/hosts/vscode/hostbridge-grpc-service.ts
@@ -120,8 +120,11 @@ export class ServiceRegistry {
  * @param serviceName The name of the service
  * @returns An object with register and handle functions
  */
-export function createServiceRegistry(serviceName: string) {
-	const registry = new ServiceRegistry(serviceName)
+export function createServiceRegistry(
+	serviceName: string,
+	createRegistry: (name: string) => ServiceRegistry = (name) => new ServiceRegistry(name),
+) {
+	const registry = createRegistry(serviceName)
 
 	return {
 		registerMethod: (methodName: string, handler: ServiceMethodHandler | StreamingMethodHandler, metadata?: MethodMetadata) =>


### PR DESCRIPTION
## What
Replace hard-coded `new` with injected factories/instances (FB-11):

- `discoverBrowser.ts`: `new BrowserSession(...)` → injected `createBrowserSession` factory (default preserves behavior).
- `hostbridge-grpc-handler.ts`: module-level `new GrpcRequestRegistry()` → `GrpcHandler` ctor-injected `requestRegistry` (default = shared `appRequestRegistry`, kept for `getRequestRegistry()` correlation).
- `createServiceRegistry` (both `grpc-service.ts` + duplicate in `hostbridge-grpc-service.ts`): `new ServiceRegistry(...)` → injected `createRegistry` factory.
- `WorkspaceResolver.ts`: `new MigrationReporter()` → ctor-injected (default); added `createWorkspaceResolver()` factory and routed the `workspaceResolver` singleton through it.

## Why
Constructors/factories accept injected deps so tests no longer need real singletons. Keeps `SqliteLockManager`-style statics as-is per FMEA note.

## Tests
New WorkspaceResolver test injecting a fake `MigrationReporter` (locally runnable — 18/18 pass).

## Verification
`tsc` vs baseline: 0 new. `biome`: 0 errors on all 6 files. Local WorkspaceResolver suite 18/18.

## Notes
- Deeper DRY (two duplicate `ServiceRegistry` classes) and singleton swap-ability parked in `private/review/FOLLOWUPS.md` (FU-1/FU-2).
- `discoverBrowser`/duplicate `createServiceRegistry` are near-dead / generated-caller paths; injected for completeness + testability.

## User test
No observable change (refactor). WorkspaceResolver suite runs locally; others covered by CI.

Closes FB-11 (FIX-BACKLOG).