### PR TITLE
refactor(fb15b): split bedrock.ts into focused modules

### DIFF
--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -436,7 +436,7 @@ export class LanguageModelChat {
 		_options: LanguageModelChatRequestOptions,
 		_token?: unknown,
 	): Promise<LanguageModelChatResponse> {
-		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+		return Promise.resolve(new LanguageModelChatResponse(this.send().stream))
 	}
 }
 

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -352,3 +352,96 @@ export type Extension<T> = any
  * Components can listen to this to clean up UI before process exit.
  */
 export const shutdownEvent = new EventEmitter<void>()
+
+// ============================================================================
+// Language Model API members (used by vscode-lm provider + transform tests)
+// ============================================================================
+
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
+export class LanguageModelTextPart {
+	public readonly value: string
+	public readonly text: string
+	constructor(text: string) {
+		this.value = text
+		this.text = text
+	}
+}
+
+export enum LanguageModelChatMessageRole {
+	User = 1,
+	Assistant = 2,
+}
+
+export class LanguageModelToolCallPart {
+	constructor(
+		public readonly callId: string,
+		public readonly name: string,
+		public readonly input: unknown,
+	) {}
+}
+
+export class LanguageModelToolResultPart {
+	constructor(
+		public readonly callId: string,
+		public readonly content: LanguageModelTextPart[],
+	) {}
+}
+
+export type LanguageModelChatContentPart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart
+
+export class LanguageModelChatMessage {
+	constructor(
+		public readonly role: LanguageModelChatMessageRole,
+		public readonly content: LanguageModelChatContentPart[],
+	) {}
+
+	static User(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.User, toParts(content))
+	}
+	static Assistant(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, toParts(content))
+	}
+}
+
+function toParts(content: string | LanguageModelChatContentPart[]): LanguageModelChatContentPart[] {
+	return typeof content === "string" ? [new LanguageModelTextPart(content)] : content
+}
+
+export interface LanguageModelChatRequestOptions {
+	justification?: string
+	tools?: unknown[]
+}
+
+export class LanguageModelChatResponse {
+	public readonly stream: AsyncIterable<LanguageModelChatContentPart>
+	constructor(stream: AsyncIterable<LanguageModelChatContentPart>) {
+		this.stream = stream
+	}
+}
+
+export class LanguageModelChat {
+	constructor(
+		public readonly name: string,
+		public readonly vendor: string,
+		private readonly send = () => ({ stream: (async function* () {})() as AsyncIterable<LanguageModelChatContentPart> }),
+	) {}
+	sendRequest(
+		_messages: LanguageModelChatMessage[],
+		_options: LanguageModelChatRequestOptions,
+		_token?: unknown,
+	): Promise<LanguageModelChatResponse> {
+		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+	}
+}
+
+export namespace lm {
+	export function selectChatModels(_selector: LanguageModelChatSelector): Promise<LanguageModelChat[]> {
+		return Promise.resolve([])
+	}
+}

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -357,6 +357,8 @@ export const shutdownEvent = new EventEmitter<void>()
 // Language Model API members (used by vscode-lm provider + transform tests)
 // ============================================================================
 
+// Keep LM shapes in sync with src/test/vscode-mock.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/core/api/providers/bedrock-client.ts
+++ b/src/core/api/providers/bedrock-client.ts
@@ -1,0 +1,89 @@
+/**
+ * Bedrock AWS auth + client construction. Extracted from `bedrock.ts` (FB-15b).
+ * Takes the subset of provider options it needs so it never imports the handler.
+ */
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime"
+
+export interface AwsBedrockClientOptions {
+	awsAuthentication?: string
+	awsUseProfile?: boolean
+	awsAccessKey?: string
+	awsSecretKey?: string
+	awsSessionToken?: string
+	awsProfile?: string
+	awsRegion?: string
+	awsBedrockApiKey?: string
+	awsBedrockEndpoint?: string
+}
+
+/** Returns the AWS region to use for the given options, with a default fallback. */
+export function resolveRegion(options: AwsBedrockClientOptions, defaultRegion: string): string {
+	return options.awsRegion || defaultRegion
+}
+
+/** Builds an AWS credentials resolver chain, then a BedrockRuntimeClient. */
+/** Resolves AWS credentials from options or the node provider chain, without mutating env. */
+export async function resolveAwsCredentials(
+	options: AwsBedrockClientOptions,
+	region: string,
+	userAgentAppId: string,
+): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
+	const useProfile =
+		(options.awsAuthentication === undefined && options.awsUseProfile) ||
+		options.awsAuthentication === "profile"
+	if (!useProfile && options.awsAccessKey && options.awsSecretKey) {
+		return {
+			accessKeyId: options.awsAccessKey,
+			secretAccessKey: options.awsSecretKey,
+			sessionToken: options.awsSessionToken,
+		}
+	}
+	const providerOptions: {
+		clientConfig: { userAgentAppId: string; region?: string }
+		ignoreCache?: boolean
+		profile?: string
+	} = {
+		clientConfig: { userAgentAppId },
+	}
+	providerOptions.clientConfig.region = region
+	if (useProfile) {
+		providerOptions.ignoreCache = true
+		if (options.awsProfile) providerOptions.profile = options.awsProfile
+	}
+	return await fromNodeProviderChain(providerOptions as never)()
+}
+
+
+
+export async function createBedrockClient(
+	options: AwsBedrockClientOptions,
+	defaultRegion: string,
+	userAgentAppId: string,
+): Promise<BedrockRuntimeClient> {
+	const region = resolveRegion(options, defaultRegion)
+
+	let auth: unknown
+	if (options.awsAuthentication === "apikey") {
+		auth = {
+			token: { token: options.awsBedrockApiKey },
+			authSchemePreference: ["httpBearerAuth"],
+		}
+	} else {
+		const credentials = await resolveAwsCredentials(options, region, userAgentAppId)
+		auth = {
+			credentials: {
+				accessKeyId: credentials.accessKeyId,
+				secretAccessKey: credentials.secretAccessKey,
+				sessionToken: credentials.sessionToken,
+			},
+		}
+	}
+
+	return new BedrockRuntimeClient({
+		userAgentAppId,
+		region,
+		...(auth as Record<string, unknown>),
+		...(options.awsBedrockEndpoint ? { endpoint: options.awsBedrockEndpoint } : {}),
+	})
+}

--- a/src/core/api/providers/bedrock-converse-utils.ts
+++ b/src/core/api/providers/bedrock-converse-utils.ts
@@ -2,6 +2,12 @@
  * Pure helpers shared by the Bedrock provider. Extracted out of
  * `src/core/api/providers/bedrock.ts` (FB-15b) — no class state.
  */
+import { calculateApiCostOpenAI } from "@utils/cost"
+import { Logger } from "@/shared/services/Logger"
+import { getErrorMessage } from "@/shared/errors"
+import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/index"
+import type { ContentBlock, Message, ToolConfiguration } from "@aws-sdk/client-bedrock-runtime"
+import type { DiracTool } from "@/shared/tools"
 
 /** Approximate token count (4 characters per token). */
 export function estimateTokenCount(text: string): number {
@@ -54,4 +60,79 @@ export function* chunkText(text: string, type: "text" | "reasoning"): Generator<
 		const chunk = text.slice(i, Math.min(i + chunkSize, text.length))
 		yield type === "reasoning" ? { type: "reasoning", reasoning: chunk } : { type: "text", text: chunk }
 	}
