### PR TITLE
refactor(fb15b2): consolidate bedrock Converse orchestration (DRY)

### DIFF
--- a/src/core/api/providers/__tests__/bedrock.test.ts
+++ b/src/core/api/providers/__tests__/bedrock.test.ts
@@ -8,7 +8,9 @@
 import "should"
 import type { ModelInfo } from "@shared/api"
 import sinon from "sinon"
+import type { DiracStorageMessage } from "@/shared/messages/content"
 import { AwsBedrockHandler } from "../bedrock"
+import { formatMessagesForConverseAPI } from "../bedrock-converse-utils"
 
 // --- Helpers ---
 const ZERO_PRICE_MODEL: ModelInfo = { inputPrice: 0, outputPrice: 0, cacheWritesPrice: 0, cacheReadsPrice: 0 } as any
@@ -41,7 +43,7 @@ function makeHandler(chunks: any[]): AwsBedrockHandler {
 }
 
 // Invoke the private executeConverseStream generator directly.
-function runStream(handler: AwsBedrockHandler, chunks: any[]): Promise<any[]> {
+function runStream(handler: AwsBedrockHandler): Promise<any[]> {
 	return collect((handler as any).executeConverseStream({}, ZERO_PRICE_MODEL))
 }
 
@@ -126,9 +128,7 @@ describe("AwsBedrockHandler cancellation", () => {
 			apiModelId: "anthropic.claude-sonnet-4-6",
 			onRetryAttempt: () => notifyRetryStarted(),
 		})
-		const getBedrockClient = sinon
-			.stub(handler as any, "getBedrockClient")
-			.resolves({ send, destroy: sinon.stub() })
+		const getBedrockClient = sinon.stub(handler as any, "getBedrockClient").resolves({ send, destroy: sinon.stub() })
 
 		const pendingChunk = handler.createMessage("system", [{ role: "user", content: "hello" }]).next()
 		const rejectedChunk = pendingChunk.should.be.rejected()
@@ -159,7 +159,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 					},
 				},
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "thinking here", signature: "sig-1" }])
 		})
 
@@ -175,7 +175,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 					},
 				},
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "no sig" }])
 		})
 
@@ -191,7 +191,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 					},
 				},
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 
@@ -207,7 +207,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 					},
 				},
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 	})
@@ -219,7 +219,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 					metadata: { usage: { inputTokens: 10, outputTokens: 5, cacheReadInputTokens: 3, cacheWriteInputTokens: 2 } },
 				},
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([
 				{
 					type: "usage",
@@ -234,7 +234,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 
 		it("defaults missing token fields to 0", async () => {
 			const chunks = [{ metadata: { usage: {} } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([
 				{
 					type: "usage",
@@ -254,7 +254,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: "tu-1", name: "get_weather" } } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: '{"city":"SF"}' } } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([
 				{
 					type: "tool_calls",
@@ -265,7 +265,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 
 		it("does not yield tool_call when no matching active tool call exists", async () => {
 			const chunks = [{ contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: "x" } } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 
@@ -274,23 +274,54 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockStart: { contentBlockIndex: 0, start: { toolUse: { toolUseId: "tu-2", name: "foo" } } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: 123 as any } } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 	})
 
 	describe("thinking blocks", () => {
+		// type may live under start, contentBlock, or the top-level block — check all three independently.
+		it("detects thinking type under contentBlock when start.type is non-matching", async () => {
+			const chunks = [
+				{
+					contentBlockStart: {
+						contentBlockIndex: 0,
+						start: { type: "something_else" },
+						contentBlock: { type: "thinking", thinking: "from-contentBlock" },
+					},
+				},
+			]
+			const out = await runStream(makeHandler(chunks))
+			out.should.deepEqual([{ type: "reasoning", reasoning: "from-contentBlock" }])
+		})
+
+		it("detects thinking type at top-level when start/contentBlock types are non-matching", async () => {
+			const chunks = [
+				{
+					contentBlockStart: {
+						contentBlockIndex: 0,
+						start: { type: "something_else" },
+						contentBlock: { type: "also_else" },
+						type: "thinking",
+						thinking: "from-top-level",
+					},
+				},
+			]
+			const out = await runStream(makeHandler(chunks))
+			out.should.deepEqual([{ type: "reasoning", reasoning: "from-top-level" }])
+		})
+
 		it("yields reasoning with signature on thinking contentBlockStart", async () => {
 			const chunks = [
 				{ contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking", thinking: "init", signature: "s" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "init", signature: "s" }])
 		})
 
 		it("yields nothing on thinking start with no content or signature", async () => {
 			const chunks = [{ contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking" } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 
@@ -299,7 +330,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking" } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { type: "thinking_delta", thinking: "more thought" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "more thought" }])
 		})
 
@@ -308,7 +339,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking" } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { thinking: "raw thinking" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "raw thinking" }])
 		})
 
@@ -317,7 +348,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockStart: { contentBlockIndex: 0, start: { type: "thinking" } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "looks like text" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "looks like text" }])
 		})
 	})
@@ -327,13 +358,13 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 			const chunks = [
 				{ contentBlockStart: { contentBlockIndex: 0, start: { type: "redacted_thinking" }, data: "encrypted" } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "[Redacted thinking block]", redacted_data: "encrypted" }])
 		})
 
 		it("yields redacted reasoning without data when absent", async () => {
 			const chunks = [{ contentBlockStart: { contentBlockIndex: 0, start: { type: "redacted_thinking" } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "[Redacted thinking block]" }])
 		})
 	})
@@ -343,13 +374,13 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 			const chunks = [
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { type: "signature_delta", signature: "sig-x" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "", signature: "sig-x" }])
 		})
 
 		it("does not yield signature_delta without signature", async () => {
 			const chunks = [{ contentBlockDelta: { contentBlockIndex: 0, delta: { type: "signature_delta" } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 	})
@@ -359,13 +390,13 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 			const chunks = [
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "nova reasoning" } } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "reasoning", reasoning: "nova reasoning" }])
 		})
 
 		it("does not yield when reasoningContent.text is empty", async () => {
 			const chunks = [{ contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: "" } } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 	})
@@ -373,7 +404,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 	describe("text content", () => {
 		it("yields text when no block type is set", async () => {
 			const chunks = [{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "hello" } } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "hello" }])
 		})
 
