### PR TITLE
test: expand TaskState coverage

### DIFF
--- a/src/core/task/__tests__/TaskState.test.ts
+++ b/src/core/task/__tests__/TaskState.test.ts
@@ -1,8 +1,47 @@
 import { strict as assert } from "node:assert"
 import { describe, it } from "mocha"
+import { TaskStatus } from "@shared/ExtensionMessage"
 import { TaskState } from "../TaskState"
+import { SteeringDeliveryState } from "../steering"
 
-describe("TaskState cancellation", () => {
+describe("TaskState", () => {
+	it("initializes with sane defaults", () => {
+		const state = new TaskState()
+		assert.equal(state.status, TaskStatus.IDLE)
+		assert.equal(state.isInitialized, false)
+		assert.equal(state.isApiRequestActive, false)
+		assert.equal(state.didCompleteReadingStream, false)
+		assert.equal(state.abandoned, false)
+		assert.equal(state.totalToolCallCount, 0)
+		assert.equal(state.consecutiveMistakeCount, 0)
+		assert.equal(state.apiErrorRetryAttempts, 0)
+		assert.equal(state.emptyResponseRetryAttempts, 0)
+		assert.equal(state.totalCost, 0)
+		assert.equal(state.totalInputTokens, 0)
+		assert.equal(state.totalOutputTokens, 0)
+		assert.equal(state.totalCacheWriteTokens, 0)
+		assert.equal(state.totalCacheReadTokens, 0)
+		assert.deepEqual(state.waitingCardIds, [])
+		assert.deepEqual(state.toolUseIdMap, new Map())
+		assert.deepEqual(state.steeringMessages, [])
+		assert.deepEqual(state.availableSkills, [])
+		assert.deepEqual(state.activeSkillIds, [])
+		assert.equal(state.taskLockAcquired, false)
+		assert.equal(state.abort, false)
+		assert.ok(Number.isFinite(state.taskStartTimeMs))
+	})
+
+	it("exposes the first waiting card id FIFO", () => {
+		const state = new TaskState()
+		assert.equal(state.lastWaitingCardId, undefined)
+		state.waitingCardIds.push("card-1", "card-2")
+		assert.equal(state.lastWaitingCardId, "card-1")
+		state.waitingCardIds.unshift("card-0")
+		assert.equal(state.lastWaitingCardId, "card-0")
+		state.waitingCardIds.shift()
+		assert.equal(state.lastWaitingCardId, "card-1")
+	})
+
 	it("aborts the current signal and creates a fresh signal when reset", () => {
 		const state = new TaskState()
 		const initialSignal = state.abortSignal
@@ -20,5 +59,61 @@ describe("TaskState cancellation", () => {
 		assert.equal(state.abort, false)
 		assert.notEqual(state.abortSignal, initialSignal)
 		assert.equal(state.abortSignal.aborted, false)
+	})
+
+	it("is idempotent when aborting an already-aborted controller", () => {
+		const state = new TaskState()
+		const signal = state.abortSignal
+		state.abort = true
+		state.abort = true // second abort must not swap the signal
+		assert.equal(state.abortSignal, signal)
+		assert.equal(state.abortSignal.aborted, true)
+	})
+
+	it("tracks tool execution and retry flags independently", () => {
+		const state = new TaskState()
+		state.didRejectTool = true
+		state.didAlreadyUseTool = true
+		state.didEditFile = true
+		state.consecutiveMistakeCount = 3
+		state.apiErrorRetryAttempts += 1
+		state.emptyResponseRetryAttempts += 2
+
+		assert.equal(state.didRejectTool, true)
+		assert.equal(state.didAlreadyUseTool, true)
+		assert.equal(state.didEditFile, true)
+		assert.equal(state.consecutiveMistakeCount, 3)
+		assert.equal(state.apiErrorRetryAttempts, 1)
+		assert.equal(state.emptyResponseRetryAttempts, 2)
+	})
+
+	it("maps tool names to ids and accumulates metrics", () => {
+		const state = new TaskState()
+		state.toolUseIdMap.set("read_file", "toolu_1")
+		state.totalInputTokens += 100
+		state.totalOutputTokens += 50
+		state.totalCost += 1.25
+		state.totalToolCallCount += 1
+
+		assert.equal(state.toolUseIdMap.get("read_file"), "toolu_1")
+		assert.equal(state.totalInputTokens, 100)
+		assert.equal(state.totalOutputTokens, 50)
+		assert.equal(state.totalCost, 1.25)
+		assert.equal(state.totalToolCallCount, 1)
+	})
+
+	it("records a pending task replacement", () => {
+		const state = new TaskState()
+		state.pendingTaskReplacement = { context: "do the next thing" }
+		assert.deepEqual(state.pendingTaskReplacement, { context: "do the next thing" })
+		state.pendingTaskReplacement = undefined
+		assert.equal(state.pendingTaskReplacement, undefined)
+	})
+
+	it("accumulates steering messages", () => {
+		const state = new TaskState()
+		state.steeringMessages.push({ id: "s1", text: "steer", createdAt: 1, transcriptMessageId: "m1", deliveryState: SteeringDeliveryState.QUEUED })
+		assert.equal(state.steeringMessages.length, 1)
+		assert.equal(state.steeringMessages[0].text, "steer")
 	})
 })


### PR DESCRIPTION
## What
FB-14 (TaskState part) — replace the 24-line/1-test `TaskState.test.ts` stub with 8 focused tests:
- default field values, `lastWaitingCardId` FIFO, abort lifecycle + idempotency, tool/retry flags, tool_use map + metrics, pending task replacement, steering accumulation.

## Why
FB-14: raise core/task coverage ahead of the god-module work (FB-15). Test-only.

## Verification
8/8 passing locally. `tsc` clean. `biome` clean.

## Note
Complements earlier FB-14 coverage (StreamChunkCoordinator + StreamingMetricsManager, #159). The huge Task class in core/task/index.ts still isn't unit-tested (that's the FB-15 refactor's own work).

FB-14 (further).