+}
+
+/** Cache-point content block type for AWS Bedrock Converse prompt caching. */
+interface CachePointContentBlockShape {
+	cachePoint: { type: "default" }
+}
+
+/**
+ * Converts Dirac's tool definitions (Anthropic format with `input_schema`) to the
+ * Bedrock Converse API `ToolConfiguration` shape.
+ */
+export function mapDiracToolsToBedrockToolConfig(tools?: DiracTool[]): ToolConfiguration | undefined {
+	if (!tools || tools.length === 0) {
+		return undefined
+	}
+	const isAnthropicTool = (tool: DiracTool): tool is AnthropicTool => "input_schema" in tool
+	const bedrockTools = tools.filter(isAnthropicTool).map((tool) => ({
+		toolSpec: {
+			name: tool.name,
+			description: tool.description || tool.name || "Tool",
+			inputSchema: { json: tool.input_schema },
+		},
+	}))
+	if (bedrockTools.length === 0) {
+		return undefined
+	}
+	return {
+		tools: bedrockTools as unknown as ToolConfiguration["tools"],
+		toolChoice: { auto: {} },
+	}
+}
+
+/** Converts a Dirac image content block into a Bedrock image content block. */
+export function processImageContent(item: any): ContentBlock | null {
+	let imageData: Uint8Array
+	let format: "png" | "jpeg" | "gif" | "webp" = "jpeg"
+	if (item.source.media_type) {
+		const formatMatch = item.source.media_type.match(/image\/(\w+)/)
+		if (formatMatch && formatMatch[1] && ["png", "jpeg", "gif", "webp"].includes(formatMatch[1])) {
+			format = formatMatch[1] as "png" | "jpeg" | "gif" | "webp"
+		}
+	}
+	try {
+		if (typeof item.source.data === "string") {
+			const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
+			imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
+		} else if (item.source.data && typeof item.source.data === "object") {
+			imageData = new Uint8Array(Buffer.from(item.source.data as Buffer | Uint8Array))
+		} else {
+			throw new Error("Unsupported image data format")
+		}
+		return { image: { format, source: { bytes: imageData } } }
+	} catch (error) {
+		Logger.error("Failed to process image content:", error)
+		return { text: `[ERROR: Failed to process image - ${getErrorMessage(error, "Unknown error")}]` }
+	}
+}
+
+/** Applies Bedrock cache-point markers to the last + second-to-last user messages. */
+export function applyCacheControlToMessages(messages: Message[], userIndices: [number, number]): Message[] {
+	const [, lastUserMsgIndex] = userIndices
+	const secondLastMsgUserIndex = userIndices[0] ?? -1
+	return messages.map((message, index) => {
+		if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
+			const messageWithCache = { ...message }
+			if (messageWithCache.content && Array.isArray(messageWithCache.content)) {
+				messageWithCache.content = [
+					...messageWithCache.content,
+					{ cachePoint: { type: "default" } } as CachePointContentBlockShape,
+				]
+			}
+			return messageWithCache
+		}
+		return message
+	})
 }

--- a/src/core/api/providers/bedrock-converse-utils.ts
+++ b/src/core/api/providers/bedrock-converse-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helpers shared by the Bedrock provider. Extracted out of
+ * `src/core/api/providers/bedrock.ts` (FB-15b) — no class state.
+ */
+
+/** Approximate token count (4 characters per token). */
+export function estimateTokenCount(text: string): number {
+	return Math.ceil(text.length / 4)
+}
+
+/** Extracts the visible text + reasoning text from a non-streaming Converse response. */
+export function extractNonStreamingContent(response: any): { fullText: string; reasoningText: string } {
+	let fullText = ""
+	let reasoningText = ""
+	if (!response.output?.message?.content) return { fullText, reasoningText }
+	for (const block of response.output.message.content) {
+		if ("reasoningContent" in block && block.reasoningContent) {
+			const reasoning = block.reasoningContent
+			if ("reasoningText" in reasoning && reasoning.reasoningText && "text" in reasoning.reasoningText) {
+				reasoningText += reasoning.reasoningText.text
+			}
+		} else if ("text" in block && block.text) {
+			fullText += block.text
+		}
+	}
+	return { fullText, reasoningText }
+}
+
+/** Formats an unknown error for the Converse error message, naming it when present. */
+export function formatConverseError(error: unknown, label: string): string {
+	if (error instanceof Error) {
+		const named = error as Error & { name?: string }
+		return named.name ? `${named.name}: ${error.message}` : error.message
+	}
+	return `Failed to process ${label} model request`
+}

--- a/src/core/api/providers/bedrock-converse-utils.ts
+++ b/src/core/api/providers/bedrock-converse-utils.ts
@@ -8,6 +8,8 @@ import { getErrorMessage } from "@/shared/errors"
 import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/index"
 import type { ContentBlock, Message, ToolConfiguration } from "@aws-sdk/client-bedrock-runtime"
 import type { DiracTool } from "@/shared/tools"
+import type { DiracStorageMessage } from "@/shared/messages/content"
+import { ConversationRole } from "@aws-sdk/client-bedrock-runtime"
 
 /** Approximate token count (4 characters per token). */
 export function estimateTokenCount(text: string): number {
@@ -135,4 +137,81 @@ export function applyCacheControlToMessages(messages: Message[], userIndices: [n
 		}
 		return message
 	})
+}
+
+export interface ContentItem {
+	type: string
+	text?: string
+	source?: unknown
+}
+
+/** Converts Dirac (Anthropic-format) messages to Bedrock Converse `Message[]`. */
+export function formatMessagesForConverseAPI(messages: DiracStorageMessage[], supportsImages = true): Message[] {
+	return messages.map((message) => {
+		const role = message.role === "user" ? ConversationRole.USER : ConversationRole.ASSISTANT
+		let content: ContentBlock[] = []
+		if (typeof message.content === "string") {
+			content = [{ text: message.content }]
+		} else if (Array.isArray(message.content)) {
+			content = message.content
+				.map((item) => {
+					if (item.type === "text") return { text: item.text }
+					if (item.type === "image") {
+						if (supportsImages) return processImageContent(item)
+						return { text: "[Image]" }
+					}
+					if (item.type === "tool_use") {
+						return {
+							toolUse: { toolUseId: item.id, name: item.name, input: item.input },
+						}
+					}
+					if (item.type === "thinking" || item.type === "redacted_thinking") return null
+					if (item.type === "tool_result") {
+						const toolResultContent = (() => {
+							if (typeof item.content === "string") return [{ text: item.content }]
+							if (Array.isArray(item.content)) {
+								return item.content
+									.map((block) => {
+										if (block.type === "text") return { text: block.text }
+										if (block.type === "image") {
+											if (supportsImages) return processImageContent(block)
+											return { text: "[Image]" }
+										}
+										return null
+									})
+									.filter((block): block is ContentBlock => block !== null)
+							}
+							return [{ text: JSON.stringify(item.content) }]
+						})()
+						return {
+							toolResult: {
+								toolUseId: item.tool_use_id,
+								content: toolResultContent,
+								status: item.is_error ? "error" : "success",
+							},
+						}
+					}
+					Logger.warn(`Unsupported content type: ${(item as ContentItem).type}`)
+					return null
+				})
+				.filter((item): item is ContentBlock => item !== null)
+		}
+		return { role, content }
+	})
+}
+
+/** Gets the Bedrock Converse inference configuration for a model type. */
+export function getInferenceConfig(modelInfo: unknown, modelType: "anthropic" | "nova", thinkingBudgetTokens: number): any {
+	const mi = modelInfo as { supportsReasoning?: boolean; maxTokens?: number; temperature?: number }
+	if (modelType === "anthropic") {
+		const reasoningOn = !!mi.supportsReasoning && thinkingBudgetTokens > 0
+		return {
+			maxTokens: mi.maxTokens || 8192,
+			temperature: reasoningOn ? undefined : (mi.temperature ?? undefined),
+		}
+	}
+	return {
+		maxTokens: mi.maxTokens || (modelType === "nova" ? 5000 : 8192),
+		temperature: mi.temperature ?? 0,
+	}
 }

--- a/src/core/api/providers/bedrock-converse-utils.ts
+++ b/src/core/api/providers/bedrock-converse-utils.ts
@@ -34,3 +34,24 @@ export function formatConverseError(error: unknown, label: string): string {
 	}
 	return `Failed to process ${label} model request`
 }
+
+/** Prepares system messages with optional Converse caching support. */
+export function prepareSystemMessages(systemPrompt: string, enableCaching: boolean): any[] | undefined {
+	if (!systemPrompt) {
+		return undefined
+	}
+	if (enableCaching) {
+		return [{ text: systemPrompt }, { cachePoint: { type: "default" } }]
+	}
+	return [{ text: systemPrompt }]
+}
+
+/** Chunks text into 1000-char segments and yields as the given chunk type. */
+export function* chunkText(text: string, type: "text" | "reasoning"): Generator<any> {
+	if (!text) return
+	const chunkSize = 1000
+	for (let i = 0; i < text.length; i += chunkSize) {
+		const chunk = text.slice(i, Math.min(i + chunkSize, text.length))
+		yield type === "reasoning" ? { type: "reasoning", reasoning: chunk } : { type: "text", text: chunk }
+	}
+}