@@ -382,7 +413,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "a" } } },
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "b" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([
 				{ type: "text", text: "a" },
 				{ type: "text", text: "b" },
@@ -399,7 +430,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				// New block at same index after stop — should be treated as text
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "plain text" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([
 				{ type: "reasoning", reasoning: "reasoning text" },
 				{ type: "text", text: "plain text" },
@@ -413,7 +444,7 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				// Tool input after stop — no active tool call, should not yield
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { toolUse: { input: "{}" } } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 	})
@@ -421,36 +452,36 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 	describe("error chunks", () => {
 		it("yields text for internalServerException", async () => {
 			const chunks = [{ internalServerException: { message: "boom" } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "[ERROR] Internal server error: boom" }])
 		})
 
 		it("yields text for modelStreamErrorException", async () => {
 			const chunks = [{ modelStreamErrorException: { message: "model failed" } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "[ERROR] Model stream error: model failed" }])
 		})
 
 		it("yields text for throttlingException", async () => {
 			const chunks = [{ throttlingException: { message: "slow down" } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "[ERROR] Throttling error: slow down" }])
 		})
 
 		it("yields text for validationException (non-context error)", async () => {
 			const chunks = [{ validationException: { message: "bad request" } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "[ERROR] Validation error: bad request" }])
 		})
 
 		it("throws for context-window validationException", async () => {
 			const chunks = [{ validationException: { message: "input is too long, context exceeds maximum" } }]
-			await runStream(makeHandler(chunks), chunks).should.be.rejectedWith(/input is too long/)
+			await runStream(makeHandler(chunks)).should.be.rejectedWith(/input is too long/)
 		})
 
 		it("yields text for serviceUnavailableException", async () => {
 			const chunks = [{ serviceUnavailableException: { message: "down" } }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.deepEqual([{ type: "text", text: "[ERROR] Service unavailable: down" }])
 		})
 	})
@@ -476,13 +507,13 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 		})
 
 		it("yields nothing for empty stream", async () => {
-			const out = await runStream(makeHandler([]), [])
+			const out = await runStream(makeHandler([]))
 			out.should.have.length(0)
 		})
 
 		it("yields nothing for unrecognized chunk shapes", async () => {
 			const chunks = [{ unknownField: "x" }, { another: 1 }]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(0)
 		})
 
@@ -493,11 +524,49 @@ describe("AwsBedrockHandler.executeConverseStream", () => {
 				{ contentBlockDelta: { contentBlockIndex: 0, delta: { thinking: "step" } } },
 				{ contentBlockDelta: { contentBlockIndex: 1, delta: { text: "answer" } } },
 			]
-			const out = await runStream(makeHandler(chunks), chunks)
+			const out = await runStream(makeHandler(chunks))
 			out.should.have.length(3)
 			out[0].type.should.equal("usage")
 			out[1].should.deepEqual({ type: "reasoning", reasoning: "step" })
 			out[2].should.deepEqual({ type: "text", text: "answer" })
 		})
+	})
+})
+
+describe("formatMessagesForConverseAPI content shaping", () => {
+	// Master contract: empty string is preserved as a text block, not collapsed to [].
+	it("preserves empty string content as a text block", () => {
+		const result = formatMessagesForConverseAPI([{ role: "user", content: "" } as DiracStorageMessage])
+		result.should.have.length(1)
+		;(result[0].content ?? []).should.deepEqual([{ text: "" }])
+	})
+
+	it("preserves empty tool_result content as a text block", () => {
+		const result = formatMessagesForConverseAPI([
+			{ role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "" }] } as DiracStorageMessage,
+		])
+		const block = result[0]?.content?.[0] as { toolResult?: { content?: unknown[] } } | undefined
+		;(block?.toolResult?.content ?? []).should.deepEqual([{ text: "" }])
+	})
+
+	it("maps tool_result nested content without top-level toolUse/toolResult blocks", () => {
+		const result = formatMessagesForConverseAPI([
+			{
+				role: "user",
+				content: [
+					{
+						type: "tool_result",
+						tool_use_id: "t1",
+						content: [
+							{ type: "text", text: "ok" },
+							{ type: "tool_use", id: "nested", name: "x", input: {} },
+							{ type: "thinking", thinking: "secret" },
+						],
+					},
+				],
+			} as DiracStorageMessage,
+		])
+		const block = result[0]?.content?.[0] as { toolResult?: { content?: unknown[] } } | undefined
+		;(block?.toolResult?.content ?? []).should.deepEqual([{ text: "ok" }])
 	})
 })

--- a/src/core/api/providers/bedrock-client.ts
+++ b/src/core/api/providers/bedrock-client.ts
@@ -2,8 +2,9 @@
  * Bedrock AWS auth + client construction. Extracted from `bedrock.ts` (FB-15b).
  * Takes the subset of provider options it needs so it never imports the handler.
  */
-import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
+import type { BedrockRuntimeClientConfig } from "@aws-sdk/client-bedrock-runtime"
 import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime"
