### PR TITLE
build: unblock test compilation (vscode LM members + node:sqlite types)

### DIFF
--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -436,7 +436,7 @@ export class LanguageModelChat {
 		_options: LanguageModelChatRequestOptions,
 		_token?: unknown,
 	): Promise<LanguageModelChatResponse> {
-		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+		return Promise.resolve(new LanguageModelChatResponse(this.send().stream))
 	}
 }
 

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -352,3 +352,96 @@ export type Extension<T> = any
  * Components can listen to this to clean up UI before process exit.
  */
 export const shutdownEvent = new EventEmitter<void>()
+
+// ============================================================================
+// Language Model API members (used by vscode-lm provider + transform tests)
+// ============================================================================
+
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
+export class LanguageModelTextPart {
+	public readonly value: string
+	public readonly text: string
+	constructor(text: string) {
+		this.value = text
+		this.text = text
+	}
+}
+
+export enum LanguageModelChatMessageRole {
+	User = 1,
+	Assistant = 2,
+}
+
+export class LanguageModelToolCallPart {
+	constructor(
+		public readonly callId: string,
+		public readonly name: string,
+		public readonly input: unknown,
+	) {}
+}
+
+export class LanguageModelToolResultPart {
+	constructor(
+		public readonly callId: string,
+		public readonly content: LanguageModelTextPart[],
+	) {}
+}
+
+export type LanguageModelChatContentPart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart
+
+export class LanguageModelChatMessage {
+	constructor(
+		public readonly role: LanguageModelChatMessageRole,
+		public readonly content: LanguageModelChatContentPart[],
+	) {}
+
+	static User(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.User, toParts(content))
+	}
+	static Assistant(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, toParts(content))
+	}
+}
+
+function toParts(content: string | LanguageModelChatContentPart[]): LanguageModelChatContentPart[] {
+	return typeof content === "string" ? [new LanguageModelTextPart(content)] : content
+}
+
+export interface LanguageModelChatRequestOptions {
+	justification?: string
+	tools?: unknown[]
+}
+
+export class LanguageModelChatResponse {
+	public readonly stream: AsyncIterable<LanguageModelChatContentPart>
+	constructor(stream: AsyncIterable<LanguageModelChatContentPart>) {
+		this.stream = stream
+	}
+}
+
+export class LanguageModelChat {
+	constructor(
+		public readonly name: string,
+		public readonly vendor: string,
+		private readonly send = () => ({ stream: (async function* () {})() as AsyncIterable<LanguageModelChatContentPart> }),
+	) {}
+	sendRequest(
+		_messages: LanguageModelChatMessage[],
+		_options: LanguageModelChatRequestOptions,
+		_token?: unknown,
+	): Promise<LanguageModelChatResponse> {
+		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+	}
+}
+
+export namespace lm {
+	export function selectChatModels(_selector: LanguageModelChatSelector): Promise<LanguageModelChat[]> {
+		return Promise.resolve([])
+	}
+}

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,13 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
 export class LanguageModelTextPart {
 	constructor(public value: string) { }
 }

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for `node:sqlite` (available at runtime on the Node
+ * version this project runs, but the bundled `@types/node` does not ship them).
+ * Only models the subset used by `SymbolIndexDatabase`.
+ */
+declare module "node:sqlite" {
+	interface StatementResult {
+		changes: number | bigint
+		lastInsertRowid: number | bigint
+	}
+	interface StatementSync {
+		get(...args: unknown[]): Record<string, unknown> | undefined
+		all(...args: unknown[]): Record<string, unknown>[]
+		iterate(...args: unknown[]): IterableIterator<Record<string, unknown>>
+		run(...args: unknown[]): StatementResult
+	}
+	class DatabaseSync {
+		constructor(path: string)
+		prepare(sql: string, ...args: unknown[]): StatementSync
+		exec(sql: string): void
+		close(): void
+	}
+	export { DatabaseSync, type StatementSync }
+}


### PR DESCRIPTION
## Summary
- Add `node:sqlite` ambient type declarations (`src/types/node-sqlite.d.ts`) — unblocks compilation of files importing the experimental `node:sqlite` module.
- Shim VS Code Language Model API members in `cli/src/vscode-shim.ts` (LanguageModelChat, LanguageModelChatMessage, LanguageModelTextPart/ToolCallPart/ToolResultPart, LanguageModelChatResponse, lm.selectChatModels) — unblocks CLI compilation of files referencing `vscode.LanguageModel*`.
- Add `LanguageModelChatSelector` to `src/test/vscode-mock.ts` — unblocks mocha test compilation for files referencing `vscode.LanguageModelChatSelector`.
- Fix `LanguageModelChatResponse` constructor call: pass `this.send().stream` (AsyncIterable) instead of `this.send()` ({ stream: AsyncIterable }).

## Why
Tests and CLI compilation were blocked by missing type declarations for `node:sqlite` and VS Code LM API members. These shims provide minimal no-op implementations so the code compiles without the real VS Code runtime.

#### Test plan
- [ ] `tsc` clean on `cli/src/vscode-shim.ts` and `src/test/vscode-mock.ts`
- [ ] `npm run compile` succeeds
- [ ] VS Code LM API referencing files compile under CLI target

Generated with [Devin](https://devin.ai)