--- a/src/core/api/providers/bedrock-stream-parser.ts
+++ b/src/core/api/providers/bedrock-stream-parser.ts
@@ -1,0 +1,238 @@
+/**
+ * Bedrock ConverseStream chunk parser. Extracted from `bedrock.ts` (FB-15b).
+ */
+import { calculateApiCostOpenAI } from "@utils/cost"
+import type { ModelInfo } from "@shared/api"
+
+interface ExtendedMetadata {
+	usage?: {
+		inputTokens?: number
+		outputTokens?: number
+		cacheReadInputTokens?: number
+		cacheWriteInputTokens?: number
+	}
+	additionalModelResponseFields?: {
+		thinkingResponse?: {
+			reasoning?: Array<{
+				type: string
+				text?: string
+				signature?: string
+			}>
+		}
+	}
+}
+
+interface ContentBlockStart {
+	contentBlockIndex?: number
+	start?: {
+		type?: string
+		thinking?: string
+		signature?: string
+		toolUse?: ToolUseStart
+	}
+	contentBlock?: {
+		type?: string
+		thinking?: string
+		signature?: string
+	}
+	type?: string
+	thinking?: string
+	// Redacted thinking block data
+	data?: string
+}
+
+interface ContentBlockDelta {
+	contentBlockIndex?: number
+	delta?: {
+		type?: string
+		thinking?: string
+		text?: string
+		signature?: string
+		reasoningContent?: {
+			text?: string
+		}
+		toolUse?: ToolUseDelta
+	}
+}
+
+interface ToolUseStart {
+	toolUseId: string
+	name: string
+}
+
+interface ToolUseDelta {
+	input: string
+}
+
+export class BedrockStreamParser {
+	private contentBuffers: Record<number, string> = {}
+	private blockTypes = new Map<number, "reasoning" | "text">()
+	private activeToolCalls: Map<number, { toolUseId: string; name: string }> = new Map()
+
+	public *parseChunk(chunk: any, modelInfo: ModelInfo): Generator<any> {
+		yield* this.handleMetadata(chunk, modelInfo)
+		yield* this.handleContentBlockStart(chunk)
+		yield* this.handleContentBlockDelta(chunk)
+		yield* this.handleContentBlockStop(chunk)
+		yield* this.handleStreamError(chunk)
+	}
+
+	private *handleMetadata(chunk: any, modelInfo: ModelInfo): Generator<any> {
+		const metadata = chunk.metadata as ExtendedMetadata | undefined
+		if (metadata?.additionalModelResponseFields?.thinkingResponse) {
+			yield* this.parseThinkingResponse(metadata.additionalModelResponseFields.thinkingResponse)
+		}
+		if (chunk.metadata?.usage) yield this.buildUsageChunk(chunk.metadata.usage, modelInfo)
+	}
+
+	private *parseThinkingResponse(thinkingResponse: any): Generator<any> {
+		if (!thinkingResponse.reasoning || !Array.isArray(thinkingResponse.reasoning)) return
+		for (const block of thinkingResponse.reasoning) {
+			if (block.type === "text" && block.text) {
+				yield { type: "reasoning", reasoning: block.text, ...(block.signature ? { signature: block.signature } : {}) }
+			}
+		}
+	}
+
+	private buildUsageChunk(usage: any, modelInfo: ModelInfo): any {
+		const inputTokens = usage.inputTokens || 0
+		const outputTokens = usage.outputTokens || 0
+		const cacheReadInputTokens = usage.cacheReadInputTokens || 0
+		const cacheWriteInputTokens = usage.cacheWriteInputTokens || 0
+		return {
+			type: "usage",
+			inputTokens,
+			outputTokens,
+			cacheReadTokens: cacheReadInputTokens,
+			cacheWriteTokens: cacheWriteInputTokens,
+			totalCost: calculateApiCostOpenAI(modelInfo, inputTokens, outputTokens, cacheWriteInputTokens, cacheReadInputTokens),
+		}
+	}
+
+	private *handleContentBlockStart(chunk: any): Generator<any> {
+		if (!chunk.contentBlockStart) return
+		const blockStart = chunk.contentBlockStart as ContentBlockStart
+		const blockIndex = chunk.contentBlockStart.contentBlockIndex
+		if (blockStart.start?.toolUse?.toolUseId && blockStart.start.toolUse.name && blockIndex !== undefined) {
+			this.activeToolCalls.set(blockIndex, {
+				toolUseId: blockStart.start.toolUse.toolUseId,
+				name: blockStart.start.toolUse.name,
+			})
+		}
+		yield* this.handleThinkingBlockStart(blockStart, blockIndex)
+		yield* this.handleRedactedThinkingBlockStart(blockStart)
+	}
+
+	private *handleThinkingBlockStart(blockStart: ContentBlockStart, blockIndex: number | undefined): Generator<any> {
+		const isThinking =
+			blockStart.start?.type === "thinking" ||
+			blockStart.contentBlock?.type === "thinking" ||
+			blockStart.type === "thinking"
+		if (!isThinking || blockIndex === undefined) return
+		this.blockTypes.set(blockIndex, "reasoning")
+		const signature = blockStart.start?.signature || blockStart.contentBlock?.signature || undefined
+		const initialContent = blockStart.start?.thinking || blockStart.contentBlock?.thinking || blockStart.thinking || ""
+		if (initialContent || signature) {
+			yield { type: "reasoning", reasoning: initialContent || "", ...(signature ? { signature } : {}) }
+		}
+	}
+
+	private *handleRedactedThinkingBlockStart(blockStart: ContentBlockStart): Generator<any> {
+		const isRedacted =
+			blockStart.start?.type === "redacted_thinking" ||
+			blockStart.contentBlock?.type === "redacted_thinking" ||
+			blockStart.type === "redacted_thinking"
+		if (!isRedacted) return
+		yield {
+			type: "reasoning",
+			reasoning: "[Redacted thinking block]",
+			...(blockStart.data ? { redacted_data: blockStart.data } : {}),
+		}
+	}
+
+	private *handleContentBlockDelta(chunk: any): Generator<any> {
+		if (!chunk.contentBlockDelta) return
+		const blockIndex = chunk.contentBlockDelta.contentBlockIndex
+		if (blockIndex === undefined) return
+		if (!(blockIndex in this.contentBuffers)) this.contentBuffers[blockIndex] = ""
+
+		const blockType = this.blockTypes.get(blockIndex)
+		const delta = chunk.contentBlockDelta.delta as ContentBlockDelta["delta"]
+		yield* this.parseDelta(delta, blockIndex, blockType, chunk)
+	}
+
+	private *parseDelta(
+		delta: ContentBlockDelta["delta"],
+		blockIndex: number,
+		blockType: "reasoning" | "text" | undefined,
+		chunk: any,
+	): Generator<any> {
+		if (delta?.type === "signature_delta" && delta?.signature) {
+			yield { type: "reasoning", reasoning: "", signature: delta.signature }
+			return
+		}
+		if (delta?.type === "thinking_delta" || delta?.thinking) {
+			const thinkingContent = delta.thinking || delta.text || ""
+			if (thinkingContent) yield { type: "reasoning", reasoning: thinkingContent }
+			return
+		}
+		if (delta?.reasoningContent?.text) {
+			yield { type: "reasoning", reasoning: delta.reasoningContent.text }
+			return
+		}
+		if (delta?.toolUse?.input !== undefined) {
+			yield* this.parseToolUseDelta(delta.toolUse.input, blockIndex)
+			return
+		}
+		if (chunk.contentBlockDelta.delta?.text) {
+			yield* this.parseTextDelta(chunk.contentBlockDelta.delta.text, blockIndex, blockType)
+		}
+	}
+
+	private *parseToolUseDelta(toolInput: any, blockIndex: number): Generator<any> {
+		const toolCall = this.activeToolCalls.get(blockIndex)
+		if (!toolCall || typeof toolInput !== "string") return
+		yield {
+			type: "tool_calls",
+			tool_call: {
+				call_id: toolCall.toolUseId,
+				function: { id: toolCall.toolUseId, name: toolCall.name, arguments: toolInput },
+			},
+		}
+	}
+
+	private *parseTextDelta(
+		textContent: string,
+		blockIndex: number,
+		blockType: "reasoning" | "text" | undefined,
+	): Generator<any> {
+		this.contentBuffers[blockIndex] += textContent
+		yield blockType === "reasoning" ? { type: "reasoning", reasoning: textContent } : { type: "text", text: textContent }
+	}
+
+	private *handleContentBlockStop(chunk: any): Generator<void> {
+		if (!chunk.contentBlockStop) return
+		const blockIndex = chunk.contentBlockStop.contentBlockIndex
+		if (blockIndex === undefined) return
+		delete this.contentBuffers[blockIndex]
+		this.blockTypes.delete(blockIndex)
+		this.activeToolCalls.delete(blockIndex)
+	}
+
+	private *handleStreamError(chunk: any): Generator<any> {
+		if (chunk.internalServerException) {
+			yield { type: "text", text: `[ERROR] Internal server error: ${chunk.internalServerException.message}` }
+		} else if (chunk.modelStreamErrorException) {
+			yield { type: "text", text: `[ERROR] Model stream error: ${chunk.modelStreamErrorException.message}` }
+		} else if (chunk.validationException) {
+			const message = chunk.validationException.message || ""
+			const isContextError = /input.*too long|context.*exceed|maximum.*token|input length.*max.*tokens/i.test(message)
+			if (isContextError) throw chunk.validationException
+			yield { type: "text", text: `[ERROR] Validation error: ${message}` }
+		} else if (chunk.throttlingException) {
+			yield { type: "text", text: `[ERROR] Throttling error: ${chunk.throttlingException.message}` }
+		} else if (chunk.serviceUnavailableException) {
+			yield { type: "text", text: `[ERROR] Service unavailable: ${chunk.serviceUnavailableException.message}` }
+		}
+	}
+}

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -19,6 +19,7 @@ import {
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
 import { estimateTokenCount, extractNonStreamingContent, formatConverseError } from "./bedrock-converse-utils"
+import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getErrorMessage } from "@/shared/errors"
 import type { DiracStorageMessage } from "@/shared/messages/content"
