### PR TITLE
test: Task abort/status transitions (FB-14b)

### DIFF
--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -436,7 +436,7 @@ export class LanguageModelChat {
 		_options: LanguageModelChatRequestOptions,
 		_token?: unknown,
 	): Promise<LanguageModelChatResponse> {
-		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+		return Promise.resolve(new LanguageModelChatResponse(this.send().stream))
 	}
 }
 

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -352,3 +352,96 @@ export type Extension<T> = any
  * Components can listen to this to clean up UI before process exit.
  */
 export const shutdownEvent = new EventEmitter<void>()
+
+// ============================================================================
+// Language Model API members (used by vscode-lm provider + transform tests)
+// ============================================================================
+
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
+export class LanguageModelTextPart {
+	public readonly value: string
+	public readonly text: string
+	constructor(text: string) {
+		this.value = text
+		this.text = text
+	}
+}
+
+export enum LanguageModelChatMessageRole {
+	User = 1,
+	Assistant = 2,
+}
+
+export class LanguageModelToolCallPart {
+	constructor(
+		public readonly callId: string,
+		public readonly name: string,
+		public readonly input: unknown,
+	) {}
+}
+
+export class LanguageModelToolResultPart {
+	constructor(
+		public readonly callId: string,
+		public readonly content: LanguageModelTextPart[],
+	) {}
+}
+
+export type LanguageModelChatContentPart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart
+
+export class LanguageModelChatMessage {
+	constructor(
+		public readonly role: LanguageModelChatMessageRole,
+		public readonly content: LanguageModelChatContentPart[],
+	) {}
+
+	static User(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.User, toParts(content))
+	}
+	static Assistant(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, toParts(content))
+	}
+}
+
+function toParts(content: string | LanguageModelChatContentPart[]): LanguageModelChatContentPart[] {
+	return typeof content === "string" ? [new LanguageModelTextPart(content)] : content
+}
+
+export interface LanguageModelChatRequestOptions {
+	justification?: string
+	tools?: unknown[]
+}
+
+export class LanguageModelChatResponse {
+	public readonly stream: AsyncIterable<LanguageModelChatContentPart>
+	constructor(stream: AsyncIterable<LanguageModelChatContentPart>) {
+		this.stream = stream
+	}
+}
+
+export class LanguageModelChat {
+	constructor(
+		public readonly name: string,
+		public readonly vendor: string,
+		private readonly send = () => ({ stream: (async function* () {})() as AsyncIterable<LanguageModelChatContentPart> }),
+	) {}
+	sendRequest(
+		_messages: LanguageModelChatMessage[],
+		_options: LanguageModelChatRequestOptions,
+		_token?: unknown,
+	): Promise<LanguageModelChatResponse> {
+		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+	}
+}
+
+export namespace lm {
+	export function selectChatModels(_selector: LanguageModelChatSelector): Promise<LanguageModelChat[]> {
+		return Promise.resolve([])
+	}
+}

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -357,6 +357,8 @@ export const shutdownEvent = new EventEmitter<void>()
 // Language Model API members (used by vscode-lm provider + transform tests)
 // ============================================================================
 
