### PR TITLE
refactor: type task metadata, drop any

### DIFF
--- a/src/core/commands/reconstructTaskHistory.ts
+++ b/src/core/commands/reconstructTaskHistory.ts
@@ -1,4 +1,5 @@
 import { getSavedDiracMessages, getTaskMetadata, readTaskHistoryFromState, writeTaskHistoryToState } from "@core/storage/disk"
+import type { TaskMetadata } from "@core/context/context-tracking/ContextTrackerTypes"
 import { HostProvider } from "@hosts/host-provider"
 import { DiracMessage, DiracMessageType } from "@shared/ExtensionMessage"
 import { HistoryItem } from "@shared/HistoryItem"
@@ -213,7 +214,7 @@ interface TaskInfo {
 	conversationHistoryDeletedRange?: [number, number]
 }
 
-function extractTaskInformation(diracMessages: DiracMessage[], metadata: any): TaskInfo {
+function extractTaskInformation(diracMessages: DiracMessage[], metadata: TaskMetadata): TaskInfo {
 	// Find the first user message (task description)
 	const firstUserMessage = diracMessages.find(
 		(msg) => msg.content.type === DiracMessageType.MARKDOWN && !msg.content.isReasoning && msg.content.content,

--- a/src/core/context/context-tracking/ContextTrackerTypes.ts
+++ b/src/core/context/context-tracking/ContextTrackerTypes.ts
@@ -13,6 +13,12 @@ export interface ModelMetadataEntry {
 	model_id: string
 	model_provider_id: string
 	mode: string
+	// Token/cost metrics present in older persisted records; absent from new writes.
+	tokensIn?: number
+	tokensOut?: number
+	cacheWrites?: number
+	cacheReads?: number
+	totalCost?: number
 }
 
 export interface EnvironmentMetadataEntry {


### PR DESCRIPTION
## What
FB-8c — type `reconstructTaskHistory`'s `metadata` (`any` → `TaskMetadata`):
- `ModelMetadataEntry` gains optional legacy token/cost fields (`tokensIn?/tokensOut?/cacheWrites?/cacheReads?/totalCost?`) — current writes carry only identifying fields; legacy records carry cost.
- `extractTaskInformation(diracMessages, metadata: TaskMetadata)`.

## Why
The declared type already matched current writes; the reads targeted optional legacy cost fields. Modeling them as optional makes the persisted shape accurate and removes the `any`.

## Verification
`tsc` clean · `biome` clean · no `any` remains in `reconstructTaskHistory`. (Local test blocked by pre-existing vscode env issue — CI covers.)

Closes FB-8c (FIX-BACKLOG).