@@ -60,73 +61,12 @@ export interface BedrockMessageConfig {
 	abortSignal?: AbortSignal
 }
 
-// Extend AWS SDK types to include additionalModelResponseFields
-interface ExtendedMetadata {
-	usage?: {
-		inputTokens?: number
-		outputTokens?: number
-		cacheReadInputTokens?: number
-		cacheWriteInputTokens?: number
-	}
-	additionalModelResponseFields?: {
-		thinkingResponse?: {
-			reasoning?: Array<{
-				type: string
-				text?: string
-				signature?: string
-			}>
-		}
-	}
-}
 
-// Define types for stream response content blocks
-interface ContentBlockStart {
-	contentBlockIndex?: number
-	start?: {
-		type?: string
-		thinking?: string
-		signature?: string
-		toolUse?: ToolUseStart
-	}
-	contentBlock?: {
-		type?: string
-		thinking?: string
-		signature?: string
-	}
-	type?: string
-	thinking?: string
-	// Redacted thinking block data
-	data?: string
-}
 
-// Define types for stream response deltas
-interface ContentBlockDelta {
-	contentBlockIndex?: number
-	delta?: {
-		type?: string
-		thinking?: string
-		text?: string
-		signature?: string
-		reasoningContent?: {
-			text?: string
-		}
-		toolUse?: ToolUseDelta
-	}
-}
 
-// Tool use types returned by Bedrock ConverseStream API.
-// The @aws-sdk/client-bedrock-runtime types don't fully cover these
-// fields in the streaming response, so we define them here.
-interface ToolUseStart {
-	toolUseId: string
-	name: string
-}
 
-interface ToolUseDelta {
-	input: string
-}
 
