### PR TITLE
refactor: prune non-null assertions in otel client

### DIFF
--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -53,7 +53,7 @@ export class Controller {
 	}
 
 	set task(value: Task | undefined) {
-		this.taskController!.task = value
+		this.taskController.task = value
 	}
 
 	// Promise for the in-flight task run; created inside TaskController.initTask (from main).

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -37,7 +37,7 @@ export abstract class DiffViewProvider {
 
 		if (fileExists) {
 			await HostProvider.workspace.saveOpenDocumentIfDirty({
-				filePath: this.absolutePath!,
+				filePath: this.absolutePath,
 			})
 		}
 

--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryClientProvider.ts
@@ -22,7 +22,7 @@ import {
 export class OpenTelemetryClientProvider {
 	readonly meterProvider: MeterProvider | null = null
 	readonly loggerProvider: LoggerProvider | null = null
-	private readonly config: OpenTelemetryClientValidConfig | null
+	private readonly config: OpenTelemetryClientValidConfig
 
 	/**
 	 * Check if debug diagnostics are enabled.
@@ -76,9 +76,9 @@ export class OpenTelemetryClientProvider {
 	}
 
 	private createMeterProvider(resource: Resource): MeterProvider {
-		const exporters = this.config!.metricsExporter!.split(",").map((type) => type.trim())
+		const exporters = (this.config.metricsExporter?.split(",") ?? []).map((type) => type.trim())
 		const readers: any[] = []
-		const interval = this.config!.metricExportInterval || 60000
+		const interval = this.config.metricExportInterval || 60000
 		const timeout = Math.min(Math.floor(interval * 0.8), 30000)
 
 		Logger.log(`[OTEL] Creating MeterProvider with exporters: ${exporters.join(", ")}`)
@@ -93,10 +93,10 @@ export class OpenTelemetryClientProvider {
 						break
 					}
 					case "otlp": {
-						const protocol = this.config!.otlpMetricsProtocol || this.config!.otlpProtocol || "grpc"
-						const endpoint = this.config!.otlpMetricsEndpoint || this.config!.otlpEndpoint
-						const insecure = this.config!.otlpInsecure || false
-						const headers = this.config!.otlpMetricsHeaders || this.config!.otlpHeaders
+						const protocol = this.config.otlpMetricsProtocol || this.config.otlpProtocol || "grpc"
+						const endpoint = this.config.otlpMetricsEndpoint || this.config.otlpEndpoint
+						const insecure = this.config.otlpInsecure || false
+						const headers = this.config.otlpMetricsHeaders || this.config.otlpHeaders
 
 						if (endpoint) {
 							const reader = createOTLPMetricReader(protocol, endpoint, insecure, interval, timeout, headers)
@@ -134,7 +134,7 @@ export class OpenTelemetryClientProvider {
 	}
 
 	private createLoggerProvider(resource: Resource): LoggerProvider {
-		const exporters = this.config!.logsExporter!.split(",").map((type) => type.trim())
+		const exporters = (this.config.logsExporter?.split(",") ?? []).map((type) => type.trim())
 		const loggerProvider = new LoggerProvider({ resource })
 
 		Logger.log(`[OTEL] Creating LoggerProvider with exporters: ${exporters.join(", ")}`)
@@ -149,10 +149,10 @@ export class OpenTelemetryClientProvider {
 						Logger.log("[OTEL] Console logs exporter created")
 						break
 					case "otlp": {
-						const protocol = this.config!.otlpLogsProtocol || this.config!.otlpProtocol || "grpc"
-						const endpoint = this.config!.otlpLogsEndpoint || this.config!.otlpEndpoint
-						const insecure = this.config!.otlpInsecure || false
-						const headers = this.config!.otlpLogsHeaders || this.config!.otlpHeaders
+						const protocol = this.config.otlpLogsProtocol || this.config.otlpProtocol || "grpc"
+						const endpoint = this.config.otlpLogsEndpoint || this.config.otlpEndpoint
+						const insecure = this.config.otlpInsecure || false
+						const headers = this.config.otlpLogsHeaders || this.config.otlpHeaders
 
 						if (endpoint) {
 							exporter = createOTLPLogExporter(protocol, endpoint, insecure, headers)
@@ -170,9 +170,9 @@ export class OpenTelemetryClientProvider {
 
 				if (exporter) {
 					const batchConfig = {
-						maxQueueSize: this.config!.logMaxQueueSize || 2048,
-						maxExportBatchSize: this.config!.logBatchSize || 512,
-						scheduledDelayMillis: this.config!.logBatchTimeout || 5000,
+						maxQueueSize: this.config.logMaxQueueSize || 2048,
+						maxExportBatchSize: this.config.logBatchSize || 512,
+						scheduledDelayMillis: this.config.logBatchTimeout || 5000,
 					}
 
 					loggerProvider.addLogRecordProcessor(new BatchLogRecordProcessor(exporter, batchConfig))


### PR DESCRIPTION
## What
FB-12 chunk 1 — prune non-null assertions in `OpenTelemetryClientProvider.ts` (19 sites):

- `config: OpenTelemetryClientValidConfig | null` → non-null (it's `readonly`, ctor-set, never nulled) → removes 17× `this.config!`.
- `metricsExporter!` / `logsExporter!` (optional props) → `?.split(",") ?? []` (identical when present; removes latent crash when absent).

## Why
FB-12: replace genuine-nullable assertions with correct types/optional chaining; drop assertions that were over-cautious typing.

## Verification
`tsc` vs baseline: 0 new. `biome` clean. `rg` non-null in file: 0. Rebased onto latest master (15 commits pulled).

## User test
No observable change (refactor). OTel providers covered by CI.

Closes FB-12 (partial — chunk 1).