+// Keep LM shapes in sync with src/test/vscode-mock.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/core/task/__tests__/TaskAbort.test.ts
+++ b/src/core/task/__tests__/TaskAbort.test.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import sinon from "sinon"
+import { TaskStatus } from "@shared/ExtensionMessage"
+import { Task } from "../index"
+import { TaskState } from "../TaskState"
+
+function createTask() {
+	const task = Object.create(Task.prototype) as {
+		taskState: TaskState
+		lifecycleManager?: { abortTask: () => Promise<void> }
+		abortTask: () => Promise<void>
+	}
+	task.taskState = new TaskState()
+	return task
+}
+
+describe("Task abort / state transitions", () => {
+	it("sets status to CANCELLING and delegates when not cancelled", async () => {
+		const task = createTask()
+		const abort = sinon.stub().resolves()
+		task.lifecycleManager = { abortTask: abort }
+		task.taskState.status = TaskStatus.EXECUTING_TOOL
+		await task.abortTask()
+		assert.equal(task.taskState.status, TaskStatus.CANCELLING)
+		assert.equal(abort.callCount, 1)
+	})
+	it("keeps CANCELLED status and still delegates when already cancelled", async () => {
+		const task = createTask()
+		const abort = sinon.stub().resolves()
+		task.lifecycleManager = { abortTask: abort }
+		task.taskState.status = TaskStatus.CANCELLED
+		await task.abortTask()
+		assert.equal(task.taskState.status, TaskStatus.CANCELLED)
+		assert.equal(abort.callCount, 1)
+	})
+})

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,13 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
 export class LanguageModelTextPart {
 	constructor(public value: string) { }
 }

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,8 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+// Keep LM shapes in sync with cli/src/vscode-shim.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for `node:sqlite` (available at runtime on the Node
+ * version this project runs, but the bundled `@types/node` does not ship them).
+ * Only models the subset used by `SymbolIndexDatabase`.
+ */
+declare module "node:sqlite" {
+	interface StatementResult {
+		changes: number | bigint
+		lastInsertRowid: number | bigint
+	}
+	interface StatementSync {
+		get(...args: unknown[]): Record<string, unknown> | undefined
+		all(...args: unknown[]): Record<string, unknown>[]
+		iterate(...args: unknown[]): IterableIterator<Record<string, unknown>>
+		run(...args: unknown[]): StatementResult
+	}
+	class DatabaseSync {
+		constructor(path: string)
+		prepare(sql: string, ...args: unknown[]): StatementSync
+		exec(sql: string): void
+		close(): void
+	}
+	export { DatabaseSync, type StatementSync }
+}

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,3 +1,4 @@
+/* DELETE once @types/node ships node:sqlite types — a future types upgrade will collide with this declare module. */
 /**
  * Minimal type declarations for `node:sqlite` (available at runtime on the Node
  * version this project runs, but the bundled `@types/node` does not ship them).

--- a/src/types/vscode-augment.d.ts
+++ b/src/types/vscode-augment.d.ts
@@ -1,0 +1,68 @@
+/**
+ * Augments the installed `@types/vscode` with the newer Language Model API
+ * members used across the codebase. Type-only; merges into the vscode module.
+ * (Tests wire vscode at runtime to src/test/vscode-mock.ts via a require hook;
+ * this augmentation is what makes the TS type-checking of `import("vscode")`
+ * forms see the missing LM members.)
+ */
+declare module "vscode" {
+	export interface LanguageModelChatSelector {
+		vendor?: string
+		family?: string
+		version?: string
+		id?: string
+	}
+
+	export class LanguageModelTextPart {
+		constructor(text: string)
+		readonly value: string
+		readonly text: string
+	}
+
+	export enum LanguageModelChatMessageRole {
+		User = 1,
+		Assistant = 2,
+	}
+
+	export class LanguageModelToolCallPart {
+		constructor(callId: string, name: string, input: unknown)
+		readonly callId: string
+		readonly name: string
+		readonly input: unknown
+	}
+
+	export class LanguageModelToolResultPart {
+		constructor(callId: string, content: LanguageModelTextPart[])
+		readonly callId: string
+		readonly content: LanguageModelTextPart[]
+	}
+
+	export class LanguageModelChatMessage {
+		role: LanguageModelChatMessageRole
+		content: Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart>
+		name?: string
+	}
+
+	export interface LanguageModelChatRequestOptions {
+		justification?: string
+		tools?: unknown[]
+	}
+
+	export class LanguageModelChatResponse {
+		readonly stream: AsyncIterable<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart>
+	}
+
+	export class LanguageModelChat {
+		readonly name: string
+		readonly vendor: string
+		sendRequest(
+			messages: LanguageModelChatMessage[],
+			options: LanguageModelChatRequestOptions,
+			token?: unknown,
+		): Thenable<LanguageModelChatResponse>
+	}
+
+	export namespace lm {
+		function selectChatModels(selector: LanguageModelChatSelector): Thenable<LanguageModelChat[]>
+	}
+}

--- a/tsconfig.unit-test.json
+++ b/tsconfig.unit-test.json
@@ -11,7 +11,8 @@
 	"ts-node": {
 		"files": true,
 		"compilerOptions": {
-			"module": "commonjs"
+			"module": "commonjs",
+			"moduleResolution": "node"
 		},
 		"require": [
 			"tsconfig-paths/register"


### PR DESCRIPTION
## What
FB-14b (test net for FB-15a): `TaskAbort.test.ts` covering `Task.abortTask()` status transitions (→ CANCELLING, delegation to lifecycleManager) via `Object.create(Task.prototype)` with stubbed deps.

## Dependencies
Requires **#166** (test-compilation unblock) — the test only runs after #166 merges. Stacked on it until then.

## Verification
`tsc` clean; runs green once the FU-4 env fix (#166) is present.

Closes FB-14b (FIX-BACKLOG).