-// Define types for supported content types
+
 type SupportedContentType = "text" | "image" | "thinking" | "redacted_thinking" | "document"
 
 interface ContentItem {
@@ -164,178 +104,7 @@ const JP_SUPPORTED_CRIS_MODELS = [
 
 // Parses Bedrock ConverseStream events into Dirac ApiStreamChunk objects.
 // Tracks per-block state (content buffers, block types, active tool calls) across the stream.
-class BedrockStreamParser {
-	private contentBuffers: Record<number, string> = {}
-	private blockTypes = new Map<number, "reasoning" | "text">()
-	private activeToolCalls: Map<number, { toolUseId: string; name: string }> = new Map()
 
-	public *parseChunk(chunk: any, modelInfo: ModelInfo): Generator<any> {
-		yield* this.handleMetadata(chunk, modelInfo)
-		yield* this.handleContentBlockStart(chunk)
-		yield* this.handleContentBlockDelta(chunk)
-		yield* this.handleContentBlockStop(chunk)
-		yield* this.handleStreamError(chunk)
-	}
-
-	private *handleMetadata(chunk: any, modelInfo: ModelInfo): Generator<any> {
-		const metadata = chunk.metadata as ExtendedMetadata | undefined
-		if (metadata?.additionalModelResponseFields?.thinkingResponse) {
-			yield* this.parseThinkingResponse(metadata.additionalModelResponseFields.thinkingResponse)
-		}
-		if (chunk.metadata?.usage) yield this.buildUsageChunk(chunk.metadata.usage, modelInfo)
-	}
-
-	private *parseThinkingResponse(thinkingResponse: any): Generator<any> {
-		if (!thinkingResponse.reasoning || !Array.isArray(thinkingResponse.reasoning)) return
-		for (const block of thinkingResponse.reasoning) {
-			if (block.type === "text" && block.text) {
-				yield { type: "reasoning", reasoning: block.text, ...(block.signature ? { signature: block.signature } : {}) }
-			}
-		}
-	}
-
-	private buildUsageChunk(usage: any, modelInfo: ModelInfo): any {
-		const inputTokens = usage.inputTokens || 0
-		const outputTokens = usage.outputTokens || 0
-		const cacheReadInputTokens = usage.cacheReadInputTokens || 0
-		const cacheWriteInputTokens = usage.cacheWriteInputTokens || 0
-		return {
-			type: "usage",
-			inputTokens,
-			outputTokens,
-			cacheReadTokens: cacheReadInputTokens,
-			cacheWriteTokens: cacheWriteInputTokens,
-			totalCost: calculateApiCostOpenAI(modelInfo, inputTokens, outputTokens, cacheWriteInputTokens, cacheReadInputTokens),
-		}
-	}
-
-	private *handleContentBlockStart(chunk: any): Generator<any> {
-		if (!chunk.contentBlockStart) return
-		const blockStart = chunk.contentBlockStart as ContentBlockStart
-		const blockIndex = chunk.contentBlockStart.contentBlockIndex
-		if (blockStart.start?.toolUse?.toolUseId && blockStart.start.toolUse.name && blockIndex !== undefined) {
-			this.activeToolCalls.set(blockIndex, {
-				toolUseId: blockStart.start.toolUse.toolUseId,
-				name: blockStart.start.toolUse.name,
-			})
-		}
-		yield* this.handleThinkingBlockStart(blockStart, blockIndex)
-		yield* this.handleRedactedThinkingBlockStart(blockStart)
-	}
-
-	private *handleThinkingBlockStart(blockStart: ContentBlockStart, blockIndex: number | undefined): Generator<any> {
-		const isThinking =
-			blockStart.start?.type === "thinking" ||
-			blockStart.contentBlock?.type === "thinking" ||
-			blockStart.type === "thinking"
-		if (!isThinking || blockIndex === undefined) return
-		this.blockTypes.set(blockIndex, "reasoning")
-		const signature = blockStart.start?.signature || blockStart.contentBlock?.signature || undefined
-		const initialContent = blockStart.start?.thinking || blockStart.contentBlock?.thinking || blockStart.thinking || ""
-		if (initialContent || signature) {
-			yield { type: "reasoning", reasoning: initialContent || "", ...(signature ? { signature } : {}) }
-		}
-	}
-
-	private *handleRedactedThinkingBlockStart(blockStart: ContentBlockStart): Generator<any> {
-		const isRedacted =
-			blockStart.start?.type === "redacted_thinking" ||
-			blockStart.contentBlock?.type === "redacted_thinking" ||
-			blockStart.type === "redacted_thinking"
-		if (!isRedacted) return
-		yield {
-			type: "reasoning",
-			reasoning: "[Redacted thinking block]",
-			...(blockStart.data ? { redacted_data: blockStart.data } : {}),
-		}
-	}
-
-	private *handleContentBlockDelta(chunk: any): Generator<any> {
-		if (!chunk.contentBlockDelta) return
-		const blockIndex = chunk.contentBlockDelta.contentBlockIndex
-		if (blockIndex === undefined) return
-		if (!(blockIndex in this.contentBuffers)) this.contentBuffers[blockIndex] = ""
-
-		const blockType = this.blockTypes.get(blockIndex)
-		const delta = chunk.contentBlockDelta.delta as ContentBlockDelta["delta"]
-		yield* this.parseDelta(delta, blockIndex, blockType, chunk)
-	}
-
-	private *parseDelta(
-		delta: ContentBlockDelta["delta"],
-		blockIndex: number,
-		blockType: "reasoning" | "text" | undefined,
-		chunk: any,
-	): Generator<any> {
-		if (delta?.type === "signature_delta" && delta?.signature) {
-			yield { type: "reasoning", reasoning: "", signature: delta.signature }
-			return
-		}
-		if (delta?.type === "thinking_delta" || delta?.thinking) {
-			const thinkingContent = delta.thinking || delta.text || ""
-			if (thinkingContent) yield { type: "reasoning", reasoning: thinkingContent }
-			return
-		}
-		if (delta?.reasoningContent?.text) {
-			yield { type: "reasoning", reasoning: delta.reasoningContent.text }
-			return
-		}
-		if (delta?.toolUse?.input !== undefined) {
-			yield* this.parseToolUseDelta(delta.toolUse.input, blockIndex)
-			return
-		}
-		if (chunk.contentBlockDelta.delta?.text) {
-			yield* this.parseTextDelta(chunk.contentBlockDelta.delta.text, blockIndex, blockType)
-		}
-	}
-
-	private *parseToolUseDelta(toolInput: any, blockIndex: number): Generator<any> {
-		const toolCall = this.activeToolCalls.get(blockIndex)
-		if (!toolCall || typeof toolInput !== "string") return
-		yield {
-			type: "tool_calls",
-			tool_call: {
-				call_id: toolCall.toolUseId,
-				function: { id: toolCall.toolUseId, name: toolCall.name, arguments: toolInput },
-			},
-		}
-	}
-
-	private *parseTextDelta(
-		textContent: string,
-		blockIndex: number,
-		blockType: "reasoning" | "text" | undefined,
-	): Generator<any> {
-		this.contentBuffers[blockIndex] += textContent
-		yield blockType === "reasoning" ? { type: "reasoning", reasoning: textContent } : { type: "text", text: textContent }
-	}
-
-	private *handleContentBlockStop(chunk: any): Generator<void> {
-		if (!chunk.contentBlockStop) return
-		const blockIndex = chunk.contentBlockStop.contentBlockIndex
-		if (blockIndex === undefined) return
-		delete this.contentBuffers[blockIndex]
-		this.blockTypes.delete(blockIndex)
-		this.activeToolCalls.delete(blockIndex)
-	}
-
-	private *handleStreamError(chunk: any): Generator<any> {
-		if (chunk.internalServerException) {
-			yield { type: "text", text: `[ERROR] Internal server error: ${chunk.internalServerException.message}` }
-		} else if (chunk.modelStreamErrorException) {
-			yield { type: "text", text: `[ERROR] Model stream error: ${chunk.modelStreamErrorException.message}` }
-		} else if (chunk.validationException) {
-			const message = chunk.validationException.message || ""
-			const isContextError = /input.*too long|context.*exceed|maximum.*token|input length.*max.*tokens/i.test(message)
-			if (isContextError) throw chunk.validationException
-			yield { type: "text", text: `[ERROR] Validation error: ${message}` }
-		} else if (chunk.throttlingException) {
-			yield { type: "text", text: `[ERROR] Throttling error: ${chunk.throttlingException.message}` }
-		} else if (chunk.serviceUnavailableException) {
-			yield { type: "text", text: `[ERROR] Service unavailable: ${chunk.serviceUnavailableException.message}` }
-		}
-	}
-}
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -17,7 +17,7 @@ import {
 	type ModelInfo,
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
-import { estimateTokenCount, extractNonStreamingContent, formatConverseError, prepareSystemMessages, chunkText } from "./bedrock-converse-utils"
+import { applyCacheControlToMessages, chunkText, estimateTokenCount, extractNonStreamingContent, formatConverseError, mapDiracToolsToBedrockToolConfig, prepareSystemMessages, processImageContent } from "./bedrock-converse-utils"
 import { createBedrockClient, resolveAwsCredentials } from "./bedrock-client"
 import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
@@ -78,12 +78,6 @@ interface ContentItem {
 	}
 }
 
-// Define cache point type for AWS Bedrock
-interface CachePointContentBlock {
-	cachePoint: {
-		type: "default"
-	}
-}
 
 // Define provider options type based on AWS SDK patterns
 
@@ -466,36 +460,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	 * Bedrock Converse API `ToolConfiguration` shape. Returns `undefined` when no tools
 	 * are provided so callers can conditionally spread into the command params.
 	 */
-	private mapDiracToolsToBedrockToolConfig(tools?: DiracTool[]): ToolConfiguration | undefined {
-		if (!tools || tools.length === 0) {
-			return undefined
-		}
-
-		const isAnthropicTool = (tool: DiracTool): tool is AnthropicTool => "input_schema" in tool
-
-		const bedrockTools = tools.filter(isAnthropicTool).map((tool) => {
-			return {
-				toolSpec: {
-					name: tool.name,
-					description: tool.description || tool.name || "Tool",
-					inputSchema: {
-						json: tool.input_schema,
-					},
-				},
-			}
-		})
-
-		if (bedrockTools.length === 0) {
-			return undefined
-		}
-
-		const toolConfig: ToolConfiguration = {
-			tools: bedrockTools as unknown as ToolConfiguration["tools"],
-			toolChoice: { auto: {} },
-		}
-
-		return toolConfig
-	}
 
 	/**
 	 * Executes a Converse API stream command and handles the response
@@ -561,7 +525,7 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		// Apply caching controls to messages if enabled
 		const messagesWithCache = this.options.awsBedrockUsePromptCache
-			? this.applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
+			? applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
 			: formattedMessages
 
 		// Prepare system message with caching support
@@ -573,7 +537,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		const useAdaptive = isAnthropicAdaptiveThinkingSupported(modelId, model.info)
 
 		// Prepare request for Anthropic model using Converse API
-		const toolConfig = this.mapDiracToolsToBedrockToolConfig(tools)
+		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseStreamCommand({
 			modelId: modelId,
 			messages: messagesWithCache,
@@ -625,7 +589,7 @@ export class AwsBedrockHandler implements ApiHandler {
 						// Image content
 						if (item.type === "image") {
 							if (supportsImages) {
-								return this.processImageContent(item)
+								return processImageContent(item)
 							}
 							return { text: "[Image]" }
 						}
@@ -659,7 +623,7 @@ export class AwsBedrockHandler implements ApiHandler {
 											}
 											if (block.type === "image") {
 												if (supportsImages) {
-													return this.processImageContent(block)
+													return processImageContent(block)
 												}
 												return { text: "[Image]" }
 											}
@@ -700,85 +664,11 @@ export class AwsBedrockHandler implements ApiHandler {
 	/**
 	 * Processes image content with proper error handling and user notification
 	 */
-	private processImageContent(item: any): ContentBlock | null {
-		let imageData: Uint8Array
-		let format: "png" | "jpeg" | "gif" | "webp" = "jpeg" // default format
-
-		// Extract format from media_type if available
-		if (item.source.media_type) {
-			// Extract format from media_type (e.g., "image/jpeg" -> "jpeg")
-			const formatMatch = item.source.media_type.match(/image\/(\w+)/)
-			if (formatMatch && formatMatch[1]) {
-				const extractedFormat = formatMatch[1]
-				// Ensure format is one of the allowed values
-				if (["png", "jpeg", "gif", "webp"].includes(extractedFormat)) {
-					format = extractedFormat as "png" | "jpeg" | "gif" | "webp"
-				}
-			}
-		}
-
-		// Get image data with improved error handling
-		try {
-			if (typeof item.source.data === "string") {
-				// Handle base64 encoded data
-				const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
-				imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
-			} else if (item.source.data && typeof item.source.data === "object") {
-				// Try to convert to Uint8Array
-				imageData = new Uint8Array(Buffer.from(item.source.data as Buffer | Uint8Array))
-			} else {
-				throw new Error("Unsupported image data format")
-			}
-
-			return {
-				image: {
-					format,
-					source: {
-						bytes: imageData,
-					},
-				},
-			}
-		} catch (error) {
-			Logger.error("Failed to process image content:", error)
-			// Return a text content indicating the error instead of null
-			// This ensures users are aware of the issue
-			return {
-				text: `[ERROR: Failed to process image - ${getErrorMessage(error, "Unknown error")}]`,
-			}
-		}
-	}
 
 	/**
 	 * Applies cache control to messages for prompt caching using AWS Bedrock's cachePoint system
 	 * AWS Bedrock uses cachePoint objects instead of Anthropic's cache_control approach
 	 */
-	private applyCacheControlToMessages(messages: Message[], userIndices: [number, number]): Message[] {
-		const [, lastUserMsgIndex] = userIndices
-		const secondLastMsgUserIndex = userIndices[0] ?? -1
-		return messages.map((message, index) => {
-			// Add cachePoint to the last user message and second-to-last user message
-			if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
-				// Clone the message to avoid modifying the original
-				const messageWithCache = { ...message }
-
-				if (messageWithCache.content && Array.isArray(messageWithCache.content)) {
-					// Add cachePoint to the end of the content array
-					messageWithCache.content = [
-						...messageWithCache.content,
-						{
-							cachePoint: {
-								type: "default",
-							},
-						} as CachePointContentBlock, // Properly typed cache point for AWS SDK
-					]
-				}
-
-				return messageWithCache
-			}
-
-			return message
-		})
-	}
 
 	/**
 	 * Creates a message using Amazon Nova models through AWS Bedrock
@@ -797,7 +687,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		// Apply caching controls to messages if model supports caching and option is enabled
 		const messagesWithCache =
 			this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
-				? this.applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
+				? applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
 				: formattedMessages
 
 		// Prepare system message with caching support for Nova models that support it
@@ -805,7 +695,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		const systemMessages = prepareSystemMessages(systemPrompt, enableCaching || false)
 
 		// Prepare request for Nova model
-		const toolConfig = this.mapDiracToolsToBedrockToolConfig(tools)
+		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseStreamCommand({
 			modelId: modelId,
 			messages: messagesWithCache,
@@ -845,7 +735,7 @@ export class AwsBedrockHandler implements ApiHandler {
 		const client = await this.getBedrockClient()
 		const formattedMessages = this.formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
 		const systemMessages = systemPrompt ? [{ text: systemPrompt }] : undefined
-		const toolConfig = this.mapDiracToolsToBedrockToolConfig(tools)
+		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseCommand({
 			modelId,
 			messages: formattedMessages,

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -18,6 +18,7 @@ import {
 	type ModelInfo,
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
+import { estimateTokenCount, extractNonStreamingContent, formatConverseError } from "./bedrock-converse-utils"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getErrorMessage } from "@/shared/errors"
 import type { DiracStorageMessage } from "@/shared/messages/content"
@@ -621,7 +622,7 @@ export class AwsBedrockHandler implements ApiHandler {
 								// For non-streaming response (full response)
 								const text = parsedChunk.choices[0].text
 								if (text) {
-									const chunkTokens = this.estimateTokenCount(text)
+									const chunkTokens = estimateTokenCount(text)
 									outputTokens += chunkTokens
 									accumulatedTokens += chunkTokens
 
@@ -644,7 +645,7 @@ export class AwsBedrockHandler implements ApiHandler {
 							} else if (parsedChunk.delta?.text) {
 								// For streaming response (delta updates)
 								const text = parsedChunk.delta.text
-								const chunkTokens = this.estimateTokenCount(text)
+								const chunkTokens = estimateTokenCount(text)
 								outputTokens += chunkTokens
 								accumulatedTokens += chunkTokens
 
@@ -751,10 +752,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	/**
 	 * Estimates token count for a text string
 	 */
-	private estimateTokenCount(text: string): number {
-		// Approximate 4 characters per token
-		return Math.ceil(text.length / 4)
-	}
 
 	/**
 	 * Converts Dirac's tool definitions (Anthropic format with `input_schema`) to the
@@ -1163,11 +1160,11 @@ export class AwsBedrockHandler implements ApiHandler {
 		try {
 			const inputTokenEstimate = this.estimateInputTokens(systemPrompt, messages)
 			const response = await client.send(command, { abortSignal: config.abortSignal })
-			const { fullText, reasoningText } = this.extractNonStreamingContent(response)
+			const { fullText, reasoningText } = extractNonStreamingContent(response)
 
 			const outputTokens = response.usage
-				? response.usage.outputTokens || this.estimateTokenCount(fullText + reasoningText)
-				: this.estimateTokenCount(fullText + reasoningText)
+				? response.usage.outputTokens || estimateTokenCount(fullText + reasoningText)
+				: estimateTokenCount(fullText + reasoningText)
 
 			if (response.usage) {
 				const actualInputTokens = response.usage.inputTokens || inputTokenEstimate
@@ -1192,29 +1189,13 @@ export class AwsBedrockHandler implements ApiHandler {
 			}
 		} catch (error) {
 			Logger.error(`Error with ${label} model via Converse API:`, error)
-			yield { type: "text", text: `[ERROR] ${this.formatConverseError(error, label)}` }
+			yield { type: "text", text: `[ERROR] ${formatConverseError(error, label)}` }
 		} finally {
 			client.destroy()
 		}
 	}
 
 	// Extracts text and reasoning content from a non-streaming Converse response.
-	private extractNonStreamingContent(response: any): { fullText: string; reasoningText: string } {
-		let fullText = ""
-		let reasoningText = ""
-		if (!response.output?.message?.content) return { fullText, reasoningText }
-		for (const block of response.output.message.content) {
-			if ("reasoningContent" in block && block.reasoningContent) {
-				const reasoning = block.reasoningContent
-				if ("reasoningText" in reasoning && reasoning.reasoningText && "text" in reasoning.reasoningText) {
-					reasoningText += reasoning.reasoningText.text
-				}
-			} else if ("text" in block && block.text) {
-				fullText += block.text
-			}
-		}
-		return { fullText, reasoningText }
-	}
 
 	// Chunks text into 1000-char segments and yields as the given chunk type.
 	private *chunkText(text: string, type: "text" | "reasoning"): Generator<any> {
@@ -1227,11 +1208,4 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	// Formats an error from the Converse API into a human-readable message.
-	private formatConverseError(error: unknown, label: string): string {
-		if (error instanceof Error) {
-			const named = error as Error & { name?: string }
-			return named.name ? `${named.name}: ${error.message}` : error.message
-		}
-		return `Failed to process ${label} model request`
-	}
 }

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -9,7 +9,6 @@ import {
 	ConverseStreamCommand,
 	InvokeModelWithResponseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime"
-import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import {
 	type BedrockModelId,
 	bedrockDefaultModelId,
@@ -19,6 +18,7 @@ import {
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
 import { estimateTokenCount, extractNonStreamingContent, formatConverseError, prepareSystemMessages, chunkText } from "./bedrock-converse-utils"
+import { createBedrockClient, resolveAwsCredentials } from "./bedrock-client"
 import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getErrorMessage } from "@/shared/errors"
@@ -86,11 +86,6 @@ interface CachePointContentBlock {
 }
 
 // Define provider options type based on AWS SDK patterns
-interface ProviderChainOptions {
-	clientConfig?: { userAgentAppId?: string; region?: string }
-	ignoreCache?: boolean
-	profile?: string
-}
 
 // a special jp inference profile was created for sonnet 4.6, opus 4.6, sonnet 4.5 & haiku 4.5
 // https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
@@ -227,41 +222,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	 * Gets AWS credentials using the provider chain
 	 * Centralizes credential retrieval logic for all AWS services
 	 */
-	private async getAwsCredentials(): Promise<{
-		accessKeyId: string
-		secretAccessKey: string
-		sessionToken?: string
-	}> {
-		// Configure provider options
-		const providerOptions: ProviderChainOptions = {
-			clientConfig: {
-				// set the inner sts client userAgentAppId
-				userAgentAppId: BEDROCK_USER_AGENT_APP_ID,
-			},
-		}
-		const useProfile =
-			(this.options.awsAuthentication === undefined && this.options.awsUseProfile) ||
-			this.options.awsAuthentication === "profile"
-		if (!useProfile && this.options.awsAccessKey && this.options.awsSecretKey) {
-			return {
-				accessKeyId: this.options.awsAccessKey,
-				secretAccessKey: this.options.awsSecretKey,
-				sessionToken: this.options.awsSessionToken,
-			}
-		}
-
-		providerOptions.clientConfig!.region = this.getRegion()
-		if (useProfile) {
-			// For profile-based auth, always use ignoreCache to detect credential file changes
-			// This solves the AWS Identity Manager issue where credential files change externally
-			providerOptions.ignoreCache = true
-			if (this.options.awsProfile) {
-				providerOptions.profile = this.options.awsProfile
-			}
-		}
-
-		return await fromNodeProviderChain(providerOptions)()
-	}
 
 	/**
 	 * Gets the AWS region to use, with fallback to default
@@ -273,34 +233,13 @@ export class AwsBedrockHandler implements ApiHandler {
 	/**
 	 * Creates a BedrockRuntimeClient with the appropriate credentials
 	 */
+	/** Resolves AWS credentials for this handler from options or the node provider chain. */
+	public getAwsCredentials(): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
+		return resolveAwsCredentials(this.options, this.getRegion(), BEDROCK_USER_AGENT_APP_ID)
+	}
+
 	private async getBedrockClient(): Promise<BedrockRuntimeClient> {
-		let auth: any
-
-		if (this.options.awsAuthentication === "apikey") {
-			auth = {
-				token: { token: this.options.awsBedrockApiKey },
-				authSchemePreference: ["httpBearerAuth"],
-			}
-		} else {
-			const credentials = await this.getAwsCredentials()
-			auth = {
-				credentials: {
-					accessKeyId: credentials.accessKeyId,
-					secretAccessKey: credentials.secretAccessKey,
-					sessionToken: credentials.sessionToken,
-				},
-			}
-		}
-
-		// TODO: Add proxy support for AWS SDK
-		// AWS SDK uses a different architecture than fetch-based SDKs.
-		// To add proxy support, we need to provide a custom requestHandler.
-		return new BedrockRuntimeClient({
-			userAgentAppId: BEDROCK_USER_AGENT_APP_ID,
-			region: this.getRegion(),
-			...auth,
-			...(this.options.awsBedrockEndpoint && { endpoint: this.options.awsBedrockEndpoint }),
-		})
+		return createBedrockClient(this.options, AwsBedrockHandler.DEFAULT_REGION, BEDROCK_USER_AGENT_APP_ID)
 	}
 
 	/**

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -17,7 +17,7 @@ import {
 	type ModelInfo,
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
-import { applyCacheControlToMessages, chunkText, estimateTokenCount, extractNonStreamingContent, formatConverseError, mapDiracToolsToBedrockToolConfig, prepareSystemMessages, processImageContent } from "./bedrock-converse-utils"
+import { applyCacheControlToMessages, chunkText, estimateTokenCount, extractNonStreamingContent, formatConverseError, formatMessagesForConverseAPI, getInferenceConfig, mapDiracToolsToBedrockToolConfig, prepareSystemMessages, processImageContent } from "./bedrock-converse-utils"
 import { createBedrockClient, resolveAwsCredentials } from "./bedrock-client"
 import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
@@ -68,15 +68,6 @@ export interface BedrockMessageConfig {
 
 
 type SupportedContentType = "text" | "image" | "thinking" | "redacted_thinking" | "document"
-
-interface ContentItem {
-	type: SupportedContentType
-	text?: string
-	source?: {
-		data: string | Buffer | Uint8Array
-		media_type?: string
-	}
-}
 
 
 // Define provider options type based on AWS SDK patterns
@@ -491,23 +482,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	/**
 	 * Gets inference configuration for different model types
 	 */
