### PR TITLE
test: cover StreamChunkCoordinator + StreamingMetricsManager

### DIFF
--- a/src/core/task/__tests__/StreamChunkCoordinator.test.ts
+++ b/src/core/task/__tests__/StreamChunkCoordinator.test.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from "node:assert"
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import type { ApiStream, ApiStreamChunk } from "@core/api/transform/stream"
+import { StreamChunkCoordinator } from "../StreamChunkCoordinator"
+
+function makeStream(chunks: ApiStreamChunk[], onReturn?: () => void): ApiStream {
+	let index = 0
+	const iterator: AsyncIterator<ApiStreamChunk> = {
+		next: async () => (index < chunks.length ? { value: chunks[index++], done: false } : { value: undefined, done: true }),
+		return: async () => {
+			onReturn?.()
+			return { value: undefined, done: true }
+		},
+	}
+	return { [Symbol.asyncIterator]: () => iterator } as unknown as ApiStream
+}
+
+describe("StreamChunkCoordinator", () => {
+	it("routes usage chunks to onUsageChunk and queues non-usage chunks", async () => {
+		const usageChunks: unknown[] = []
+		const coordinator = new StreamChunkCoordinator(
+			makeStream([{ type: "usage", inputTokens: 1, outputTokens: 1 }, { type: "text", text: "hi" }]),
+			{ onUsageChunk: (chunk) => usageChunks.push(chunk) },
+		)
+
+		expect(await coordinator.nextChunk()).to.deep.equal({ type: "text", text: "hi" })
+		expect(usageChunks).to.have.length(1)
+		await coordinator.waitForCompletion()
+	})
+
+	it("returns chunks in stream order", async () => {
+		const coordinator = new StreamChunkCoordinator(
+			makeStream([{ type: "text", text: "a" }, { type: "reasoning", reasoning: "r" }]),
+			{ onUsageChunk: () => {} },
+		)
+
+		expect((await coordinator.nextChunk())?.type).to.equal("text")
+		expect((await coordinator.nextChunk())?.type).to.equal("reasoning")
+		expect(await coordinator.nextChunk()).to.equal(undefined)
+	})
+
+	it("rethrows when the underlying stream errors", async () => {
+		const badStream = {
+			[Symbol.asyncIterator]: () => ({
+				next: async () => {
+					throw new Error("stream boom")
+				},
+				return: async () => ({ value: undefined, done: true }),
+			}),
+		} as unknown as ApiStream
+		const coordinator = new StreamChunkCoordinator(badStream, { onUsageChunk: () => {} })
+
+		await assert.rejects(() => coordinator.nextChunk(), /stream boom/)
+	})
+
+	it("closes the stream iterator on stop", async () => {
+		let closed = false
+		const coordinator = new StreamChunkCoordinator(makeStream([{ type: "text", text: "a" }], () => (closed = true)), {
+			onUsageChunk: () => {},
+		})
+		await coordinator.stop()
+		expect(closed).to.equal(true)
+	})
+})

--- a/src/core/task/__tests__/StreamingMetricsManager.test.ts
+++ b/src/core/task/__tests__/StreamingMetricsManager.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { StreamingMetricsManager } from "../StreamingMetricsManager"
+
+function stubApi(contextWindow?: number) {
+	return {
+		getModel: () => ({ info: { contextWindow } }),
+	} as any
+}
+
+describe("StreamingMetricsManager", () => {
+	it("merges usage chunks into running totals", () => {
+		const manager = new StreamingMetricsManager({} as any, 0, stubApi() as any)
+		manager.updateFromChunk({ inputTokens: 10, outputTokens: 5, reasoningTokens: 2 })
+		manager.updateFromChunk({ inputTokens: 10, outputTokens: 5, cacheWriteTokens: 3, cacheReadTokens: 4 })
+
+		expect(manager.getMetrics()).to.deep.equal({
+			inputTokens: 10,
+			outputTokens: 5,
+			reasoningTokens: 2,
+			cacheWriteTokens: 3,
+			cacheReadTokens: 4,
+			totalCost: undefined,
+		})
+	})
+
+	it("falls back to thoughtsTokenCount for reasoning and keeps prior cache values", () => {
+		const manager = new StreamingMetricsManager({} as any, 0, stubApi() as any)
+		manager.updateFromChunk({ inputTokens: 1, outputTokens: 1, thoughtsTokenCount: 7 })
+		// a later chunk without cache values must keep the previous ones
+		manager.updateFromChunk({ inputTokens: 1, outputTokens: 1, cacheWriteTokens: 9 })
+		manager.updateFromChunk({ inputTokens: 1, outputTokens: 1 })
+
+		expect(manager.getMetrics().reasoningTokens).to.equal(7)
+		expect(manager.getMetrics().cacheWriteTokens).to.equal(9)
+	})
+
+	it("returns the provider-calculated total cost when present", () => {
+		const manager = new StreamingMetricsManager({} as any, 0, stubApi() as any)
+		manager.updateFromChunk({ inputTokens: 10, outputTokens: 5, totalCost: 1.23 })
+		expect(manager.getTotalCost()).to.equal(1.23)
+	})
+
+	it("computes cost via calculateCost when provider totalCost is absent", () => {
+		const manager = new StreamingMetricsManager({} as any, 0, stubApi(100_000) as any)
+		manager.updateFromChunk({ inputTokens: 0, outputTokens: 0 })
+		// zero tokens and no provider cost -> calculateCost yields 0
+		expect(manager.getTotalCost()).to.equal(0)
+	})
+
+	it("getMetrics returns a snapshot, not a live reference", () => {
+		const manager = new StreamingMetricsManager({} as any, 0, stubApi() as any)
+		const snapshot = manager.getMetrics()
+		snapshot.inputTokens = 999
+		expect(manager.getMetrics().inputTokens).to.equal(0)
+	})
+})


### PR DESCRIPTION
## What
FB-14 (test-enabler, partial) — add unit tests for two previously-untested core/task modules:

- `StreamChunkCoordinator.test.ts` (4): usage→callback routing + non-usage queue, in-order delivery, stream-error rethrow, `stop()` closes iterator.
- `StreamingMetricsManager.test.ts` (5): usage-chunk merge totals, `thoughtsTokenCount` fallback + cache-keeps-prior, provider `totalCost` path, `calculateCost` fallback, snapshot isolation.

## Why
FB-14: raise core/task coverage ahead of the god-module work. Test-only — zero production change.

## Verification
9/9 passing locally (no vscode/sqlite blocker). 0 new `tsc` errors. `biome` clean.

## Note
A would-be `steering.test.ts` addition was dropped — that suite already exists on master and covers steering restore/format; caught a near-clobber and restored it unchanged.

FB-14 (partial — enabler chunk).