+import { fromNodeProviderChain } from "@aws-sdk/credential-providers"
 
 export interface AwsBedrockClientOptions {
 	awsAuthentication?: string
@@ -17,12 +18,18 @@ export interface AwsBedrockClientOptions {
 	awsBedrockEndpoint?: string
 }
 
+type FromNodeProviderChainOptions = NonNullable<Parameters<typeof fromNodeProviderChain>[0]>
+
+/** Either bearer-token auth (Bedrock Gateway API key) or resolved AK/SK credentials. */
+type BedrockClientAuth =
+	| Pick<BedrockRuntimeClientConfig, "token" | "authSchemePreference">
+	| Pick<BedrockRuntimeClientConfig, "credentials">
+
 /** Returns the AWS region to use for the given options, with a default fallback. */
-export function resolveRegion(options: AwsBedrockClientOptions, defaultRegion: string): string {
+function resolveRegion(options: AwsBedrockClientOptions, defaultRegion: string): string {
 	return options.awsRegion || defaultRegion
 }
 
-/** Builds an AWS credentials resolver chain, then a BedrockRuntimeClient. */
 /** Resolves AWS credentials from options or the node provider chain, without mutating env. */
 export async function resolveAwsCredentials(
 	options: AwsBedrockClientOptions,
@@ -39,22 +46,15 @@ export async function resolveAwsCredentials(
 			sessionToken: options.awsSessionToken,
 		}
 	}
-	const providerOptions: {
-		clientConfig: { userAgentAppId: string; region?: string }
-		ignoreCache?: boolean
-		profile?: string
-	} = {
-		clientConfig: { userAgentAppId },
+	const providerOptions: FromNodeProviderChainOptions = {
+		clientConfig: { userAgentAppId, region },
 	}
-	providerOptions.clientConfig.region = region
 	if (useProfile) {
 		providerOptions.ignoreCache = true
 		if (options.awsProfile) providerOptions.profile = options.awsProfile
 	}
-	return await fromNodeProviderChain(providerOptions as never)()
+	return fromNodeProviderChain(providerOptions)()
 }
-
-
 
 export async function createBedrockClient(
 	options: AwsBedrockClientOptions,
@@ -63,27 +63,20 @@ export async function createBedrockClient(
 ): Promise<BedrockRuntimeClient> {
 	const region = resolveRegion(options, defaultRegion)
 
-	let auth: unknown
+	let auth: BedrockClientAuth
 	if (options.awsAuthentication === "apikey") {
 		auth = {
-			token: { token: options.awsBedrockApiKey },
+			token: { token: options.awsBedrockApiKey ?? "" },
 			authSchemePreference: ["httpBearerAuth"],
 		}
 	} else {
-		const credentials = await resolveAwsCredentials(options, region, userAgentAppId)
-		auth = {
-			credentials: {
-				accessKeyId: credentials.accessKeyId,
-				secretAccessKey: credentials.secretAccessKey,
-				sessionToken: credentials.sessionToken,
-			},
-		}
+		auth = { credentials: await resolveAwsCredentials(options, region, userAgentAppId) }
 	}
 
 	return new BedrockRuntimeClient({
 		userAgentAppId,
 		region,
-		...(auth as Record<string, unknown>),
+		...auth,
 		...(options.awsBedrockEndpoint ? { endpoint: options.awsBedrockEndpoint } : {}),
 	})
 }

--- a/src/core/api/providers/bedrock-converse-utils.ts
+++ b/src/core/api/providers/bedrock-converse-utils.ts
@@ -2,13 +2,27 @@
  * Pure helpers shared by the Bedrock provider. Extracted out of
  * `src/core/api/providers/bedrock.ts` (FB-15b) — no class state.
  */
-import { Logger } from "@/shared/services/Logger"
-import { getErrorMessage } from "@/shared/errors"
 import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/index"
-import type { ContentBlock, Message, ToolConfiguration } from "@aws-sdk/client-bedrock-runtime"
-import type { DiracTool } from "@/shared/tools"
-import type { DiracStorageMessage } from "@/shared/messages/content"
+import type {
+	ContentBlock,
+	ConverseCommandOutput,
+	ImageFormat,
+	InferenceConfiguration,
+	Message,
+	SystemContentBlock,
+	Tool,
+	ToolConfiguration,
+	ToolResultContentBlock,
+	ToolSpecification,
+	ToolUseBlock,
+} from "@aws-sdk/client-bedrock-runtime"
 import { ConversationRole } from "@aws-sdk/client-bedrock-runtime"
+import type { ModelInfo } from "@shared/api"
+import { getErrorMessage } from "@/shared/errors"
+import type { DiracContent, DiracImageContentBlock, DiracStorageMessage } from "@/shared/messages/content"
+import { Logger } from "@/shared/services/Logger"
+import type { DiracTool } from "@/shared/tools"
+import type { ApiStreamChunk } from "../transform/stream"
 
 /** Approximate token count (4 characters per token). */
 export function estimateTokenCount(text: string): number {
@@ -16,17 +30,13 @@ export function estimateTokenCount(text: string): number {
 }
 
 /** Extracts the visible text + reasoning text from a non-streaming Converse response. */
-export function extractNonStreamingContent(response: any): { fullText: string; reasoningText: string } {
+export function extractNonStreamingContent(response: ConverseCommandOutput): { fullText: string; reasoningText: string } {
 	let fullText = ""
 	let reasoningText = ""
-	if (!response.output?.message?.content) return { fullText, reasoningText }
-	for (const block of response.output.message.content) {
-		if ("reasoningContent" in block && block.reasoningContent) {
-			const reasoning = block.reasoningContent
-			if ("reasoningText" in reasoning && reasoning.reasoningText && "text" in reasoning.reasoningText) {
-				reasoningText += reasoning.reasoningText.text
-			}
-		} else if ("text" in block && block.text) {
+	for (const block of response.output?.message?.content ?? []) {
+		if (block.reasoningContent?.reasoningText?.text) {
+			reasoningText += block.reasoningContent.reasoningText.text
+		} else if (block.text) {
 			fullText += block.text
 		}
 	}
@@ -43,7 +53,7 @@ export function formatConverseError(error: unknown, label: string): string {
 }
 
 /** Prepares system messages with optional Converse caching support. */
-export function prepareSystemMessages(systemPrompt: string, enableCaching: boolean): any[] | undefined {
+export function prepareSystemMessages(systemPrompt: string, enableCaching: boolean): SystemContentBlock[] | undefined {
 	if (!systemPrompt) {
 		return undefined
 	}
@@ -53,19 +63,15 @@ export function prepareSystemMessages(systemPrompt: string, enableCaching: boole
 	return [{ text: systemPrompt }]
 }
 
-/** Chunks text into 1000-char segments and yields as the given chunk type. */
-export function* chunkText(text: string, type: "text" | "reasoning"): Generator<any> {
+const TEXT_CHUNK_SIZE = 1000
+
+/** Chunks text into TEXT_CHUNK_SIZE segments and yields as the given chunk type. */
+export function* chunkText(text: string, type: "text" | "reasoning"): Generator<ApiStreamChunk> {
 	if (!text) return
-	const chunkSize = 1000
-	for (let i = 0; i < text.length; i += chunkSize) {
-		const chunk = text.slice(i, Math.min(i + chunkSize, text.length))
+	for (let i = 0; i < text.length; i += TEXT_CHUNK_SIZE) {
+		const chunk = text.slice(i, Math.min(i + TEXT_CHUNK_SIZE, text.length))
 		yield type === "reasoning" ? { type: "reasoning", reasoning: chunk } : { type: "text", text: chunk }
 	}
-}
-
-/** Cache-point content block type for AWS Bedrock Converse prompt caching. */
-interface CachePointContentBlockShape {
-	cachePoint: { type: "default" }
 }
 
 /**
@@ -81,37 +87,37 @@ export function mapDiracToolsToBedrockToolConfig(tools?: DiracTool[]): ToolConfi
 		toolSpec: {
 			name: tool.name,
 			description: tool.description || tool.name || "Tool",
-			inputSchema: { json: tool.input_schema },
+			// Anthropic's JSON schema is structurally a valid Converse JSON schema.
+			inputSchema: { json: tool.input_schema as NonNullable<ToolSpecification["inputSchema"]>["json"] },
 		},
 	}))
 	if (bedrockTools.length === 0) {
 		return undefined
 	}
 	return {
-		tools: bedrockTools as unknown as ToolConfiguration["tools"],
+		// The literal matches ToolSpecMember; Smithy union members additionally
+		// declare exclusive/$unknown fields that plain literals cannot carry.
+		tools: bedrockTools as Tool[],
 		toolChoice: { auto: {} },
 	}
 }
 
 /** Converts a Dirac image content block into a Bedrock image content block. */
-export function processImageContent(item: any): ContentBlock | null {
-	let imageData: Uint8Array
-	let format: "png" | "jpeg" | "gif" | "webp" = "jpeg"
-	if (item.source.media_type) {
-		const formatMatch = item.source.media_type.match(/image\/(\w+)/)
-		if (formatMatch && formatMatch[1] && ["png", "jpeg", "gif", "webp"].includes(formatMatch[1])) {
-			format = formatMatch[1] as "png" | "jpeg" | "gif" | "webp"
+export function processImageContent(item: DiracImageContentBlock): ContentBlock | null {
+	const source = item.source
+	let format: ImageFormat = "jpeg"
+	if (source.type === "base64") {
+		const formatMatch = source.media_type.match(/image\/(\w+)/)
+		if (formatMatch?.[1] && (["png", "jpeg", "gif", "webp"] as readonly string[]).includes(formatMatch[1])) {
+			format = formatMatch[1] as ImageFormat
 		}
 	}
 	try {
-		if (typeof item.source.data === "string") {
-			const base64Data = item.source.data.replace(/^data:image\/\w+;base64,/, "")
-			imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
-		} else if (item.source.data && typeof item.source.data === "object") {
-			imageData = new Uint8Array(Buffer.from(item.source.data as Buffer | Uint8Array))
-		} else {
+		if (source.type !== "base64") {
 			throw new Error("Unsupported image data format")
 		}
+		const base64Data = source.data.replace(/^data:image\/\w+;base64,/, "")
+		const imageData = new Uint8Array(Buffer.from(base64Data, "base64"))
 		return { image: { format, source: { bytes: imageData } } }
 	} catch (error) {
 		Logger.error("Failed to process image content:", error)
@@ -119,29 +125,28 @@ export function processImageContent(item: any): ContentBlock | null {
 	}
 }
 
-/** Applies Bedrock cache-point markers to the last + second-to-last user messages. */
-export function applyCacheControlToMessages(messages: Message[], userIndices: [number, number]): Message[] {
-	const [, lastUserMsgIndex] = userIndices
-	const secondLastMsgUserIndex = userIndices[0] ?? -1
+/**
+ * Applies Bedrock cache-point markers to the last + second-to-last user messages.
+ * A -1 index marks "no such message".
+ */
+export function applyCacheControlToMessages(
+	messages: Message[],
+	userIndices: { lastUserIndex: number; secondLastUserIndex: number },
+): Message[] {
+	const { lastUserIndex, secondLastUserIndex } = userIndices
 	return messages.map((message, index) => {
-		if (index === lastUserMsgIndex || index === secondLastMsgUserIndex) {
-			const messageWithCache = { ...message }
-			if (messageWithCache.content && Array.isArray(messageWithCache.content)) {
-				messageWithCache.content = [
-					...messageWithCache.content,
-					{ cachePoint: { type: "default" } } as CachePointContentBlockShape,
-				]
-			}
-			return messageWithCache
+		if (index !== lastUserIndex && index !== secondLastUserIndex) {
+			return message
 		}
-		return message
+		return appendCachePoint(message)
 	})
 }
 
-export interface ContentItem {
-	type: string
-	text?: string
-	source?: unknown
+function appendCachePoint(message: Message): Message {
+	if (!message.content || !Array.isArray(message.content)) {
+		return message
+	}
+	return { ...message, content: [...message.content, { cachePoint: { type: "default" } }] }
 }
 
 /** Converts Dirac (Anthropic-format) messages to Bedrock Converse `Message[]`. */
@@ -149,68 +154,77 @@ export function formatMessagesForConverseAPI(messages: DiracStorageMessage[], su
 	return messages.map((message) => {
 		const role = message.role === "user" ? ConversationRole.USER : ConversationRole.ASSISTANT
 		let content: ContentBlock[] = []
+		// Preserve empty-string content as a text block (master contract).
 		if (typeof message.content === "string") {
 			content = [{ text: message.content }]
 		} else if (Array.isArray(message.content)) {
 			content = message.content
-				.map((item) => {
-					if (item.type === "text") return { text: item.text }
-					if (item.type === "image") {
-						if (supportsImages) return processImageContent(item)
-						return { text: "[Image]" }
-					}
-					if (item.type === "tool_use") {
-						return {
-							toolUse: { toolUseId: item.id, name: item.name, input: item.input },
-						}
-					}
-					if (item.type === "thinking" || item.type === "redacted_thinking") return null
-					if (item.type === "tool_result") {
-						const toolResultContent = (() => {
-							if (typeof item.content === "string") return [{ text: item.content }]
-							if (Array.isArray(item.content)) {
-								return item.content
-									.map((block) => {
-										if (block.type === "text") return { text: block.text }
-										if (block.type === "image") {
-											if (supportsImages) return processImageContent(block)
-											return { text: "[Image]" }
-										}
-										return null
-									})
-									.filter((block): block is ContentBlock => block !== null)
-							}
-							return [{ text: JSON.stringify(item.content) }]
-						})()
-						return {
-							toolResult: {
-								toolUseId: item.tool_use_id,
-								content: toolResultContent,
-								status: item.is_error ? "error" : "success",
-							},
-						}
-					}
-					Logger.warn(`Unsupported content type: ${(item as ContentItem).type}`)
-					return null
-				})
+				.map((item) => mapMessageContentBlock(item as DiracContent, supportsImages))
 				.filter((item): item is ContentBlock => item !== null)
 		}
 		return { role, content }
 	})
 }
 
-/** Gets the Bedrock Converse inference configuration for a model type. */
-export function getInferenceConfig(modelInfo: unknown, modelType: "anthropic" | "nova", thinkingBudgetTokens: number): any {
-	const mi = modelInfo as { supportsReasoning?: boolean; maxTokens?: number; temperature?: number }
-	if (modelType === "anthropic") {
-		const reasoningOn = !!mi.supportsReasoning && thinkingBudgetTokens > 0
+function mapMessageContentBlock(item: DiracContent, supportsImages: boolean): ContentBlock | null {
+	if (item.type === "text") return { text: item.text }
+	if (item.type === "image") return supportsImages ? processImageContent(item) : { text: "[Image]" }
+	if (item.type === "tool_use") {
+		// Tool inputs are unvalidated JSON at the Converse boundary.
+		return { toolUse: { toolUseId: item.id, name: item.name, input: item.input as ToolUseBlock["input"] } }
+	}
+	if (item.type === "thinking" || item.type === "redacted_thinking") return null
+	if (item.type === "tool_result") {
 		return {
-			maxTokens: mi.maxTokens || 8192,
-			temperature: reasoningOn ? undefined : (mi.temperature ?? undefined),
+			toolResult: {
+				toolUseId: item.tool_use_id,
+				content: mapToolResultContent(item.content, supportsImages),
+				status: item.is_error ? "error" : "success",
+			},
+		}
+	}
+	Logger.warn(`Unsupported content type: ${item.type}`)
+	return null
+}
+
+// Maps tool_result payload to ToolResultContentBlock only (text/image/json) — never top-level toolUse/toolResult.
+function mapToolResultContent(
+	content: string | readonly DiracContent[] | unknown,
+	supportsImages: boolean,
+): ToolResultContentBlock[] {
+	if (typeof content === "string") return [{ text: content }]
+	if (Array.isArray(content)) {
+		return content.flatMap((block) => mapToolResultContentBlock(block as DiracContent, supportsImages))
+	}
+	return [{ json: content as never }]
+}
+
+function mapToolResultContentBlock(block: DiracContent, supportsImages: boolean): ToolResultContentBlock[] {
+	if (block.type === "text") return [{ text: block.text }]
+	if (block.type === "image") {
+		if (!supportsImages) return [{ text: "[Image]" }]
+		const imageBlock = processImageContent(block)
+		return imageBlock?.image ? [{ image: imageBlock.image }] : [{ text: "[Image]" }]
+	}
+	// Nested tool_use/tool_result/thinking are not valid ToolResultContentBlock members.
+	return []
+}
+
+/** Gets the Bedrock Converse inference configuration for a model type. */
+export function getInferenceConfig(
+	modelInfo: ModelInfo,
+	modelType: "anthropic" | "nova",
+	thinkingBudgetTokens: number,
+): InferenceConfiguration {
+	if (modelType === "anthropic") {
+		const reasoningOn = thinkingBudgetTokens > 0 && (modelInfo.supportsReasoning ?? false)
+		return {
+			maxTokens: modelInfo.maxTokens || 8192,
+			temperature: reasoningOn ? undefined : modelInfo.temperature,
 		}
 	}
 	return {
-		maxTokens: mi.maxTokens || (modelType === "nova" ? 5000 : 8192),
-		temperature: mi.temperature ?? 0,
+		maxTokens: modelInfo.maxTokens || (modelType === "nova" ? 5000 : 8192),
+		temperature: modelInfo.temperature ?? 0,
 	}
 }

--- a/src/core/api/providers/bedrock-stream-parser.ts
+++ b/src/core/api/providers/bedrock-stream-parser.ts
@@ -1,75 +1,48 @@
 /**
  * Bedrock ConverseStream chunk parser. Extracted from `bedrock.ts` (FB-15b).
+ *
+ * Chunks are typed against the SDK's `ConverseStreamOutput` union. The
+ * reasoning payloads that Anthropic-on-Bedrock emits extend beyond the strict
+ * SDK shapes, so those fields are read through the small structural
+ * interfaces documented below.
  */
-import { calculateApiCostOpenAI } from "@utils/cost"
+import type { ConverseStreamOutput, TokenUsage } from "@aws-sdk/client-bedrock-runtime"
 import type { ModelInfo } from "@shared/api"
+import { calculateApiCostOpenAI } from "@utils/cost"
+import type { ApiStreamChunk } from "../transform/stream"
 
-interface ExtendedMetadata {
-	usage?: {
-		inputTokens?: number
-		outputTokens?: number
-		cacheReadInputTokens?: number
-		cacheWriteInputTokens?: number
-	}
-	additionalModelResponseFields?: {
-		thinkingResponse?: {
-			reasoning?: Array<{
-				type: string
-				text?: string
-				signature?: string
-			}>
-		}
-	}
+/** Reasoning blocks delivered via metadata.additionalModelResponseFields. */
+interface ThinkingResponseFields {
+	reasoning?: Array<{ type: string; text?: string; signature?: string }>
 }
 
-interface ContentBlockStart {
-	contentBlockIndex?: number
-	start?: {
-		type?: string
-		thinking?: string
-		signature?: string
-		toolUse?: ToolUseStart
-	}
-	contentBlock?: {
-		type?: string
-		thinking?: string
-		signature?: string
-	}
+/** additionalModelResponseFields is delivered by Bedrock but absent from the published SDK event shape. */
+type MetadataWithThinkingFields = {
+	additionalModelResponseFields?: { thinkingResponse?: ThinkingResponseFields }
+}
+
+/** Reasoning fields delivered on contentBlockStart beyond the strict SDK event shape. */
+interface ReasoningStartFields {
 	type?: string
 	thinking?: string
-	// Redacted thinking block data
-	data?: string
+	signature?: string
 }
 
-interface ContentBlockDelta {
-	contentBlockIndex?: number
-	delta?: {
-		type?: string
-		thinking?: string
-		text?: string
-		signature?: string
-		reasoningContent?: {
-			text?: string
-		}
-		toolUse?: ToolUseDelta
-	}
-}
-
-interface ToolUseStart {
-	toolUseId: string
-	name: string
-}
-
-interface ToolUseDelta {
-	input: string
+/** Fields delivered on contentBlockDelta beyond the strict SDK ContentBlockDelta union. */
+interface ReasoningDeltaFields {
+	type?: string
+	text?: string
+	thinking?: string
+	signature?: string
+	reasoningContent?: { text?: string }
+	toolUse?: { input: string }
 }
 
 export class BedrockStreamParser {
-	private contentBuffers: Record<number, string> = {}
-	private blockTypes = new Map<number, "reasoning" | "text">()
-	private activeToolCalls: Map<number, { toolUseId: string; name: string }> = new Map()
+	private reasoningBlocks = new Set<number>()
+	private activeToolCalls = new Map<number, { toolUseId: string; name: string }>()
 
-	public *parseChunk(chunk: any, modelInfo: ModelInfo): Generator<any> {
+	public *parseChunk(chunk: ConverseStreamOutput, modelInfo: ModelInfo): Generator<ApiStreamChunk> {
 		yield* this.handleMetadata(chunk, modelInfo)
 		yield* this.handleContentBlockStart(chunk)
 		yield* this.handleContentBlockDelta(chunk)
@@ -77,24 +50,23 @@ export class BedrockStreamParser {
 		yield* this.handleStreamError(chunk)
 	}
 
-	private *handleMetadata(chunk: any, modelInfo: ModelInfo): Generator<any> {
-		const metadata = chunk.metadata as ExtendedMetadata | undefined
-		if (metadata?.additionalModelResponseFields?.thinkingResponse) {
-			yield* this.parseThinkingResponse(metadata.additionalModelResponseFields.thinkingResponse)
-		}
-		if (chunk.metadata?.usage) yield this.buildUsageChunk(chunk.metadata.usage, modelInfo)
+	private *handleMetadata(chunk: ConverseStreamOutput, modelInfo: ModelInfo): Generator<ApiStreamChunk> {
+		if (!chunk.metadata) return
+		const thinkingResponse = (chunk.metadata as MetadataWithThinkingFields).additionalModelResponseFields?.thinkingResponse
+		if (thinkingResponse) yield* this.parseThinkingResponse(thinkingResponse)
+		if (chunk.metadata.usage) yield this.buildUsageChunk(chunk.metadata.usage, modelInfo)
 	}
 
-	private *parseThinkingResponse(thinkingResponse: any): Generator<any> {
-		if (!thinkingResponse.reasoning || !Array.isArray(thinkingResponse.reasoning)) return
-		for (const block of thinkingResponse.reasoning) {
-			if (block.type === "text" && block.text) {
-				yield { type: "reasoning", reasoning: block.text, ...(block.signature ? { signature: block.signature } : {}) }
-			}
+	private *parseThinkingResponse(thinkingResponse: ThinkingResponseFields): Generator<ApiStreamChunk> {
+		for (const block of thinkingResponse.reasoning ?? []) {
+			if (block.type !== "text" || !block.text) continue
+			yield block.signature
+				? { type: "reasoning", reasoning: block.text, signature: block.signature }
+				: { type: "reasoning", reasoning: block.text }
 		}
 	}
 
-	private buildUsageChunk(usage: any, modelInfo: ModelInfo): any {
+	private buildUsageChunk(usage: TokenUsage, modelInfo: ModelInfo): ApiStreamChunk {
 		const inputTokens = usage.inputTokens || 0
 		const outputTokens = usage.outputTokens || 0
 		const cacheReadInputTokens = usage.cacheReadInputTokens || 0
@@ -109,40 +81,45 @@ export class BedrockStreamParser {
 		}
 	}
 
-	private *handleContentBlockStart(chunk: any): Generator<any> {
+	private *handleContentBlockStart(chunk: ConverseStreamOutput): Generator<ApiStreamChunk> {
 		if (!chunk.contentBlockStart) return
-		const blockStart = chunk.contentBlockStart as ContentBlockStart
-		const blockIndex = chunk.contentBlockStart.contentBlockIndex
-		if (blockStart.start?.toolUse?.toolUseId && blockStart.start.toolUse.name && blockIndex !== undefined) {
-			this.activeToolCalls.set(blockIndex, {
-				toolUseId: blockStart.start.toolUse.toolUseId,
-				name: blockStart.start.toolUse.name,
-			})
+		const blockStart = chunk.contentBlockStart as unknown as ContentBlockStartFields
+		const blockIndex = blockStart.contentBlockIndex
+		const start = blockStart.start
+		if (start?.toolUse?.toolUseId && start.toolUse.name && blockIndex !== undefined) {
+			this.activeToolCalls.set(blockIndex, { toolUseId: start.toolUse.toolUseId, name: start.toolUse.name })
 		}
 		yield* this.handleThinkingBlockStart(blockStart, blockIndex)
 		yield* this.handleRedactedThinkingBlockStart(blockStart)
 	}
 
-	private *handleThinkingBlockStart(blockStart: ContentBlockStart, blockIndex: number | undefined): Generator<any> {
-		const isThinking =
-			blockStart.start?.type === "thinking" ||
-			blockStart.contentBlock?.type === "thinking" ||
-			blockStart.type === "thinking"
-		if (!isThinking || blockIndex === undefined) return
-		this.blockTypes.set(blockIndex, "reasoning")
+	/**
+	 * contentBlockStart fields. The SDK event carries them under `start`, but some
+	 * providers nest them under `contentBlock` or inline at the block level — all
+	 * three locations are checked independently (not short-circuited with ??).
+	 */
+	private blockStartType(blockStart: ContentBlockStartFields): "thinking" | "redacted_thinking" | undefined {
+		for (const type of [blockStart.start?.type, blockStart.contentBlock?.type, blockStart.type]) {
+			if (type === "thinking" || type === "redacted_thinking") return type
+		}
+		return undefined
+	}
+
+	private *handleThinkingBlockStart(
+		blockStart: ContentBlockStartFields,
+		blockIndex: number | undefined,
+	): Generator<ApiStreamChunk> {
+		if (this.blockStartType(blockStart) !== "thinking" || blockIndex === undefined) return
+		this.reasoningBlocks.add(blockIndex)
 		const signature = blockStart.start?.signature || blockStart.contentBlock?.signature || undefined
 		const initialContent = blockStart.start?.thinking || blockStart.contentBlock?.thinking || blockStart.thinking || ""
 		if (initialContent || signature) {
-			yield { type: "reasoning", reasoning: initialContent || "", ...(signature ? { signature } : {}) }
+			yield { type: "reasoning", reasoning: initialContent, ...(signature ? { signature } : {}) }
 		}
 	}
 
-	private *handleRedactedThinkingBlockStart(blockStart: ContentBlockStart): Generator<any> {
-		const isRedacted =
-			blockStart.start?.type === "redacted_thinking" ||
-			blockStart.contentBlock?.type === "redacted_thinking" ||
-			blockStart.type === "redacted_thinking"
-		if (!isRedacted) return
+	private *handleRedactedThinkingBlockStart(blockStart: ContentBlockStartFields): Generator<ApiStreamChunk> {
+		if (this.blockStartType(blockStart) !== "redacted_thinking") return
 		yield {
 			type: "reasoning",
 			reasoning: "[Redacted thinking block]",
@@ -150,24 +127,16 @@ export class BedrockStreamParser {
 		}
 	}
 
-	private *handleContentBlockDelta(chunk: any): Generator<any> {
+	private *handleContentBlockDelta(chunk: ConverseStreamOutput): Generator<ApiStreamChunk> {
 		if (!chunk.contentBlockDelta) return
 		const blockIndex = chunk.contentBlockDelta.contentBlockIndex
 		if (blockIndex === undefined) return
-		if (!(blockIndex in this.contentBuffers)) this.contentBuffers[blockIndex] = ""
-
-		const blockType = this.blockTypes.get(blockIndex)
-		const delta = chunk.contentBlockDelta.delta as ContentBlockDelta["delta"]
-		yield* this.parseDelta(delta, blockIndex, blockType, chunk)
+		const delta = chunk.contentBlockDelta.delta as unknown as ReasoningDeltaFields | undefined
+		yield* this.parseDelta(delta, blockIndex)
 	}
 
-	private *parseDelta(
-		delta: ContentBlockDelta["delta"],
-		blockIndex: number,
-		blockType: "reasoning" | "text" | undefined,
-		chunk: any,
-	): Generator<any> {
-		if (delta?.type === "signature_delta" && delta?.signature) {
+	private *parseDelta(delta: ReasoningDeltaFields | undefined, blockIndex: number): Generator<ApiStreamChunk> {
+		if (delta?.type === "signature_delta" && delta.signature) {
 			yield { type: "reasoning", reasoning: "", signature: delta.signature }
 			return
 		}
@@ -180,16 +149,16 @@ export class BedrockStreamParser {
 			yield { type: "reasoning", reasoning: delta.reasoningContent.text }
 			return
 		}
-		if (delta?.toolUse?.input !== undefined) {
+		if (delta?.toolUse) {
 			yield* this.parseToolUseDelta(delta.toolUse.input, blockIndex)
 			return
 		}
-		if (chunk.contentBlockDelta.delta?.text) {
-			yield* this.parseTextDelta(chunk.contentBlockDelta.delta.text, blockIndex, blockType)
+		if (delta?.text) {
+			yield* this.parseTextDelta(delta.text, blockIndex)
 		}
 	}
 
-	private *parseToolUseDelta(toolInput: any, blockIndex: number): Generator<any> {
+	private *parseToolUseDelta(toolInput: unknown, blockIndex: number): Generator<ApiStreamChunk> {
 		const toolCall = this.activeToolCalls.get(blockIndex)
 		if (!toolCall || typeof toolInput !== "string") return
 		yield {
@@ -201,25 +170,21 @@ export class BedrockStreamParser {
 		}
 	}
 
-	private *parseTextDelta(
-		textContent: string,
-		blockIndex: number,
-		blockType: "reasoning" | "text" | undefined,
-	): Generator<any> {
-		this.contentBuffers[blockIndex] += textContent
-		yield blockType === "reasoning" ? { type: "reasoning", reasoning: textContent } : { type: "text", text: textContent }
+	private *parseTextDelta(textContent: string, blockIndex: number): Generator<ApiStreamChunk> {
+		yield this.reasoningBlocks.has(blockIndex)
+			? { type: "reasoning", reasoning: textContent }
+			: { type: "text", text: textContent }
 	}
 
-	private *handleContentBlockStop(chunk: any): Generator<void> {
+	private *handleContentBlockStop(chunk: ConverseStreamOutput): Generator<ApiStreamChunk> {
 		if (!chunk.contentBlockStop) return
 		const blockIndex = chunk.contentBlockStop.contentBlockIndex
 		if (blockIndex === undefined) return
-		delete this.contentBuffers[blockIndex]
-		this.blockTypes.delete(blockIndex)
+		this.reasoningBlocks.delete(blockIndex)
 		this.activeToolCalls.delete(blockIndex)
 	}
 
-	private *handleStreamError(chunk: any): Generator<any> {
+	private *handleStreamError(chunk: ConverseStreamOutput): Generator<ApiStreamChunk> {
 		if (chunk.internalServerException) {
 			yield { type: "text", text: `[ERROR] Internal server error: ${chunk.internalServerException.message}` }
 		} else if (chunk.modelStreamErrorException) {
@@ -235,4 +200,14 @@ export class BedrockStreamParser {
 			yield { type: "text", text: `[ERROR] Service unavailable: ${chunk.serviceUnavailableException.message}` }
 		}
 	}
+}
+
+/** contentBlockStart payload with the reasoning extensions this parser reads. */
+interface ContentBlockStartFields {
+	contentBlockIndex?: number
+	start?: ReasoningStartFields & { toolUse?: { toolUseId: string; name: string } }
+	contentBlock?: ReasoningStartFields
+	type?: string
+	thinking?: string
+	data?: string
 }

--- a/src/core/api/providers/bedrock.ts
+++ b/src/core/api/providers/bedrock.ts
@@ -1,5 +1,6 @@
 // Import proper AWS SDK types
 
+import type { Message, SystemContentBlock, ToolConfiguration } from "@aws-sdk/client-bedrock-runtime"
 import {
 	BedrockRuntimeClient,
 	ConverseCommand,
@@ -14,9 +15,6 @@ import {
 	type ModelInfo,
 } from "@shared/api"
 import { calculateApiCostOpenAI, calculateApiCostQwen } from "@utils/cost"
-import { applyCacheControlToMessages, chunkText, estimateTokenCount, extractNonStreamingContent, formatConverseError, formatMessagesForConverseAPI, getInferenceConfig, mapDiracToolsToBedrockToolConfig, prepareSystemMessages } from "./bedrock-converse-utils"
-import { createBedrockClient, resolveAwsCredentials } from "./bedrock-client"
-import { BedrockStreamParser } from "./bedrock-stream-parser"
 import { ExtensionRegistryInfo } from "@/registry"
 import { getErrorMessage } from "@/shared/errors"
 import type { DiracStorageMessage } from "@/shared/messages/content"
@@ -26,6 +24,19 @@ import type { ApiHandler, CommonApiHandlerOptions } from "../"
 import { withRetry } from "../retry"
 import { convertToR1Format } from "../transform/r1-format"
 import type { ApiStream } from "../transform/stream"
+import { createBedrockClient, resolveAwsCredentials } from "./bedrock-client"
+import {
+	applyCacheControlToMessages,
+	chunkText,
+	estimateTokenCount,
+	extractNonStreamingContent,
+	formatConverseError,
+	formatMessagesForConverseAPI,
+	getInferenceConfig,
+	mapDiracToolsToBedrockToolConfig,
+	prepareSystemMessages,
+} from "./bedrock-converse-utils"
+import { BedrockStreamParser } from "./bedrock-stream-parser"
 
 const BEDROCK_USER_AGENT_APP_ID = `dirac#${ExtensionRegistryInfo.version}`
 
@@ -58,17 +69,6 @@ export interface BedrockMessageConfig {
 	abortSignal?: AbortSignal
 }
 
-
-
-
-
-
-
-type SupportedContentType = "text" | "image" | "thinking" | "redacted_thinking" | "document"
-
-
-// Define provider options type based on AWS SDK patterns
-
 // a special jp inference profile was created for sonnet 4.6, opus 4.6, sonnet 4.5 & haiku 4.5
 // https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
 const JP_SUPPORTED_CRIS_MODELS = [
@@ -81,7 +81,6 @@ const JP_SUPPORTED_CRIS_MODELS = [
 
 // Parses Bedrock ConverseStream events into Dirac ApiStreamChunk objects.
 // Tracks per-block state (content buffers, block types, active tool calls) across the stream.
-
 
 // https://docs.anthropic.com/en/api/claude-on-amazon-bedrock
 export class AwsBedrockHandler implements ApiHandler {
@@ -201,20 +200,12 @@ export class AwsBedrockHandler implements ApiHandler {
 	private static readonly DEFAULT_REGION = "us-east-1"
 
 	/**
-	 * Gets AWS credentials using the provider chain
-	 * Centralizes credential retrieval logic for all AWS services
-	 */
-
-	/**
 	 * Gets the AWS region to use, with fallback to default
 	 */
 	private getRegion(): string {
 		return this.options.awsRegion || AwsBedrockHandler.DEFAULT_REGION
 	}
 
-	/**
-	 * Creates a BedrockRuntimeClient with the appropriate credentials
-	 */
 	/** Resolves AWS credentials for this handler from options or the node provider chain. */
 	public getAwsCredentials(): Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }> {
 		return resolveAwsCredentials(this.options, this.getRegion(), BEDROCK_USER_AGENT_APP_ID)
@@ -473,34 +464,44 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	/**
-	 * Prepares system messages with optional caching support
+	 * Shared Converse preamble: format messages, apply (optional) cache controls,
+	 * prepare system messages, and map tools. De-duplicates create*Message methods.
 	 */
-
-	/**
-	 * Gets inference configuration for different model types
-	 */
+	private prepareConverseInputs(
+		config: BedrockMessageConfig,
+		applyCache: boolean,
+	): {
+		messagesWithCache: Message[]
+		systemMessages: SystemContentBlock[] | undefined
+		toolConfig: ToolConfiguration | undefined
+	} {
+		const { messages, model, systemPrompt, tools } = config
+		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
+		const userMsgIndices: number[] = []
+		messages.forEach((msg, index) => {
+			if (msg.role === "user") userMsgIndices.push(index)
+		})
+		const messagesWithCache = applyCache
+			? applyCacheControlToMessages(formattedMessages, {
+					lastUserIndex: userMsgIndices.at(-1) ?? -1,
+					secondLastUserIndex: userMsgIndices.at(-2) ?? -1,
+				})
+			: formattedMessages
+		const systemMessages = prepareSystemMessages(systemPrompt, applyCache)
+		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
+		return { messagesWithCache, systemMessages, toolConfig }
+	}
 
 	/**
 	 * Creates a message using Anthropic Claude models through AWS Bedrock Converse API
 	 * Implements support for Anthropic Claude models using the unified Converse API
 	 */
 	private async *createAnthropicMessage(config: BedrockMessageConfig): ApiStream {
-		const { systemPrompt, messages, modelId, model, tools } = config
-		// Format messages for Anthropic model using unified formatter
-		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
-
-		// Get model info and message indices for caching
-		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		// Apply caching controls to messages if enabled
-		const messagesWithCache = this.options.awsBedrockUsePromptCache
-			? applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
-			: formattedMessages
-
-		// Prepare system message with caching support
-		const systemMessages = prepareSystemMessages(systemPrompt, this.options.awsBedrockUsePromptCache || false)
+		const { modelId, model } = config
+		const { messagesWithCache, systemMessages, toolConfig } = this.prepareConverseInputs(
+			config,
+			!!this.options.awsBedrockUsePromptCache,
+		)
 
 		// Get thinking configuration
 		const budget_tokens = this.options.thinkingBudgetTokens || 0
@@ -508,7 +509,6 @@ export class AwsBedrockHandler implements ApiHandler {
 		const useAdaptive = isAnthropicAdaptiveThinkingSupported(modelId, model.info)
 
 		// Prepare request for Anthropic model using Converse API
-		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseStreamCommand({
 			modelId: modelId,
 			messages: messagesWithCache,
@@ -534,45 +534,15 @@ export class AwsBedrockHandler implements ApiHandler {
 	}
 
 	/**
-	 * Formats messages for models using the Converse API specification
-	 * Used by both Anthropic and Nova models to avoid code duplication
-	 */
-
-	/**
-	 * Processes image content with proper error handling and user notification
-	 */
-
-	/**
-	 * Applies cache control to messages for prompt caching using AWS Bedrock's cachePoint system
-	 * AWS Bedrock uses cachePoint objects instead of Anthropic's cache_control approach
-	 */
-
-	/**
 	 * Creates a message using Amazon Nova models through AWS Bedrock
 	 * Implements support for Amazon Nova models with caching support
 	 */
 	private async *createNovaMessage(config: BedrockMessageConfig): ApiStream {
-		const { systemPrompt, messages, modelId, model, tools } = config
-		// Format messages for Nova model using unified formatter
-		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
-
-		// Get model info and message indices for caching (for Nova models that support it)
-		const userMsgIndices = messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [] as number[])
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastMsgUserIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		// Apply caching controls to messages if model supports caching and option is enabled
-		const messagesWithCache =
-			this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
-				? applyCacheControlToMessages(formattedMessages, [secondLastMsgUserIndex, lastUserMsgIndex])
-				: formattedMessages
-
-		// Prepare system message with caching support for Nova models that support it
-		const enableCaching = this.options.awsBedrockUsePromptCache && model.info.supportsPromptCache
-		const systemMessages = prepareSystemMessages(systemPrompt, enableCaching || false)
+		const { modelId, model } = config
+		const applyCache = !!this.options.awsBedrockUsePromptCache && !!model.info.supportsPromptCache
+		const { messagesWithCache, systemMessages, toolConfig } = this.prepareConverseInputs(config, applyCache)
 
 		// Prepare request for Nova model
-		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseStreamCommand({
 			modelId: modelId,
 			messages: messagesWithCache,
@@ -603,29 +573,27 @@ export class AwsBedrockHandler implements ApiHandler {
 
 	// Shared non-streaming Converse API logic for OpenAI and Qwen models.
 	// Simulates streaming by chunking the response text into 1000-char segments.
+	// Contract (master): usage only when present (or estimated at end); errors yield [ERROR] text, not throw.
 	private async *createNonStreamingConverseMessage(
 		config: BedrockMessageConfig,
 		costFn: typeof calculateApiCostOpenAI,
 		label: string,
 	): ApiStream {
-		const { systemPrompt, messages, modelId, model, tools } = config
+		const { messages, model } = config
+		const { messagesWithCache, systemMessages, toolConfig } = this.prepareConverseInputs(config, false)
 		const client = await this.getBedrockClient()
-		const formattedMessages = formatMessagesForConverseAPI(messages, model.info.supportsImages !== false)
-		const systemMessages = systemPrompt ? [{ text: systemPrompt }] : undefined
-		const toolConfig = mapDiracToolsToBedrockToolConfig(tools)
 		const command = new ConverseCommand({
-			modelId,
-			messages: formattedMessages,
+			modelId: config.modelId,
+			messages: messagesWithCache,
 			system: systemMessages,
 			inferenceConfig: { maxTokens: model.info.maxTokens || 8192, temperature: model.info.temperature ?? 0 },
 			...(toolConfig ? { toolConfig } : {}),
 		})
 
 		try {
-			const inputTokenEstimate = this.estimateInputTokens(systemPrompt, messages)
+			const inputTokenEstimate = this.estimateInputTokens(config.systemPrompt, messages)
 			const response = await client.send(command, { abortSignal: config.abortSignal })
 			const { fullText, reasoningText } = extractNonStreamingContent(response)
-
 			const outputTokens = response.usage
 				? response.usage.outputTokens || estimateTokenCount(fullText + reasoningText)
 				: estimateTokenCount(fullText + reasoningText)
@@ -658,10 +626,4 @@ export class AwsBedrockHandler implements ApiHandler {
 			client.destroy()
 		}
 	}
-
-	// Extracts text and reasoning content from a non-streaming Converse response.
-
-	// Chunks text into 1000-char segments and yields as the given chunk type.
-
-	// Formats an error from the Converse API into a human-readable message.
 }


### PR DESCRIPTION
## What
- Extracts Converse orchestration preamble (`prepareConverseInputs`) shared by Anthropic/Nova/OpenAI/Qwen paths
- Splits `bedrock.ts` into `bedrock-client.ts`, `bedrock-stream-parser.ts`, `bedrock-converse-utils.ts`
- Types tightened against SDK shapes (`ConverseStreamOutput`, `ConverseCommandOutput`, `ToolResultContentBlock`)

## Why
`bedrock.ts` had duplicated message-shaping, client construction, and stream parsing across 4 model paths. fb15b2 consolidates the orchestration; fb15b/fb15b2 split the file.

## Notes / Caveats
- **Review fixes applied** (2026-08-12) for the three CHANGES_REQUESTED findings:
  - Parser: `blockStartType` now checks `start`/`contentBlock`/top-level independently (no `??` short-circuit); tests cover each location
  - Mapper: dedicated `mapToolResultContent` → `ToolResultContentBlock[]`; no cast; nested toolUse/thinking dropped
  - Stream contract: reverted to master behavior — errors yield `[ERROR]` text via `formatConverseError`, usage only when present (else estimate at end)
  - Empty-string content: reverted to master — `""` stays `[{ text: "" }]`, not collapsed to `[]`
- Pre-existing `noExplicitAny` infos in test file (also on master) left as-is
- Pre-existing root tsc error in `src/shared/storage/types.ts` on master (delta 0)

## Verification
- tsc delta vs master: 0 new errors (1 pre-existing on both)
- biome: no new errors on touched files
- mocha `bedrock.test.ts`: 43 passing (incl. 5 new tests for review fixes)

## User test
No observable behavior change — pure refactor with contracts pinned to master.

Closes FB-15b2 (FIX-BACKLOG).

Alexandros Salapatas