-	private getInferenceConfig(modelInfo: ModelInfo, modelType: "anthropic" | "nova"): any {
-		// For Anthropic models with thinking enabled, temperature must be 1
-		if (modelType === "anthropic") {
-			const budget_tokens = this.options.thinkingBudgetTokens || 0
-			const reasoningOn = modelInfo.supportsReasoning && budget_tokens > 0
-
-			return {
-				maxTokens: modelInfo.maxTokens || 8192,
-				temperature: reasoningOn ? undefined : (modelInfo.temperature ?? undefined),
-			}
-		}
-
-		return {
-			maxTokens: modelInfo.maxTokens || (modelType === "nova" ? 5000 : 8192),
-			temperature: modelInfo.temperature ?? 0,
-		}
-	}
 
 	/**
 	 * Creates a message using Anthropic Claude models through AWS Bedrock Converse API
@@ -516,7 +490,7 @@ export class AwsBedrockHandler implements ApiHandler {
 	private async *createAnthropicMessage(config: BedrockMessageConfig): ApiStream {
 		const { systemPrompt, messages, modelId, model, tools } = config
 		// Format messages for Anthropic model using unified formatter
-		const formattedMessages = this.formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
+		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
 
 		// Get model info and message indices for caching
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
@@ -542,7 +516,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			modelId: modelId,
 			messages: messagesWithCache,
 			system: systemMessages,
-			inferenceConfig: this.getInferenceConfig(model.info, "anthropic"),
+			inferenceConfig: getInferenceConfig(model.info, "anthropic", this.options.thinkingBudgetTokens || 0),
 			...(toolConfig ? { toolConfig } : {}),
 			additionalModelRequestFields: {
 				// Add thinking configuration as per LangChain documentation
@@ -566,100 +540,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	 * Formats messages for models using the Converse API specification
 	 * Used by both Anthropic and Nova models to avoid code duplication
 	 */
-	private formatMessagesForConverseAPI(messages: DiracStorageMessage[], supportsImages = true): Message[] {
-		return messages.map((message) => {
-			// Determine role (user or assistant)
-			const role = message.role === "user" ? ConversationRole.USER : ConversationRole.ASSISTANT
-
-			// Process content based on type
-			let content: ContentBlock[] = []
-
-			if (typeof message.content === "string") {
-				// Simple text content
-				content = [{ text: message.content }]
-			} else if (Array.isArray(message.content)) {
-				// Convert Anthropic content format to Converse API content format
-				const processedContent = message.content
-					.map((item) => {
-						// Text content
-						if (item.type === "text") {
-							return { text: item.text }
-						}
-
-						// Image content
-						if (item.type === "image") {
-							if (supportsImages) {
-								return processImageContent(item)
-							}
-							return { text: "[Image]" }
-						}
-
-						if (item.type === "tool_use") {
-							return {
-								toolUse: {
-									toolUseId: item.id,
-									name: item.name,
-									input: item.input,
-								},
-							}
-						}
-
-						// Skip thinking blocks - Bedrock Converse API handles thinking via
-						// the thinking config parameter, not by replaying blocks in history
-						if (item.type === "thinking" || item.type === "redacted_thinking") {
-							return null
-						}
-
-						if (item.type === "tool_result") {
-							const content = (() => {
-								if (typeof item.content === "string") {
-									return [{ text: item.content }]
-								}
-								if (Array.isArray(item.content)) {
-									return item.content
-										.map((block) => {
-											if (block.type === "text") {
-												return { text: block.text }
-											}
-											if (block.type === "image") {
-												if (supportsImages) {
-													return processImageContent(block)
-												}
-												return { text: "[Image]" }
-											}
-											return null
-										})
-										.filter((block): block is ContentBlock => block !== null)
-								}
-
-								return [{ text: JSON.stringify(item.content) }]
-							})()
-
-							return {
-								toolResult: {
-									toolUseId: item.tool_use_id,
-									content,
-									status: item.is_error ? "error" : "success",
-								},
-							}
-						}
-
-						// Log unsupported content types for debugging
-						Logger.warn(`Unsupported content type: ${(item as ContentItem).type}`)
-						return null
-					})
-					.filter((item): item is ContentBlock => item !== null)
-
-				content = processedContent
-			}
-
-			// Return formatted message
-			return {
-				role,
-				content,
-			}
-		})
-	}
 
 	/**
 	 * Processes image content with proper error handling and user notification
@@ -677,7 +557,7 @@ export class AwsBedrockHandler implements ApiHandler {
 	private async *createNovaMessage(config: BedrockMessageConfig): ApiStream {
 		const { systemPrompt, messages, modelId, model, tools } = config
 		// Format messages for Nova model using unified formatter
-		const formattedMessages = this.formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
+		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
 
 		// Get model info and message indices for caching (for Nova models that support it)
 		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
@@ -700,7 +580,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			modelId: modelId,
 			messages: messagesWithCache,
 			system: systemMessages,
-			inferenceConfig: this.getInferenceConfig(model.info, "nova"),
+			inferenceConfig: getInferenceConfig(model.info, "nova", this.options.thinkingBudgetTokens || 0),
 			...(toolConfig ? { toolConfig } : {}),
 		})
 
@@ -733,7 +613,7 @@ export class AwsBedrockHandler implements ApiHandler {
 	): ApiStream {
 		const { systemPrompt, messages, modelId, model, tools } = config
 		const client = await this.getBedrockClient()
-		const formattedMessages = this.formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
+		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
 		const systemMessages = systemPrompt ? [{ text: systemPrompt }] : undefined
 		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseCommand({

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -18,7 +18,7 @@ import {
 	type ModelInfo,
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
-import { estimateTokenCount, extractNonStreamingContent, formatConverseError } from "./bedrock-converse-utils"
+import { estimateTokenCount, extractNonStreamingContent, formatConverseError, prepareSystemMessages, chunkText } from "./bedrock-converse-utils"
 import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getErrorMessage } from "@/shared/errors"
@@ -584,17 +584,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	/**
 	 * Prepares system messages with optional caching support
 	 */
-	private prepareSystemMessages(systemPrompt: string, enableCaching: boolean): any[] | undefined {
-		if (!systemPrompt) {
-			return undefined
-		}
-
-		if (enableCaching) {
-			return [{ text: systemPrompt }, { cachePoint: { type: "default" } }]
-		}
-
-		return [{ text: systemPrompt }]
-	}
 
 	/**
 	 * Gets inference configuration for different model types
@@ -637,7 +626,7 @@ export class AwsBedrockHandler implements ApiHandler {
 			: formattedMessages
 
 		// Prepare system message with caching support
-		const systemMessages = this.prepareSystemMessages(systemPrompt, this.options.awsBedrockUsePromptCache || false)
+		const systemMessages = prepareSystemMessages(systemPrompt, this.options.awsBedrockUsePromptCache || false)
 
 		// Get thinking configuration
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
@@ -874,7 +863,7 @@ export class AwsBedrockHandler implements ApiHandler {
 
 		// Prepare system message with caching support for Nova models that support it
 		const enableCaching = this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
-		const systemMessages = this.prepareSystemMessages(systemPrompt, enableCaching || false)
+		const systemMessages = prepareSystemMessages(systemPrompt, enableCaching || false)
 
 		// Prepare request for Nova model
 		const toolConfig = this.mapDiracToolsToBedrockToolConfig(tools)
@@ -945,8 +934,8 @@ export class AwsBedrockHandler implements ApiHandler {
 				}
 			}
 
-			yield* this.chunkText(reasoningText, "reasoning")
-			yield* this.chunkText(fullText, "text")
+			yield* chunkText(reasoningText, "reasoning")
+			yield* chunkText(fullText, "text")
 
 			if (!response.usage) {
 				yield {
@@ -967,14 +956,6 @@ export class AwsBedrockHandler implements ApiHandler {
 	// Extracts text and reasoning content from a non-streaming Converse response.
 
 	// Chunks text into 1000-char segments and yields as the given chunk type.
-	private *chunkText(text: string, type: "text" | "reasoning"): Generator<any> {
-		if (!text) return
-		const chunkSize = 1000
-		for (let i = 0; i < text.length; i += chunkSize) {
-			const chunk = text.slice(i, Math.min(i + chunkSize, text.length))
-			yield type === "reasoning" ? { type: "reasoning", reasoning: chunk } : { type: "text", text: chunk }
-		}
-	}
 
 	// Formats an error from the Converse API into a human-readable message.
 }

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,13 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
 export class LanguageModelTextPart {
 	constructor(public value: string) { }
 }

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,8 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+// Keep LM shapes in sync with cli/src/vscode-shim.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for `node:sqlite` (available at runtime on the Node
+ * version this project runs, but the bundled `@types/node` does not ship them).
+ * Only models the subset used by `SymbolIndexDatabase`.
+ */
+declare module "node:sqlite" {
+	interface StatementResult {
+		changes: number | bigint
+		lastInsertRowid: number | bigint
+	}
+	interface StatementSync {
+		get(...args: unknown[]): Record<string, unknown> | undefined
+		all(...args: unknown[]): Record<string, unknown>[]
+		iterate(...args: unknown[]): IterableIterator<Record<string, unknown>>
+		run(...args: unknown[]): StatementResult
+	}
+	class DatabaseSync {
+		constructor(path: string)
+		prepare(sql: string, ...args: unknown[]): StatementSync
+		exec(sql: string): void
+		close(): void
+	}
+	export { DatabaseSync, type StatementSync }
+}

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,3 +1,4 @@
+/* DELETE once @types/node ships node:sqlite types — a future types upgrade will collide with this declare module. */
 /**
  * Minimal type declarations for `node:sqlite` (available at runtime on the Node
  * version this project runs, but the bundled `@types/node` does not ship them).

--- a/src/types/vscode-augment.d.ts
+++ b/src/types/vscode-augment.d.ts
@@ -1,0 +1,68 @@
+/**
+ * Augments the installed `@types/vscode` with the newer Language Model API
+ * members used across the codebase. Type-only; merges into the vscode module.
+ * (Tests wire vscode at runtime to src/test/vscode-mock.ts via a require hook;
+ * this augmentation is what makes the TS type-checking of `import("vscode")`
+ * forms see the missing LM members.)
+ */
+declare module "vscode" {
+	export interface LanguageModelChatSelector {
+		vendor?: string
+		family?: string
+		version?: string
+		id?: string
+	}
+
+	export class LanguageModelTextPart {
+		constructor(text: string)
+		readonly value: string
+		readonly text: string
+	}
+
+	export enum LanguageModelChatMessageRole {
+		User = 1,
+		Assistant = 2,
+	}
+
+	export class LanguageModelToolCallPart {
+		constructor(callId: string, name: string, input: unknown)
+		readonly callId: string
+		readonly name: string
+		readonly input: unknown
+	}
+
+	export class LanguageModelToolResultPart {
+		constructor(callId: string, content: LanguageModelTextPart[])
+		readonly callId: string
+		readonly content: LanguageModelTextPart[]
+	}
+
+	export class LanguageModelChatMessage {
+		role: LanguageModelChatMessageRole
+		content: Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart>
+		name?: string
+	}
+
+	export interface LanguageModelChatRequestOptions {
+		justification?: string
+		tools?: unknown[]
+	}
+
+	export class LanguageModelChatResponse {
+		readonly stream: AsyncIterable<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart>
+	}
+
+	export class LanguageModelChat {
+		readonly name: string
+		readonly vendor: string
+		sendRequest(
+			messages: LanguageModelChatMessage[],
+			options: LanguageModelChatRequestOptions,
+			token?: unknown,
+		): Thenable<LanguageModelChatResponse>
+	}
+
+	export namespace lm {
+		function selectChatModels(selector: LanguageModelChatSelector): Thenable<LanguageModelChat[]>
+	}
+}

--- a/tsconfig.unit-test.json
+++ b/tsconfig.unit-test.json
@@ -11,7 +11,8 @@
 	"ts-node": {
 		"files": true,
 		"compilerOptions": {
-			"module": "commonjs"
+			"module": "commonjs",
+			"moduleResolution": "node"
 		},
 		"require": [
 			"tsconfig-paths/register"


### PR DESCRIPTION
## What
Decompose `src/core/api/providers/bedrock.ts` (1234 → ~670 lines) into single-responsibility modules:
- `bedrock-stream-parser.ts` (238) — BedrockStreamParser + stream types
- `bedrock-client.ts` (89) — AWS auth/credential + client factory
- `bedrock-converse-utils.ts` (~217) — message-shaping, inference, image/cache/tool helpers

6 commits, each test-validated.

## Dependencies
Requires **#166** (test-compilation unblock) for its test suite to run; stacked on it until #166 merges. **#163** is independent.

## Verification
38/38 bedrock tests pass per commit; `tsc` + `biome` clean.

Closes FB-15b (FIX-BACKLOG).