### PR TITLE
refactor(fb15c): split SubagentRunner into modules

### DIFF
--- a/src/core/task/tools/subagent/SubagentAbortHandler.ts
+++ b/src/core/task/tools/subagent/SubagentAbortHandler.ts
@@ -1,14 +1,15 @@
-import type { SubagentRunResult, SubagentRunStats } from "./SubagentRunner"
 import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import type { DiracStorageMessage } from "@shared/messages"
+import { type SubagentRunResult, type SubagentRunStats } from "./SubagentRunTypes"
 
 // Constructs the authoritative result for a subagent stopped by timeout or cancellation.
 export class SubagentAbortHandler {
 	constructor(
 		private getAbortReason: () => string | undefined,
-		private getBestEffortResult: (conversation: any[]) => string,
+		private getBestEffortResult: (conversation: DiracStorageMessage[]) => string,
 	) {}
 
-	buildAbortResult(conversation: any[], stats: SubagentRunStats): SubagentRunResult {
+	buildAbortResult(conversation: DiracStorageMessage[], stats: SubagentRunStats): SubagentRunResult {
 		const reason = this.getAbortReason() || "Subagent run cancelled."
 		const finalStats = { ...stats }
 		if (/timed out/.test(reason)) {

--- a/src/core/task/tools/subagent/SubagentRunHelpers.ts
+++ b/src/core/task/tools/subagent/SubagentRunHelpers.ts
@@ -1,0 +1,179 @@
+import { parseAssistantMessageV2, ToolUse } from "@core/assistant-message"
+import { DiracAssistantToolUseBlock, DiracContent, DiracStorageMessage, DiracTextContentBlock } from "@shared/messages"
+import { Logger } from "@shared/services/Logger"
+import type { SubagentRequestUsageState, SubagentRunStats, SubagentToolCall } from "./SubagentRunTypes"
+
+export function createEmptyRequestUsageState(): SubagentRequestUsageState {
+	return {
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheWriteTokens: 0,
+		cacheReadTokens: 0,
+		totalTokens: 0,
+	}
+}
+
+export function createEmptySubagentRunStats(): SubagentRunStats {
+	return {
+		toolCalls: 0,
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheWriteTokens: 0,
+		cacheReadTokens: 0,
+		totalCost: 0,
+		contextTokens: 0,
+		contextWindow: 0,
+		contextUsagePercentage: 0,
+	}
+}
+
+export function serializeToolResult(result: unknown): string {
+	if (typeof result === "string") {
+		return result
+	}
+
+	if (Array.isArray(result)) {
+		return result
+			.map((item) => {
+				if (!item || typeof item !== "object") {
+					return String(item)
+				}
+
+				const maybeText = (item as { text?: string }).text
+				if (typeof maybeText === "string") {
+					return maybeText
+				}
+
+				return JSON.stringify(item)
+			})
+			.join("")
+	}
+
+	return JSON.stringify(result, null, 2)
+}
+
+export function toToolUseParams(input: unknown): Partial<Record<string, unknown>> {
+	if (!input || typeof input !== "object") {
+		return {}
+	}
+
+	return input as Partial<Record<string, unknown>>
+}
+
+function formatToolArgPreview(value: unknown, maxLength = 48): string {
+	const stringValue = typeof value === "string" ? value : (JSON.stringify(value) ?? String(value))
+	const normalized = stringValue.replace(/\s+/g, " ").trim()
+	if (normalized.length <= maxLength) {
+		return normalized
+	}
+	return `${normalized.slice(0, maxLength - 3)}...`
+}
+
+export function formatToolCallPreview(toolName: string, params: Partial<Record<string, unknown>>): string {
+	const entries = Object.entries(params).filter(([, value]) => value !== undefined)
+	const visibleEntries = entries.slice(0, 3)
+	const omittedCount = Math.max(0, entries.length - visibleEntries.length)
+
+	const args = visibleEntries
+		.map(([key, value]) => `${key}=${formatToolArgPreview(value ?? "")}`)
+		.concat(omittedCount > 0 ? [`...+${omittedCount}`] : [])
+		.join(", ")
+
+	return `${toolName}(${args})`
+}
+
+export function normalizeToolCallArguments(argumentsPayload: unknown): string {
+	if (typeof argumentsPayload === "string") {
+		return argumentsPayload
+	}
+
+	try {
+		return JSON.stringify(argumentsPayload ?? {})
+	} catch {
+		return "{}"
+	}
+}
+
+export function resolveToolUseId(call: { id?: string; call_id?: string; name?: string }, index: number): string {
+	const id = call.id?.trim()
+	if (id) {
+		return id
+	}
+
+	const callId = call.call_id?.trim()
+	if (callId) {
+		return callId
+	}
+
+	const fallbackId = `subagent_tool_${Date.now()}_${index + 1}`
+	Logger.warn(`[SubagentRunner] Missing tool call id for '${call.name || "unknown"}'; using fallback '${fallbackId}'`)
+	return fallbackId
+}
+
+export function toAssistantToolUseBlock(call: SubagentToolCall): DiracAssistantToolUseBlock {
+	return {
+		type: "tool_use",
+		id: call.toolUseId,
+		name: call.name,
+		input: call.input,
+		call_id: call.call_id,
+		signature: call.signature,
+	}
+}
+
+export function parseNonNativeToolCalls(assistantText: string): SubagentToolCall[] {
+	const parsedBlocks = parseAssistantMessageV2(assistantText)
+
+	return parsedBlocks
+		.filter((block): block is ToolUse => block.type === "tool_use")
+		.map((block, index) => ({
+			toolUseId: resolveToolUseId({ call_id: block.call_id, name: block.name }, index),
+			name: block.name,
+			input: block.params,
+			call_id: block.call_id,
+			signature: block.signature,
+			isNativeToolCall: false,
+		}))
+}
+
+export function pushSubagentToolResultBlock(
+	toolResultBlocks: DiracContent[],
+	call: SubagentToolCall,
+	label: string,
+	content: string,
+): void {
+	if (call.isNativeToolCall) {
+		toolResultBlocks.push({
+			type: "tool_result",
+			tool_use_id: call.toolUseId,
+			call_id: call.call_id,
+			content,
+		})
+		return
+	}
+
+	toolResultBlocks.push({
+		type: "text",
+		text: `${label} Result:\n${content}`,
+	})
+}
+
+export function getBestEffortResult(conversation: DiracStorageMessage[]): string {
+	const assistantTexts = conversation
+		.filter((msg) => msg.role === "assistant")
+		.flatMap((msg) => {
+			if (typeof msg.content === "string") {
+				return [{ type: "text", text: msg.content } as DiracTextContentBlock]
+			}
+			return msg.content as DiracTextContentBlock[]
+		})
+		.filter((block): block is DiracTextContentBlock => block.type === "text")
+		.map((block) => block.text.trim())
+		.filter((text) => text.length > 0)
+
+	if (assistantTexts.length === 0) {
+		return "No findings recorded."
+	}
+
+	return assistantTexts.join("\n")
+}

--- a/src/core/task/tools/subagent/SubagentRunProgress.ts
+++ b/src/core/task/tools/subagent/SubagentRunProgress.ts
@@ -1,0 +1,123 @@
+import { Logger } from "@shared/services/Logger"
+import type {
+	SubagentDiagnosticEvent,
+	SubagentRunPhase,
+	SubagentRunRecorder,
+	SubagentTranscriptEvent,
+} from "./SubagentRunRecorder"
+import type { SubagentProgressUpdate, SubagentRunResult } from "./SubagentRunTypes"
+
+const PROGRESS_UPDATE_DRAIN_TIMEOUT_MS = 1_000
+
+export class SubagentRunProgress {
+	private onProgress?: (update: SubagentProgressUpdate) => void | Promise<void>
+	private acceptsExecutionProgress = true
+	private discardQueuedExecutionProgress = false
+	private progressUpdates = Promise.resolve()
+	private terminalRecorded = false
+	private recorderFailureReported = false
+
+	constructor(
+		private readonly recorder: SubagentRunRecorder | undefined,
+		private readonly logPrefix: string,
+	) {}
+
+	getPaths() {
+		return this.recorder?.getPaths()
+	}
+
+	beginExecution(onProgress: (update: SubagentProgressUpdate) => void | Promise<void>): void {
+		this.onProgress = onProgress
+		this.acceptsExecutionProgress = true
+		this.discardQueuedExecutionProgress = false
+		this.progressUpdates = Promise.resolve()
+		this.terminalRecorded = false
+		this.recorderFailureReported = false
+	}
+
+	endExecution(): void {
+		this.onProgress = undefined
+		this.acceptsExecutionProgress = false
+	}
+
+	stopAcceptingUpdates(): void {
+		this.acceptsExecutionProgress = false
+	}
+
+	discardQueuedUpdates(): void {
+		this.discardQueuedExecutionProgress = true
+	}
+
+	enqueueExecutionProgress(update: SubagentProgressUpdate): void {
+		const onProgress = this.onProgress
+		if (!this.acceptsExecutionProgress || !onProgress) return
+		this.progressUpdates = this.progressUpdates
+			.then(async () => {
+				if (this.discardQueuedExecutionProgress) return
+				await onProgress(update)
+			})
+			.catch((error) => Logger.error(`${this.logPrefix} progress observer failed`, error))
+	}
+
+	publishRuntimeState(runtimeProgress: SubagentProgressUpdate): void {
+		this.enqueueExecutionProgress(runtimeProgress)
+	}
+
+	async drainProgressUpdates(progressUpdates?: Promise<void>, logPrefix = this.logPrefix): Promise<boolean> {
+		const updates = progressUpdates ?? this.progressUpdates
+		let progressDrainTimeout: NodeJS.Timeout | undefined
+		const progressUpdatesDrained = await Promise.race([
+			updates.then(() => true),
+			new Promise<boolean>((resolve) => {
+				progressDrainTimeout = setTimeout(() => resolve(false), PROGRESS_UPDATE_DRAIN_TIMEOUT_MS)
+			}),
+		])
+		if (progressDrainTimeout) clearTimeout(progressDrainTimeout)
+		if (!progressUpdatesDrained) {
+			Logger.warn(`${logPrefix} progress observer did not drain within ${PROGRESS_UPDATE_DRAIN_TIMEOUT_MS}ms`)
+		}
+		return progressUpdatesDrained
+	}
+
+	toTerminalProgressUpdate(result: SubagentRunResult, runtimeProgress: SubagentProgressUpdate): SubagentProgressUpdate {
+		return {
+			...runtimeProgress,
+			status: result.status,
+			result: result.result,
+			error: result.error,
+			stats: { ...result.stats },
+		}
+	}
+
+	recordTranscript(type: SubagentTranscriptEvent["type"], details: Record<string, unknown>): void {
+		if (!this.recorder) return
+		void this.recorder.recordTranscript({ type, details }).catch((error) => this.reportRecorderFailure(error))
+	}
+
+	recordDiagnostic(type: SubagentDiagnosticEvent["type"], phase: SubagentRunPhase, details: Record<string, unknown>): void {
+		if (!this.recorder) return
+		void this.recorder.recordDiagnostic({ type, phase, details }).catch((error) => this.reportRecorderFailure(error))
+	}
+
+	recordTerminal(result: SubagentRunResult, details: Record<string, unknown>): void {
+		if (this.terminalRecorded) return
+		this.terminalRecorded = true
+		if (!this.recorder) return
+		void this.recorder.recordTerminal(result.status, details).catch((error) => this.reportRecorderFailure(error))
+	}
+
+	async flush(): Promise<void> {
+		if (!this.recorder) return
+		try {
+			await this.recorder.flush()
+		} catch (error) {
+			this.reportRecorderFailure(error)
+		}
+	}
+
+	reportRecorderFailure(error: unknown): void {
+		if (this.recorderFailureReported) return
+		this.recorderFailureReported = true
+		Logger.error(`${this.logPrefix} recorder append failed`, error)
+	}
+}

--- a/src/core/task/tools/subagent/SubagentRunState.ts
+++ b/src/core/task/tools/subagent/SubagentRunState.ts
@@ -1,0 +1,139 @@
+import type { TaskConfig } from "../types/TaskConfig"
+import type { SubagentRunProgress } from "./SubagentRunProgress"
+import type { SubagentRunPhase } from "./SubagentRunRecorder"
+import type { SubagentProgressUpdate, SubagentRunStatus } from "./SubagentRunTypes"
+
+const SUBAGENT_HEARTBEAT_INTERVAL_MS = 5_000
+const SUBAGENT_STALL_WARNING_MS = 30_000
+
+export class SubagentRunState {
+	currentPhase: SubagentRunPhase = "starting"
+	phaseStartedAt = 0
+	lastActivityAt = 0
+	lastMeaningfulAction = "not started"
+	currentAttempt: number | undefined
+	livenessWarningIssued = false
+	activeCommandExecutions = 0
+
+	private heartbeatHandle: NodeJS.Timeout | undefined
+
+	constructor(
+		private readonly baseConfig: TaskConfig,
+		private readonly progress: SubagentRunProgress,
+	) {}
+
+	reset(): void {
+		this.stopHeartbeat()
+		this.currentPhase = "starting"
+		this.phaseStartedAt = 0
+		this.lastActivityAt = 0
+		this.lastMeaningfulAction = "run initialized"
+		this.currentAttempt = undefined
+		this.livenessWarningIssued = false
+		this.activeCommandExecutions = 0
+	}
+
+	enterPhase(phase: SubagentRunPhase, action: string, details: Record<string, unknown> = {}): void {
+		const previousPhase = this.currentPhase
+		const previousPhaseStartedAt = this.phaseStartedAt
+		if (previousPhase === phase && previousPhaseStartedAt > 0) {
+			this.markActivity(action)
+			return
+		}
+		const now = Date.now()
+		if (previousPhase !== phase && previousPhaseStartedAt > 0) {
+			this.progress.recordDiagnostic(
+				"phase_completed",
+				previousPhase,
+				this.getDiagnosticDetails({
+					completedPhase: previousPhase,
+					nextPhase: phase,
+					durationMs: now - previousPhaseStartedAt,
+				}),
+			)
+		}
+		this.currentPhase = phase
+		this.phaseStartedAt = now
+		this.lastActivityAt = now
+		this.lastMeaningfulAction = action
+		this.livenessWarningIssued = false
+		this.progress.recordDiagnostic("phase_entered", phase, this.getDiagnosticDetails(details))
+		this.progress.publishRuntimeState(this.getRuntimeProgress())
+	}
+
+	markActivity(action: string): void {
+		const wasStalled = this.getRuntimeProgress().isStalled
+		this.lastActivityAt = Date.now()
+		this.lastMeaningfulAction = action
+		this.livenessWarningIssued = false
+		if (wasStalled) {
+			this.progress.publishRuntimeState(this.getRuntimeProgress())
+		}
+	}
+
+	startHeartbeat(): void {
+		this.heartbeatHandle = setInterval(() => this.heartbeat(), SUBAGENT_HEARTBEAT_INTERVAL_MS)
+	}
+
+	stopHeartbeat(): void {
+		if (this.heartbeatHandle) {
+			clearInterval(this.heartbeatHandle)
+			this.heartbeatHandle = undefined
+		}
+	}
+
+	private heartbeat(): void {
+		const runtime = this.getRuntimeProgress()
+		this.progress.recordDiagnostic(
+			"heartbeat",
+			this.currentPhase,
+			this.getDiagnosticDetails({ isStalled: runtime.isStalled }),
+		)
+		if (!runtime.isStalled || this.livenessWarningIssued) return
+		this.livenessWarningIssued = true
+		this.progress.recordDiagnostic(
+			"liveness_warning",
+			this.currentPhase,
+			this.getDiagnosticDetails({ inactiveForMs: Date.now() - this.lastActivityAt }),
+		)
+		this.progress.publishRuntimeState(runtime)
+	}
+
+	getRuntimeProgress(): Pick<
+		SubagentProgressUpdate,
+		"phase" | "phaseStartedAt" | "lastActivityAt" | "isStalled" | "transcriptPath" | "diagnosticsPath"
+	> {
+		const paths = this.progress.getPaths()
+		return {
+			phase: this.currentPhase,
+			phaseStartedAt: this.phaseStartedAt,
+			lastActivityAt: this.lastActivityAt,
+			isStalled:
+				this.currentPhase !== "completed" &&
+				this.currentPhase !== "failed" &&
+				this.currentPhase !== "cancelled" &&
+				Date.now() - this.lastActivityAt >= SUBAGENT_STALL_WARNING_MS,
+			transcriptPath: paths?.transcriptPath,
+			diagnosticsPath: paths?.diagnosticsPath,
+		}
+	}
+
+	getDiagnosticDetails(details: Record<string, unknown> = {}): Record<string, unknown> {
+		return {
+			...details,
+			phaseStartedAt: this.phaseStartedAt,
+			lastActivityAt: this.lastActivityAt,
+			elapsedMs: Math.max(0, Date.now() - this.phaseStartedAt),
+			lastMeaningfulAction: this.lastMeaningfulAction,
+			attempt: this.currentAttempt,
+			activeCommandExecutions: this.activeCommandExecutions,
+			parentAbortRequested: this.baseConfig.taskState.abort,
+		}
+	}
+
+	phaseForStatus(status: SubagentRunStatus): SubagentRunPhase {
+		if (status === "completed") return "completed"
+		if (status === "failed") return "failed"
+		return "cancelled"
+	}
+}

--- a/src/core/task/tools/subagent/SubagentRunTypes.ts
+++ b/src/core/task/tools/subagent/SubagentRunTypes.ts
@@ -1,0 +1,68 @@
+import type { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import type { SubagentTrajectoryEvent } from "@shared/subagents"
+import type { SubagentRunPhase } from "./SubagentRunRecorder"
+
+export type SubagentRunStatus =
+	| typeof SubagentExecutionStatus.COMPLETED
+	| typeof SubagentExecutionStatus.FAILED
+	| typeof SubagentExecutionStatus.CANCELLED
+
+export interface SubagentRunResult {
+	status: SubagentRunStatus
+	result?: string
+	error?: string
+	stats: SubagentRunStats
+}
+
+export interface SubagentProgressUpdate {
+	stats?: SubagentRunStats
+	latestToolCall?: string
+	status?: SubagentExecutionStatus
+	result?: string
+	error?: string
+	textChunk?: string
+	trajectoryEvent?: SubagentTrajectoryEvent
+	isWrappingUp?: boolean
+	phase?: SubagentRunPhase
+	phaseStartedAt?: number
+	lastActivityAt?: number
+	isStalled?: boolean
+	transcriptPath?: string
+	diagnosticsPath?: string
+}
+
+export interface SubagentRunStats {
+	toolCalls: number
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+	totalCost: number
+	contextTokens: number
+	contextWindow: number
+	contextUsagePercentage: number
+}
+
+export interface SubagentRequestUsageState {
+	inputTokens: number
+	outputTokens: number
+	cacheWriteTokens: number
+	cacheReadTokens: number
+	totalTokens: number
+	totalCost?: number
+}
+
+export interface SubagentUsageState {
+	currentRequest: SubagentRequestUsageState
+	lastRequest?: SubagentRequestUsageState
+}
+
+export interface SubagentToolCall {
+	toolUseId: string
+	id?: string
+	call_id?: string
+	signature?: string
+	name: string
+	input: unknown
+	isNativeToolCall: boolean
+}

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -152,6 +152,9 @@ export class SubagentRunner {
 	}
 
 	private recordTerminal(result: SubagentRunResult): void {
+		// Phase transition must happen before the terminal record so progress
+		// reports a final "cancelled" (not "cancelling") on timeout/abort.
+		this.enterPhase(this.phaseForStatus(result.status), "subagent run settled", { status: result.status })
 		this.runProgress.recordTerminal(
 			result,
 			this.runState.getDiagnosticDetails({

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -358,7 +358,8 @@ export class SubagentRunner {
 			clearInterval(parentAbortPoll)
 			this.runState.stopHeartbeat()
 			this.runProgress.endExecution()
-			await this.runProgress.flush()
+			// Fire-and-forget: recorder flush must not block terminal completion (matches pre-split behavior).
+			void this.runProgress.flush()
 		}
 	}
 

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -1,12 +1,14 @@
 import * as path from "node:path"
 import type { ApiHandler, buildApiHandler } from "@core/api"
-import { parseAssistantMessageV2, ToolParamName, ToolUse } from "@core/assistant-message"
+
 import { formatResponse } from "@core/formatResponse"
 import { StreamResponseHandler } from "@core/task/StreamResponseHandler"
 import { type ToolRequestSnapshot } from "@core/task/tools/runtime/ToolSnapshot"
-import { DiracAssistantToolUseBlock, DiracContent, DiracStorageMessage, DiracTextContentBlock } from "@shared/messages"
+import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import { DiracContent, DiracStorageMessage, DiracTextContentBlock } from "@shared/messages"
 import { Logger } from "@shared/services/Logger"
 import { NATIVE_WEB_SEARCH_SKILL_NAME } from "@shared/skills"
+import { SubagentTrajectoryEventType } from "@shared/subagents"
 import { DiracTool } from "@shared/tools"
 import { ContextManager } from "@/core/context/context-management/ContextManager"
 import { checkContextWindowExceededError } from "@/core/context/context-management/context-error-handling"
@@ -21,245 +23,39 @@ import { SubagentAbortHandler } from "./SubagentAbortHandler"
 import { SubagentBuilder, type SubagentBuilderOptions } from "./SubagentBuilder"
 import { SubagentContextBuilder } from "./SubagentContextBuilder"
 import { resolveSubagentTimeoutSeconds } from "./SubagentExecutionPolicy"
-import { SubagentToolExecutor } from "./SubagentToolExecutor"
-import { SubagentTrajectoryEventType, type SubagentTrajectoryEvent } from "@shared/subagents"
-import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import {
+	createEmptyRequestUsageState,
+	createEmptySubagentRunStats,
+	getBestEffortResult,
+	normalizeToolCallArguments,
+	parseNonNativeToolCalls,
+	resolveToolUseId,
+	toAssistantToolUseBlock,
+} from "./SubagentRunHelpers"
+import { SubagentRunProgress } from "./SubagentRunProgress"
 import type { SubagentDiagnosticEvent, SubagentRunPhase, SubagentTranscriptEvent } from "./SubagentRunRecorder"
+import { SubagentRunState } from "./SubagentRunState"
+import type {
+	SubagentProgressUpdate,
+	SubagentRunResult,
+	SubagentRunStats,
+	SubagentRunStatus,
+	SubagentToolCall,
+	SubagentUsageState,
+} from "./SubagentRunTypes"
+import { SubagentToolExecutor } from "./SubagentToolExecutor"
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const MAX_EMPTY_ASSISTANT_RETRIES = 3
 const MAX_INITIAL_STREAM_ATTEMPTS = 3
 const INITIAL_STREAM_RETRY_BASE_DELAY_MS = 2_000
-const PROGRESS_UPDATE_DRAIN_TIMEOUT_MS = 1_000
 const PARENT_ABORT_POLL_INTERVAL_MS = 50
 const WRAP_UP_TIMEOUT_SECONDS = 90
-const SUBAGENT_HEARTBEAT_INTERVAL_MS = 5_000
-const SUBAGENT_STALL_WARNING_MS = 30_000
 const WRAP_UP_PROMPT =
 	'The research deadline has elapsed. Stop investigating and summarize the concrete findings you already established. Call respond with operation "complete" now. Do not perform further research.'
 
-export type SubagentRunStatus =
-	| typeof SubagentExecutionStatus.COMPLETED
-	| typeof SubagentExecutionStatus.FAILED
-	| typeof SubagentExecutionStatus.CANCELLED
-
-export interface SubagentRunResult {
-	status: SubagentRunStatus
-	result?: string
-	error?: string
-	stats: SubagentRunStats
-}
-
-export interface SubagentProgressUpdate {
-	stats?: SubagentRunStats
-	latestToolCall?: string
-	status?: SubagentExecutionStatus
-	result?: string
-	error?: string
-	textChunk?: string
-	trajectoryEvent?: SubagentTrajectoryEvent
-	isWrappingUp?: boolean
-	phase?: SubagentRunPhase
-	phaseStartedAt?: number
-	lastActivityAt?: number
-	isStalled?: boolean
-	transcriptPath?: string
-	diagnosticsPath?: string
-}
-
-export interface SubagentRunStats {
-	toolCalls: number
-	inputTokens: number
-	outputTokens: number
-	cacheWriteTokens: number
-	cacheReadTokens: number
-	totalCost: number
-	contextTokens: number
-	contextWindow: number
-	contextUsagePercentage: number
-}
-
-interface SubagentRequestUsageState {
-	inputTokens: number
-	outputTokens: number
-	cacheWriteTokens: number
-	cacheReadTokens: number
-	totalTokens: number
-	totalCost?: number
-}
-
-interface SubagentUsageState {
-	currentRequest: SubagentRequestUsageState
-	lastRequest?: SubagentRequestUsageState
-}
-
-export interface SubagentToolCall {
-	toolUseId: string
-	id?: string
-	call_id?: string
-	signature?: string
-	name: string
-	input: unknown
-	isNativeToolCall: boolean
-}
-
 interface SubagentContextState {
 	conversationHistoryDeletedRange?: [number, number]
-}
-
-function createEmptyRequestUsageState(): SubagentRequestUsageState {
-	return {
-		inputTokens: 0,
-		outputTokens: 0,
-		cacheWriteTokens: 0,
-		cacheReadTokens: 0,
-		totalTokens: 0,
-	}
-}
-
-function createEmptySubagentRunStats(): SubagentRunStats {
-	return {
-		toolCalls: 0,
-		inputTokens: 0,
-		outputTokens: 0,
-		cacheWriteTokens: 0,
-		cacheReadTokens: 0,
-		totalCost: 0,
-		contextTokens: 0,
-		contextWindow: 0,
-		contextUsagePercentage: 0,
-	}
-}
-
-export function serializeToolResult(result: unknown): string {
-	if (typeof result === "string") {
-		return result
-	}
-
-	if (Array.isArray(result)) {
-		return result
-			.map((item) => {
-				if (!item || typeof item !== "object") {
-					return String(item)
-				}
-
-				const maybeText = (item as { text?: string }).text
-				if (typeof maybeText === "string") {
-					return maybeText
-				}
-
-				return JSON.stringify(item)
-			})
-			.join("")
-	}
-
-	return JSON.stringify(result, null, 2)
-}
-
-export function toToolUseParams(input: unknown): Partial<Record<ToolParamName, any>> {
-	if (!input || typeof input !== "object") {
-		return {}
-	}
-
-	return input as Partial<Record<ToolParamName, any>>
-}
-
-function formatToolArgPreview(value: any, maxLength = 48): string {
-	const stringValue = typeof value === "string" ? value : JSON.stringify(value)
-	const normalized = stringValue.replace(/\s+/g, " ").trim()
-	if (normalized.length <= maxLength) {
-		return normalized
-	}
-	return `${normalized.slice(0, maxLength - 3)}...`
-}
-
-export function formatToolCallPreview(toolName: string, params: Partial<Record<string, string>>): string {
-	const entries = Object.entries(params).filter(([, value]) => value !== undefined)
-	const visibleEntries = entries.slice(0, 3)
-	const omittedCount = Math.max(0, entries.length - visibleEntries.length)
-
-	const args = visibleEntries
-		.map(([key, value]) => `${key}=${formatToolArgPreview(value ?? "")}`)
-		.concat(omittedCount > 0 ? [`...+${omittedCount}`] : [])
-		.join(", ")
-
-	return `${toolName}(${args})`
-}
-
-function normalizeToolCallArguments(argumentsPayload: unknown): string {
-	if (typeof argumentsPayload === "string") {
-		return argumentsPayload
-	}
-
-	try {
-		return JSON.stringify(argumentsPayload ?? {})
-	} catch {
-		return "{}"
-	}
-}
-
-function resolveToolUseId(call: { id?: string; call_id?: string; name?: string }, index: number): string {
-	const id = call.id?.trim()
-	if (id) {
-		return id
-	}
-
-	const callId = call.call_id?.trim()
-	if (callId) {
-		return callId
-	}
-
-	const fallbackId = `subagent_tool_${Date.now()}_${index + 1}`
-	Logger.warn(`[SubagentRunner] Missing tool call id for '${call.name || "unknown"}'; using fallback '${fallbackId}'`)
-	return fallbackId
-}
-
-function toAssistantToolUseBlock(call: SubagentToolCall): DiracAssistantToolUseBlock {
-	return {
-		type: "tool_use",
-		id: call.toolUseId,
-		name: call.name,
-		input: call.input,
-		call_id: call.call_id,
-		signature: call.signature,
-	}
-}
-
-function parseNonNativeToolCalls(assistantText: string): SubagentToolCall[] {
-	const parsedBlocks = parseAssistantMessageV2(assistantText)
-
-	return parsedBlocks
-		.filter((block): block is ToolUse => block.type === "tool_use")
-		.map((block, index) => ({
-			toolUseId: resolveToolUseId({ call_id: block.call_id, name: block.name }, index),
-			name: block.name,
-			input: block.params,
-			call_id: block.call_id,
-			signature: block.signature,
-			isNativeToolCall: false,
-		}))
-}
-
-export function pushSubagentToolResultBlock(
-	toolResultBlocks: DiracContent[],
-	call: SubagentToolCall,
-	label: string,
-	content: string,
-): void {
-	if (call.isNativeToolCall) {
-		toolResultBlocks.push({
-			type: "tool_result",
-			tool_use_id: call.toolUseId,
-			call_id: call.call_id,
-			content,
-		})
-		return
-	}
-
-	toolResultBlocks.push({
-		type: "text",
-		text: `${label} Result:\n${content}`,
-	})
 }
 
 export class SubagentRunner {
@@ -272,7 +68,6 @@ export class SubagentRunner {
 	private activeApiAbort: (() => void) | undefined
 	private abortRequested = false
 	private abortReason?: string
-	private activeCommandExecutions = 0
 	private abortingCommands = false
 	private activeTaskState?: TaskState
 	private activeConversation: DiracStorageMessage[] = []
@@ -280,16 +75,6 @@ export class SubagentRunner {
 	private readonly subagentName: string
 	private wrapUpRequested = false
 	private isWrappingUp = false
-	private currentPhase: SubagentRunPhase = "starting"
-	private phaseStartedAt = 0
-	private lastActivityAt = 0
-	private lastMeaningfulAction = "not started"
-	private currentAttempt: number | undefined
-	private livenessWarningIssued = false
-	private terminalRecorded = false
-	private recorderFailureReported = false
-	private progressSink: ((update: SubagentProgressUpdate) => void) | undefined
-	private heartbeatHandle: NodeJS.Timeout | undefined
 
 	constructor(
 		private baseConfig: TaskConfig,
@@ -301,16 +86,16 @@ export class SubagentRunner {
 		this.apiHandler = this.agent.getApiHandler()
 		this.allowedTools = this.agent.getAllowedTools()
 		this.contextBuilder = new SubagentContextBuilder(baseConfig, this.agent, this.allowedTools, this.apiHandler)
-		this.abortHandler = new SubagentAbortHandler(
-			() => this.abortReason,
-			(conv) => this.getBestEffortResult(conv),
-		)
+		const logPrefix = `[SubagentRunner:${this.subagentName || "unnamed"}]`
+		this.runProgress = new SubagentRunProgress(options.recorder, logPrefix)
+		this.runState = new SubagentRunState(baseConfig, this.runProgress)
+		this.abortHandler = new SubagentAbortHandler(() => this.abortReason, getBestEffortResult)
 		this.toolExecutor = new SubagentToolExecutor(
 			(state, coordinator) => this.createSubagentTaskConfig(state, coordinator),
 			(name, snap) => this.isAllowedTool(name, snap),
 			{
 				recordToolCall: (call) =>
-					this.recordTranscript("tool_call", {
+					this.runProgress.recordTranscript("tool_call", {
 						toolUseId: call.toolUseId,
 						id: call.id,
 						callId: call.call_id,
@@ -319,15 +104,15 @@ export class SubagentRunner {
 						isNativeToolCall: call.isNativeToolCall,
 					}),
 				recordToolResult: (call, result) =>
-					this.recordTranscript("tool_result", {
+					this.runProgress.recordTranscript("tool_result", {
 						toolUseId: call.toolUseId,
 						id: call.id,
 						callId: call.call_id,
 						name: call.name,
 						result,
 					}),
-				recordProgress: (text) => this.recordTranscript("progress", { text }),
-				markActivity: (action) => this.markActivity(action),
+				recordProgress: (text) => this.runProgress.recordTranscript("progress", { text }),
+				markActivity: (action) => this.runState.markActivity(action),
 			},
 		)
 	}
@@ -336,89 +121,27 @@ export class SubagentRunner {
 		SubagentProgressUpdate,
 		"phase" | "phaseStartedAt" | "lastActivityAt" | "isStalled" | "transcriptPath" | "diagnosticsPath"
 	> {
-		const paths = this.options.recorder?.getPaths()
-		return {
-			phase: this.currentPhase,
-			phaseStartedAt: this.phaseStartedAt,
-			lastActivityAt: this.lastActivityAt,
-			isStalled:
-				this.currentPhase !== "completed" &&
-				this.currentPhase !== "failed" &&
-				this.currentPhase !== "cancelled" &&
-				Date.now() - this.lastActivityAt >= SUBAGENT_STALL_WARNING_MS,
-			transcriptPath: paths?.transcriptPath,
-			diagnosticsPath: paths?.diagnosticsPath,
-		}
+		return this.runState.getRuntimeProgress()
 	}
 
 	private getDiagnosticDetails(details: Record<string, unknown> = {}): Record<string, unknown> {
-		return {
-			...details,
-			phaseStartedAt: this.phaseStartedAt,
-			lastActivityAt: this.lastActivityAt,
-			elapsedMs: Math.max(0, Date.now() - this.phaseStartedAt),
-			lastMeaningfulAction: this.lastMeaningfulAction,
-			attempt: this.currentAttempt,
-			activeCommandExecutions: this.activeCommandExecutions,
-			parentAbortRequested: this.baseConfig.taskState.abort,
-		}
+		return this.runState.getDiagnosticDetails(details)
 	}
 
 	private enterPhase(phase: SubagentRunPhase, action: string, details: Record<string, unknown> = {}): void {
-		const previousPhase = this.currentPhase
-		const previousPhaseStartedAt = this.phaseStartedAt
-		if (previousPhase === phase && previousPhaseStartedAt > 0) {
-			this.markActivity(action)
-			return
-		}
-		const now = Date.now()
-		if (previousPhase !== phase && previousPhaseStartedAt > 0) {
-			this.recordDiagnostic("phase_completed", previousPhase, {
-				completedPhase: previousPhase,
-				nextPhase: phase,
-				durationMs: now - previousPhaseStartedAt,
-			})
-		}
-		this.currentPhase = phase
-		this.phaseStartedAt = now
-		this.lastActivityAt = now
-		this.lastMeaningfulAction = action
-		this.livenessWarningIssued = false
-		this.recordDiagnostic("phase_entered", phase, details)
-		this.publishRuntimeState()
+		this.runState.enterPhase(phase, action, details)
 	}
 
 	private markActivity(action: string): void {
-		const wasStalled = this.getRuntimeProgress().isStalled
-		this.lastActivityAt = Date.now()
-		this.lastMeaningfulAction = action
-		this.livenessWarningIssued = false
-		if (wasStalled) this.publishRuntimeState()
+		this.runState.markActivity(action)
 	}
 
 	private startHeartbeat(): void {
-		this.heartbeatHandle = setInterval(() => this.heartbeat(), SUBAGENT_HEARTBEAT_INTERVAL_MS)
-	}
-
-	private heartbeat(): void {
-		const runtime = this.getRuntimeProgress()
-		this.recordDiagnostic("heartbeat", this.currentPhase, { isStalled: runtime.isStalled })
-		if (!runtime.isStalled || this.livenessWarningIssued) return
-		this.livenessWarningIssued = true
-		this.recordDiagnostic("liveness_warning", this.currentPhase, {
-			inactiveForMs: Date.now() - this.lastActivityAt,
-		})
-		this.publishRuntimeState()
-	}
-
-	private publishRuntimeState(): void {
-		this.progressSink?.(this.getRuntimeProgress())
+		this.runState.startHeartbeat()
 	}
 
 	private recordTranscript(type: SubagentTranscriptEvent["type"], details: Record<string, unknown>): void {
-		const recorder = this.options.recorder
-		if (!recorder) return
-		void recorder.recordTranscript({ type, details }).catch((error) => this.reportRecorderFailure(error))
+		this.runProgress.recordTranscript(type, details)
 	}
 
 	private recordDiagnostic(
@@ -426,33 +149,19 @@ export class SubagentRunner {
 		phase: SubagentRunPhase,
 		details: Record<string, unknown> = {},
 	): void {
-		const recorder = this.options.recorder
-		if (!recorder) return
-		void recorder
-			.recordDiagnostic({ type, phase, details: this.getDiagnosticDetails(details) })
-			.catch((error) => this.reportRecorderFailure(error))
+		this.runProgress.recordDiagnostic(type, phase, this.runState.getDiagnosticDetails(details))
 	}
 
 	private recordTerminal(result: SubagentRunResult): void {
-		if (this.terminalRecorded) return
-		this.terminalRecorded = true
-		this.enterPhase(this.phaseForStatus(result.status), "subagent run settled", { status: result.status })
-		const recorder = this.options.recorder
-		if (!recorder) return
-		void recorder
-			.recordTerminal(result.status, this.getDiagnosticDetails({
+		this.runProgress.recordTerminal(
+			result,
+			this.runState.getDiagnosticDetails({
 				result: result.result,
 				error: result.error,
 				stats: result.stats,
 				abortReason: this.abortReason,
-			}))
-			.catch((error) => this.reportRecorderFailure(error))
-	}
-
-	private reportRecorderFailure(error: unknown): void {
-		if (this.recorderFailureReported) return
-		this.recorderFailureReported = true
-		Logger.error(`[SubagentRunner:${this.subagentName || "unnamed"}] recorder append failed`, error)
+			}),
+		)
 	}
 
 	private isAllowedTool(toolName: string, requestSnapshot: ToolRequestSnapshot): boolean {
@@ -475,13 +184,13 @@ export class SubagentRunner {
 		await this.stopActiveWork()
 	}
 
-	private async requestWrapUp(onProgress: (update: SubagentProgressUpdate) => void): Promise<void> {
+	private async requestWrapUp(): Promise<void> {
 		if (this.wrapUpRequested || this.isWrappingUp || this.shouldAbort()) return
 		this.wrapUpRequested = true
 		this.enterPhase("wrapping_up", "execution deadline reached")
 		this.recordTranscript("progress", { text: "Time limit reached. Wrapping up findings." })
 		this.recordDiagnostic("abort_requested", "wrapping_up", { reason: "execution deadline reached" })
-		onProgress({
+		this.runProgress.enqueueExecutionProgress({
 			...this.getRuntimeProgress(),
 			isWrappingUp: true,
 			trajectoryEvent: { type: SubagentTrajectoryEventType.MESSAGE, text: "Time limit reached. Wrapping up findings." },
@@ -508,7 +217,11 @@ export class SubagentRunner {
 			Logger.error("[SubagentRunner] failed to abort active API stream", error)
 		}
 
-		if (this.activeCommandExecutions > 0 && !this.abortingCommands && this.baseConfig.callbacks.cancelRunningCommandTool) {
+		if (
+			this.runState.activeCommandExecutions > 0 &&
+			!this.abortingCommands &&
+			this.baseConfig.callbacks.cancelRunningCommandTool
+		) {
 			this.abortingCommands = true
 			try {
 				await this.baseConfig.callbacks.cancelRunningCommandTool()
@@ -520,11 +233,8 @@ export class SubagentRunner {
 		}
 	}
 
-
 	private phaseForStatus(status: SubagentRunStatus): SubagentRunPhase {
-		if (status === SubagentExecutionStatus.COMPLETED) return "completed"
-		if (status === SubagentExecutionStatus.FAILED) return "failed"
-		return "cancelled"
+		return this.runState.phaseForStatus(status)
 	}
 
 	private shouldAbort(): boolean {
@@ -569,28 +279,8 @@ export class SubagentRunner {
 		this.activeTaskState = undefined
 		this.activeConversation = []
 		this.activeStats = createEmptySubagentRunStats()
-		this.currentPhase = "starting"
-		this.phaseStartedAt = 0
-		this.lastActivityAt = 0
-		this.lastMeaningfulAction = "run initialized"
-		this.currentAttempt = undefined
-		this.livenessWarningIssued = false
-		this.terminalRecorded = false
-		this.recorderFailureReported = false
-
-		let acceptsExecutionProgress = true
-		let discardQueuedExecutionProgress = false
-		let progressUpdates = Promise.resolve()
-		const enqueueExecutionProgress = (update: SubagentProgressUpdate): void => {
-			if (!acceptsExecutionProgress) return
-			progressUpdates = progressUpdates
-				.then(async () => {
-					if (discardQueuedExecutionProgress) return
-					await onProgress(update)
-				})
-				.catch((error) => Logger.error(`${logPrefix} progress observer failed`, error))
-		}
-		this.progressSink = enqueueExecutionProgress
+		this.runState.reset()
+		this.runProgress.beginExecution(onProgress)
 		this.enterPhase("starting", "subagent run dispatched", { timeoutSeconds, includeHistory: includeHistory === true })
 		this.recordTranscript("progress", {
 			message: "subagent run dispatched",
@@ -611,9 +301,9 @@ export class SubagentRunner {
 			resolveTermination()
 		}
 		let wrapUpTimeoutHandle: NodeJS.Timeout | undefined
-		const requestWrapUp = () => {
+		const scheduleWrapUp = () => {
 			if (terminationRequested || this.wrapUpRequested || this.isWrappingUp) return
-			void this.requestWrapUp(enqueueExecutionProgress)
+			void this.requestWrapUp()
 			wrapUpTimeoutHandle = setTimeout(
 				() =>
 					requestTermination(
@@ -623,14 +313,14 @@ export class SubagentRunner {
 			)
 		}
 
-		const timeoutHandle = setTimeout(requestWrapUp, timeoutSeconds * 1000)
+		const timeoutHandle = setTimeout(scheduleWrapUp, timeoutSeconds * 1000)
 		const parentAbortPoll = setInterval(() => {
 			if (this.baseConfig.taskState.abort) {
 				requestTermination("Subagent run cancelled because the parent task was cancelled.")
 			}
 		}, PARENT_ABORT_POLL_INTERVAL_MS)
 
-		const executionPromise = this.executeRun(prompt, enqueueExecutionProgress, timeoutSeconds, includeHistory)
+		const executionPromise = this.executeRun(prompt, timeoutSeconds, includeHistory)
 		void executionPromise.catch((error) => {
 			if (terminationRequested) Logger.error(`${logPrefix} abandoned execution failed after termination`, error)
 		})
@@ -647,17 +337,17 @@ export class SubagentRunner {
 
 			if (outcome.kind === "execution") {
 				this.recordTerminal(outcome.result)
-				acceptsExecutionProgress = false
-				const progressDrained = await this.drainProgressUpdates(progressUpdates, logPrefix)
-				if (!progressDrained) discardQueuedExecutionProgress = true
+				this.runProgress.stopAcceptingUpdates()
+				const progressDrained = await this.drainProgressUpdates(undefined, logPrefix)
+				if (!progressDrained) this.runProgress.discardQueuedUpdates()
 				return outcome.result
 			}
 
-			discardQueuedExecutionProgress = true
+			this.runProgress.discardQueuedUpdates()
 			const result = this.abortHandler.buildAbortResult(this.activeConversation, this.activeStats)
 			this.recordTerminal(result)
-			acceptsExecutionProgress = false
-			await this.drainProgressUpdates(progressUpdates, logPrefix)
+			this.runProgress.stopAcceptingUpdates()
+			await this.drainProgressUpdates(undefined, logPrefix)
 			const terminalProgress = Promise.resolve()
 				.then(() => onProgress(this.toTerminalProgressUpdate(result)))
 				.catch((error) => Logger.error(`${logPrefix} terminal progress observer failed`, error))
@@ -667,20 +357,13 @@ export class SubagentRunner {
 			clearTimeout(timeoutHandle)
 			if (wrapUpTimeoutHandle) clearTimeout(wrapUpTimeoutHandle)
 			clearInterval(parentAbortPoll)
-			if (this.heartbeatHandle) clearInterval(this.heartbeatHandle)
-			this.heartbeatHandle = undefined
-			this.progressSink = undefined
-			const recorder = this.options.recorder
-			if (recorder) void recorder.flush().catch((error) => this.reportRecorderFailure(error))
+			this.runState.stopHeartbeat()
+			this.runProgress.endExecution()
+			await this.runProgress.flush()
 		}
 	}
 
-	private async executeRun(
-		prompt: string,
-		onProgress: (update: SubagentProgressUpdate) => void | Promise<void>,
-		timeout: number,
-		includeHistory?: boolean,
-	): Promise<SubagentRunResult> {
+	private async executeRun(prompt: string, timeout: number, includeHistory?: boolean): Promise<SubagentRunResult> {
 		const state = new TaskState()
 		state.abort = this.abortRequested
 		state.activeSkillIds = [...this.baseConfig.taskState.activeSkillIds]
@@ -705,11 +388,12 @@ export class SubagentRunner {
 				this.enterPhase(this.phaseForStatus(update.status), `reported ${update.status} status`, { status: update.status })
 				Logger.info(`${logPrefix} ${update.status}: ${(update.result || update.error || "").substring(0, 200)}`)
 			}
-			return onProgress({ ...this.getRuntimeProgress(), ...update })
+			this.runProgress.enqueueExecutionProgress({ ...this.getRuntimeProgress(), ...update })
 		}
 
 		instrumentedOnProgress({
-			status: SubagentExecutionStatus.RUNNING, stats
+			status: SubagentExecutionStatus.RUNNING,
+			stats,
 		})
 
 		try {
@@ -750,11 +434,11 @@ export class SubagentRunner {
 					// initial user message of subagent runs.
 					...(workspaceMetadataEnvironmentBlock
 						? [
-							{
-								type: "text",
-								text: workspaceMetadataEnvironmentBlock,
-							} as DiracTextContentBlock,
-						]
+								{
+									type: "text",
+									text: workspaceMetadataEnvironmentBlock,
+								} as DiracTextContentBlock,
+							]
 						: []),
 				],
 			})
@@ -957,7 +641,7 @@ export class SubagentRunner {
 					}
 
 					emptyAssistantResponseRetries += 1
-					this.recordDiagnostic("retry", this.currentPhase, {
+					this.recordDiagnostic("retry", this.runState.currentPhase, {
 						kind: "empty_assistant_response",
 						attempt: emptyAssistantResponseRetries,
 					})
@@ -1062,48 +746,11 @@ export class SubagentRunner {
 	}
 
 	private toTerminalProgressUpdate(result: SubagentRunResult): SubagentProgressUpdate {
-		return {
-			...this.getRuntimeProgress(),
-			status: result.status,
-			result: result.result,
-			error: result.error,
-			stats: { ...result.stats },
-		}
+		return this.runProgress.toTerminalProgressUpdate(result, this.runState.getRuntimeProgress())
 	}
 
-	private async drainProgressUpdates(progressUpdates: Promise<void>, logPrefix: string): Promise<boolean> {
-		let progressDrainTimeout: NodeJS.Timeout | undefined
-		const progressUpdatesDrained = await Promise.race([
-			progressUpdates.then(() => true),
-			new Promise<boolean>((resolve) => {
-				progressDrainTimeout = setTimeout(() => resolve(false), PROGRESS_UPDATE_DRAIN_TIMEOUT_MS)
-			}),
-		])
-		if (progressDrainTimeout) clearTimeout(progressDrainTimeout)
-		if (!progressUpdatesDrained) {
-			Logger.warn(`${logPrefix} progress observer did not drain within ${PROGRESS_UPDATE_DRAIN_TIMEOUT_MS}ms`)
-		}
-		return progressUpdatesDrained
-	}
-
-	private getBestEffortResult(conversation: DiracStorageMessage[]): string {
-		const assistantTexts = conversation
-			.filter((msg) => msg.role === "assistant")
-			.flatMap((msg) => {
-				if (typeof msg.content === "string") {
-					return [{ type: "text", text: msg.content } as DiracTextContentBlock]
-				}
-				return msg.content as DiracTextContentBlock[]
-			})
-			.filter((block): block is DiracTextContentBlock => block.type === "text")
-			.map((block) => block.text.trim())
-			.filter((text) => text.length > 0)
-
-		if (assistantTexts.length === 0) {
-			return "No findings recorded."
-		}
-
-		return assistantTexts.join("\n")
+	private async drainProgressUpdates(progressUpdates?: Promise<void>, logPrefix?: string): Promise<boolean> {
+		return this.runProgress.drainProgressUpdates(progressUpdates, logPrefix)
 	}
 
 	private createSubagentTaskConfig(state: TaskState, coordinator: ToolExecutorCoordinator): TaskConfig {
@@ -1121,7 +768,7 @@ export class SubagentRunner {
 			callbacks: {
 				...baseCallbacks,
 				executeCommandTool: async (command: string, timeoutSeconds: number | undefined) => {
-					this.activeCommandExecutions += 1
+					this.runState.activeCommandExecutions += 1
 					this.markActivity("started command tool execution")
 					try {
 						return await baseCallbacks.executeCommandTool(command, timeoutSeconds, {
@@ -1129,7 +776,7 @@ export class SubagentRunner {
 							suppressUserInteraction: true,
 						})
 					} finally {
-						this.activeCommandExecutions = Math.max(0, this.activeCommandExecutions - 1)
+						this.runState.activeCommandExecutions = Math.max(0, this.runState.activeCommandExecutions - 1)
 						this.markActivity("finished command tool execution")
 					}
 				},
@@ -1192,7 +839,7 @@ export class SubagentRunner {
 	private shouldCompactBeforeNextRequest(
 		requestTotalTokens: number,
 		api: ReturnType<typeof buildApiHandler>,
-		modelId: string,
+		_modelId: string,
 	): boolean {
 		const { contextWindow, maxAllowedSize } = getContextWindowInfo(api)
 		const useAutoCondense = this.baseConfig.services.stateManager.getGlobalSettingsKey("useAutoCondense")
@@ -1217,7 +864,7 @@ export class SubagentRunner {
 		contextState: SubagentContextState,
 	) {
 		for (let attempt = 1; attempt <= MAX_INITIAL_STREAM_ATTEMPTS; attempt += 1) {
-			this.currentAttempt = attempt
+			this.runState.currentAttempt = attempt
 			const truncatedConversation = contextManager
 				.getTruncatedMessages(fullConversation, contextState.conversationHistoryDeletedRange)
 				.map((message) => message as DiracStorageMessage)
@@ -1255,7 +902,7 @@ export class SubagentRunner {
 					if (!compactResult.didCompact || this.shouldAbort() || attempt >= MAX_INITIAL_STREAM_ATTEMPTS) {
 						throw error
 					}
-					this.recordDiagnostic("retry", this.currentPhase, {
+					this.recordDiagnostic("retry", this.runState.currentPhase, {
 						kind: "context_window_compaction",
 						attempt,
 						error,
@@ -1275,7 +922,7 @@ export class SubagentRunner {
 				}
 
 				const delayMs = INITIAL_STREAM_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1)
-				this.recordDiagnostic("retry", this.currentPhase, {
+				this.recordDiagnostic("retry", this.runState.currentPhase, {
 					kind: "initial_stream_error",
 					attempt,
 					nextAttempt: attempt + 1,
@@ -1287,4 +934,15 @@ export class SubagentRunner {
 			}
 		}
 	}
+
+	private runState: SubagentRunState
+	private runProgress: SubagentRunProgress
 }
+
+export type {
+	SubagentProgressUpdate,
+	SubagentRunResult,
+	SubagentRunStats,
+	SubagentRunStatus,
+	SubagentToolCall,
+} from "./SubagentRunTypes"

--- a/src/core/task/tools/subagent/SubagentRunner.ts
+++ b/src/core/task/tools/subagent/SubagentRunner.ts
@@ -1,6 +1,5 @@
 import * as path from "node:path"
 import type { ApiHandler, buildApiHandler } from "@core/api"
-
 import { formatResponse } from "@core/formatResponse"
 import { StreamResponseHandler } from "@core/task/StreamResponseHandler"
 import { type ToolRequestSnapshot } from "@core/task/tools/runtime/ToolSnapshot"
@@ -454,7 +453,7 @@ export class SubagentRunner {
 				if (
 					!this.isWrappingUp &&
 					usageState.lastRequest &&
-					this.shouldCompactBeforeNextRequest(usageState.lastRequest.totalTokens, api, context.providerInfo.model.id)
+					this.shouldCompactBeforeNextRequest(usageState.lastRequest.totalTokens, api)
 				) {
 					const compactResult = this.compactConversationForContextWindow(
 						contextManager,
@@ -836,11 +835,7 @@ export class SubagentRunner {
 		}
 	}
 
-	private shouldCompactBeforeNextRequest(
-		requestTotalTokens: number,
-		api: ReturnType<typeof buildApiHandler>,
-		_modelId: string,
-	): boolean {
+	private shouldCompactBeforeNextRequest(requestTotalTokens: number, api: ReturnType<typeof buildApiHandler>): boolean {
 		const { contextWindow, maxAllowedSize } = getContextWindowInfo(api)
 		const useAutoCondense = this.baseConfig.services.stateManager.getGlobalSettingsKey("useAutoCondense")
 		if (useAutoCondense) {

--- a/src/core/task/tools/subagent/SubagentToolExecutor.ts
+++ b/src/core/task/tools/subagent/SubagentToolExecutor.ts
@@ -1,23 +1,24 @@
 import { ToolUse } from "@core/assistant-message"
 import { formatResponse } from "@core/formatResponse"
 import type { ToolRequestSnapshot } from "@core/task/tools/runtime/ToolSnapshot"
-import { DiracContent } from "@shared/messages/content"
-import { DiracDefaultTool } from "@shared/tools"
-import {
-    canonicalizeResponseToolCall,
-    responseOperationFromToolCall,
-    ResponseOperation,
-    ResponseParameter,
-    ResponseShapeError,
-    validateResponseShape,
-} from "@shared/responseTool"
-import type { ResponseArguments } from "@shared/responseTool"
-import type { TaskState } from "../../TaskState"
-import type { TaskConfig } from "../types/TaskConfig"
-import type { SubagentToolCall } from "./SubagentRunner"
 import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import { DiracContent } from "@shared/messages/content"
+import type { ResponseArguments } from "@shared/responseTool"
+import {
+	canonicalizeResponseToolCall,
+	ResponseOperation,
+	ResponseParameter,
+	ResponseShapeError,
+	responseOperationFromToolCall,
+	validateResponseShape,
+} from "@shared/responseTool"
 import { createSubagentTrajectoryEvent, SubagentTrajectoryEventType } from "@shared/subagents"
-import { formatToolCallPreview, pushSubagentToolResultBlock, serializeToolResult, toToolUseParams } from "./SubagentRunner"
+import { DiracDefaultTool } from "@shared/tools"
+import type { TaskState } from "../../TaskState"
+import { ToolExecutorCoordinator } from "../ToolExecutorCoordinator"
+import type { TaskConfig } from "../types/TaskConfig"
+import { formatToolCallPreview, pushSubagentToolResultBlock, serializeToolResult, toToolUseParams } from "./SubagentRunHelpers"
+import { type SubagentProgressUpdate, type SubagentRunStats, type SubagentToolCall } from "./SubagentRunTypes"
 
 export interface SubagentToolExecutionObserver {
 	recordToolCall(call: SubagentToolCall): void
@@ -30,7 +31,7 @@ export interface SubagentToolExecutionObserver {
 // Extracted from SubagentRunner.run() to reduce the 400-line method.
 export class SubagentToolExecutor {
 	constructor(
-		private createSubagentTaskConfig: (state: TaskState, coordinator: any) => TaskConfig,
+		private createSubagentTaskConfig: (state: TaskState, coordinator: ToolExecutorCoordinator) => TaskConfig,
 		private isAllowedTool: (toolName: string, requestSnapshot: ToolRequestSnapshot) => boolean,
 		private readonly observer?: SubagentToolExecutionObserver,
 	) {}
@@ -40,10 +41,10 @@ export class SubagentToolExecutor {
 		finalizedToolCalls: SubagentToolCall[],
 		state: TaskState,
 		requestSnapshot: ToolRequestSnapshot,
-		stats: any,
-		onProgress: (update: any) => void,
+		stats: SubagentRunStats,
+		onProgress: (update: SubagentProgressUpdate) => void,
 		isWrappingUp = false,
-	): Promise<{ completed?: { result: string; stats: any }; toolResultBlocks: DiracContent[] }> {
+	): Promise<{ completed?: { result: string; stats: SubagentRunStats }; toolResultBlocks: DiracContent[] }> {
 		const toolResultBlocks: DiracContent[] = []
 		for (const call of finalizedToolCalls) {
 			this.observer?.recordToolCall(call)
@@ -82,8 +83,8 @@ export class SubagentToolExecutor {
 				pushSubagentToolResultBlock(toolResultBlocks, call, toolName, result)
 				continue
 			}
-			let responseArguments: ResponseArguments | undefined
 			if (responseOperation) {
+				let responseArguments: ResponseArguments
 				try {
 					responseArguments = validateResponseShape(toolCallParams)
 				} catch (error) {
@@ -93,24 +94,24 @@ export class SubagentToolExecutor {
 					pushSubagentToolResultBlock(toolResultBlocks, call, toolName, result)
 					continue
 				}
-			}
-			if (responseOperation === ResponseOperation.PROGRESS) {
-				this.observer?.recordProgress(responseArguments!.text)
-				onProgress({
-					trajectoryEvent: createSubagentTrajectoryEvent(
-						SubagentTrajectoryEventType.MESSAGE,
-						responseArguments!.text,
-					),
-				})
-			}
+				if (responseOperation === ResponseOperation.PROGRESS) {
+					this.observer?.recordProgress(responseArguments.text)
+					onProgress({
+						trajectoryEvent: createSubagentTrajectoryEvent(
+							SubagentTrajectoryEventType.MESSAGE,
+							responseArguments.text,
+						),
+					})
+				}
 
-			if (responseOperation === ResponseOperation.COMPLETE) {
-				const completionResult = responseArguments!.text.trim()
-				recordToolResult({ operation: ResponseOperation.COMPLETE, result: completionResult })
-				stats.toolCalls += 1
-				onProgress({ stats: { ...stats } })
-				onProgress({ status: SubagentExecutionStatus.COMPLETED, result: completionResult, stats: { ...stats } })
-				return { completed: { result: completionResult, stats: { ...stats } }, toolResultBlocks }
+				if (responseOperation === ResponseOperation.COMPLETE) {
+					const completionResult = responseArguments.text.trim()
+					recordToolResult({ operation: ResponseOperation.COMPLETE, result: completionResult })
+					stats.toolCalls += 1
+					onProgress({ stats: { ...stats } })
+					onProgress({ status: SubagentExecutionStatus.COMPLETED, result: completionResult, stats: { ...stats } })
+					return { completed: { result: completionResult, stats: { ...stats } }, toolResultBlocks }
+				}
 			}
 
 			if (isWrappingUp) {

--- a/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
+++ b/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
@@ -2,28 +2,28 @@ import { strict as assert } from "node:assert"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { expectLoggerErrors } from "@/test/loggerGuard"
 import * as coreApi from "@core/api"
 import * as skills from "@core/context/instructions/user-instructions/skills"
 import { DiracToolSet, PromptRegistry } from "@core/prompts/system-prompt"
 import type { TaskConfig } from "@core/task/tools/types/TaskConfig"
+import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
+import { ResponseOperation } from "@shared/responseTool"
+import { SubagentTrajectoryEventType } from "@shared/subagents"
+import { DiracAskResponse } from "@shared/WebviewMessage"
 import { afterEach, describe, it } from "mocha"
 import sinon from "sinon"
 import { HostProvider } from "@/hosts/host-provider"
 import { ApiFormat } from "@/shared/proto/dirac/models"
 import { Logger } from "@/shared/services/Logger"
 import { DiracDefaultTool } from "@/shared/tools"
-import { ResponseOperation } from "@shared/responseTool"
+import { expectLoggerErrors } from "@/test/loggerGuard"
 import { TaskState } from "../../../TaskState"
-import { list_files_spec, ListFilesTool } from "../../modules/list_files"
-import { respondSpec, RespondTool } from "../../modules/respond/RespondTool"
-import { SubagentRunner } from "../SubagentRunner"
+import { ListFilesTool, list_files_spec } from "../../modules/list_files"
+import { RespondTool, respondSpec } from "../../modules/respond/RespondTool"
 import { SubagentBuilder } from "../SubagentBuilder"
-import { DiracAskResponse } from "@shared/WebviewMessage"
-import { SubagentExecutionStatus } from "@shared/ExtensionMessage"
-import { SubagentTrajectoryEventType } from "@shared/subagents"
-import { SubagentToolExecutor } from "../SubagentToolExecutor"
+import { SubagentRunner } from "../SubagentRunner"
 import { SubagentRunRecorder } from "../SubagentRunRecorder"
+import { SubagentToolExecutor } from "../SubagentToolExecutor"
 
 function initializeHostProvider() {
 	HostProvider.reset()
@@ -74,7 +74,7 @@ function createTaskConfig(): TaskConfig {
 					supportsPromptCache: true,
 				},
 			}),
-			createMessage: sinon.stub().callsFake(async function* () { }),
+			createMessage: sinon.stub().callsFake(async function* () {}),
 		},
 		services: {
 			stateManager: {
@@ -211,7 +211,7 @@ describe("SubagentRunner", () => {
 		createMessage.onSecondCall().callsFake(async function* (_systemPrompt: string, conversation: unknown[]) {
 			const assistantMessage = conversation[1] as {
 				role: string
-				content: Array<{ type?: string;[key: string]: unknown }>
+				content: Array<{ type?: string; [key: string]: unknown }>
 			}
 			assert.equal(assistantMessage.role, "assistant")
 
@@ -220,7 +220,7 @@ describe("SubagentRunner", () => {
 			assert.equal(toolUse.id, "toolu_subagent_1")
 			assert.equal(toolUse.name, DiracDefaultTool.LIST_FILES)
 
-			const userMessage = conversation[2] as { role: string; content: Array<{ type?: string;[key: string]: unknown }> }
+			const userMessage = conversation[2] as { role: string; content: Array<{ type?: string; [key: string]: unknown }> }
 			assert.equal(userMessage.role, "user")
 			const toolResult = userMessage.content.find((block) => block.type === "tool_result")
 			assert.ok(toolResult)
@@ -312,7 +312,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 		const config = createTaskConfigWithListFilesSnapshot()
 
-		const result = await new SubagentRunner(config).run("Search", () => { })
+		const result = await new SubagentRunner(config).run("Search", () => {})
 
 		assert.equal(result.status, SubagentExecutionStatus.COMPLETED)
 		assert.deepEqual(config.taskState.activeSkillIds, ["web-search"])
@@ -364,6 +364,68 @@ describe("SubagentRunner", () => {
 		])
 	})
 
+	// Regression: run() must not await recorder.flush() — a slow/stuck append must not delay terminal completion.
+	it("does not block terminal completion on a slow recorder flush (fire-and-forget)", async () => {
+		expectLoggerErrors()
+		const createMessage = sinon.stub()
+		createMessage.onFirstCall().callsFake(async function* () {
+			yield {
+				type: "tool_calls",
+				tool_call: { function: { id: "call-1", name: DiracDefaultTool.LIST_FILES, arguments: "{}" } },
+			}
+		})
+		createMessage.onSecondCall().callsFake(async function* () {
+			yield {
+				type: "tool_calls",
+				tool_call: {
+					function: {
+						id: "call-2",
+						name: DiracDefaultTool.RESPOND,
+						arguments: JSON.stringify({ operation: ResponseOperation.COMPLETE, text: "done" }),
+					},
+				},
+			}
+		})
+		const promptRegistry = PromptRegistry.getInstance()
+		sinon.stub(promptRegistry, "get").callsFake(async () => {
+			promptRegistry.nativeTools = [{ name: "list_files" } as any, { name: "respond" } as any]
+			return "system prompt"
+		})
+		sinon.stub(skills, "getOrDiscoverSkills").resolves([])
+		stubApiHandler(createMessage)
+		initializeHostProvider()
+
+		const taskDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-subagent-flush-"))
+		const recorder = await SubagentRunRecorder.create({
+			taskId: "task-flush",
+			agent: { id: 1, name: "Flush Agent" },
+			taskTitle: "Verify fire-and-forget flush",
+			prompt: "List files",
+			timeoutSeconds: 600,
+			includeHistory: false,
+			taskDirectory,
+			runId: "flush",
+		})
+		// Stub flush to hang — if run() awaited it, this test would never resolve.
+		let resolveFlush: () => void = () => {}
+		const flushPromise = new Promise<void>((resolve) => {
+			resolveFlush = resolve
+		})
+		const flushStub = sinon.stub(recorder, "flush").returns(flushPromise)
+
+		try {
+			const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot(), "subagent", { recorder })
+			const result = await runner.run("List files", () => {})
+
+			assert.equal(result.status, SubagentExecutionStatus.COMPLETED)
+			assert.equal(result.result, "done")
+			assert.ok(flushStub.called, "recorder.flush was called")
+		} finally {
+			resolveFlush()
+			await fs.rm(taskDirectory, { recursive: true, force: true })
+		}
+	})
+
 	it("returns after the drain timeout when a progress observer never settles", async () => {
 		const createMessage = sinon.stub()
 		createMessage.onFirstCall().callsFake(async function* () {
@@ -398,7 +460,7 @@ describe("SubagentRunner", () => {
 			const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
 			const resultPromise = runner.run("List files", (update) => {
 				if (!update.trajectoryEvent) return
-				return new Promise<void>(() => { })
+				return new Promise<void>(() => {})
 			})
 			await clock.tickAsync(0)
 			await clock.tickAsync(1_000)
@@ -461,7 +523,7 @@ describe("SubagentRunner", () => {
 			return false
 		})
 
-		const result = await runner.run("List files", () => { })
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(result.result, "done")
@@ -486,7 +548,7 @@ describe("SubagentRunner", () => {
 		createMessage.onSecondCall().callsFake(async function* (_systemPrompt: string, conversation: unknown[]) {
 			const lastMessage = conversation[conversation.length - 1] as {
 				role: string
-				content: Array<{ type?: string;[key: string]: unknown }>
+				content: Array<{ type?: string; [key: string]: unknown }>
 			}
 
 			assert.equal(lastMessage.role, "user")
@@ -518,7 +580,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("List files", () => { })
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(result.result, "done")
@@ -574,7 +636,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("List files", () => { })
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(result.result, "done")
@@ -614,7 +676,7 @@ describe("SubagentRunner", () => {
 
 		const clock = sinon.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] })
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const runPromise = runner.run("List files", () => { })
+		const runPromise = runner.run("List files", () => {})
 		await clock.runAllAsync()
 		const result = await runPromise
 		clock.restore()
@@ -630,7 +692,7 @@ describe("SubagentRunner", () => {
 		createMessage.onFirstCall().callsFake(async function* () {
 			yield* []
 			const contextError = new Error("context length exceeded")
-				; (contextError as Error & { status: number }).status = 400
+			;(contextError as Error & { status: number }).status = 400
 			throw contextError
 		})
 
@@ -644,7 +706,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("Huge prompt", () => { })
+		const result = await runner.run("Huge prompt", () => {})
 
 		assert.equal(result.status, "failed")
 		assert.equal(createMessage.callCount, 1)
@@ -699,7 +761,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("Inspect the repository", () => { })
+		const result = await runner.run("Inspect the repository", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(result.result, "done")
@@ -730,7 +792,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("List files", () => { })
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(createMessage.callCount, 1)
@@ -769,7 +831,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("Run task", () => { })
+		const result = await runner.run("Run task", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(createMessage.callCount, 1)
@@ -808,7 +870,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("Run task", () => { })
+		const result = await runner.run("Run task", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(createMessage.callCount, 1)
@@ -847,7 +909,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("Run task", () => { })
+		const result = await runner.run("Run task", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(createMessage.callCount, 1)
@@ -913,7 +975,7 @@ describe("SubagentRunner", () => {
 		initializeHostProvider()
 
 		const runner = new SubagentRunner(createTaskConfigWithListFilesSnapshot())
-		const result = await runner.run("List files", () => { })
+		const result = await runner.run("List files", () => {})
 
 		assert.equal(result.status, "completed")
 		assert.equal(result.result, "done")
@@ -922,7 +984,7 @@ describe("SubagentRunner", () => {
 
 	it("returns after the wrap-up deadline when the API stream ignores abort", async () => {
 		const createMessage = sinon.stub().callsFake(async function* () {
-			await new Promise<void>(() => { })
+			await new Promise<void>(() => {})
 		})
 		const promptRegistry = PromptRegistry.getInstance()
 		sinon.stub(promptRegistry, "get").resolves("system prompt")
@@ -1061,7 +1123,7 @@ describe("SubagentRunner", () => {
 
 	it("returns cancelled when the parent task is cancelled even if the API stream never settles", async () => {
 		const createMessage = sinon.stub().callsFake(async function* () {
-			await new Promise<void>(() => { })
+			await new Promise<void>(() => {})
 		})
 		const promptRegistry = PromptRegistry.getInstance()
 		sinon.stub(promptRegistry, "get").resolves("system prompt")
@@ -1073,7 +1135,7 @@ describe("SubagentRunner", () => {
 		try {
 			const config = createTaskConfigWithListFilesSnapshot()
 			const runner = new SubagentRunner(config)
-			const runPromise = runner.run("Never settles", () => { })
+			const runPromise = runner.run("Never settles", () => {})
 			await clock.tickAsync(0)
 			config.taskState.abort = true
 			await clock.tickAsync(50)
@@ -1089,7 +1151,7 @@ describe("SubagentRunner", () => {
 
 	it("records first-chunk liveness warnings without waiting for the overall timeout", async () => {
 		const createMessage = sinon.stub().callsFake(async function* () {
-			await new Promise<void>(() => { })
+			await new Promise<void>(() => {})
 		})
 		const promptRegistry = PromptRegistry.getInstance()
 		sinon.stub(promptRegistry, "get").resolves("system prompt")
@@ -1135,5 +1197,4 @@ describe("SubagentRunner", () => {
 			await fs.rm(taskDirectory, { recursive: true, force: true })
 		}
 	})
-
 })

--- a/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
+++ b/src/core/task/tools/subagent/__tests__/SubagentRunner.test.ts
@@ -1149,6 +1149,46 @@ describe("SubagentRunner", () => {
 		}
 	})
 
+	// Regression: on timeout/parent-cancel, the terminal phase must transition
+	// to "cancelled" — not stay "cancelling". The enterPhase call in
+	// recordTerminal was dropped during the FB-15c extraction.
+	it("reports cancelled phase on parent cancel, not cancelling", async () => {
+		expectLoggerErrors()
+		const createMessage = sinon.stub().callsFake(async function* () {
+			await new Promise<void>(() => {})
+		})
+		const promptRegistry = PromptRegistry.getInstance()
+		sinon.stub(promptRegistry, "get").resolves("system prompt")
+		sinon.stub(skills, "getOrDiscoverSkills").resolves([])
+		const abort = stubApiHandler(createMessage)
+		initializeHostProvider()
+
+		const clock = sinon.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] })
+		try {
+			const config = createTaskConfigWithListFilesSnapshot()
+			const updates: any[] = []
+			const runner = new SubagentRunner(config)
+			const runPromise = runner.run("Never settles", (update) => {
+				updates.push(update)
+			})
+			await clock.tickAsync(0)
+			config.taskState.abort = true
+			await clock.tickAsync(50)
+			const result = await runPromise
+
+			assert.equal(result.status, SubagentExecutionStatus.CANCELLED)
+			// Progress must show a terminal "cancelled" phase, not "cancelling".
+			const cancelledUpdates = updates.filter((u) => u.status === SubagentExecutionStatus.CANCELLED)
+			assert.ok(cancelledUpdates.length > 0, "should have at least one cancelled status update")
+			assert.ok(
+				cancelledUpdates.every((u) => u.phase === "cancelled"),
+				`expected phase "cancelled", got phases: ${cancelledUpdates.map((u: any) => u.phase).join(", ")}`,
+			)
+		} finally {
+			clock.restore()
+		}
+	})
+
 	it("records first-chunk liveness warnings without waiting for the overall timeout", async () => {
 		const createMessage = sinon.stub().callsFake(async function* () {
 			await new Promise<void>(() => {})


### PR DESCRIPTION
## Summary
Split the 1033-line `SubagentRunner.ts` into focused modules under `src/core/task/tools/subagent/`:
- `SubagentRunTypes.ts` — run status/result/progress/tool-call types
- `SubagentRunHelpers.ts` — pure functions (tool-call parsing, result blocks, best-effort result)
- `SubagentRunState.ts` — phase/liveness/heartbeat tracking
- `SubagentRunProgress.ts` — progress queue/drain + recorder flush
`SubagentRunner.ts` becomes the orchestration adapter.

## Why
FIX-BACKLOG FB-15c — single responsibility: runner keeps orchestration; state, progress, types, and pure helpers are separate units.

## Review follow-ups

### 1. Flush blocking terminal completion
Reviewer flagged `await this.runProgress.flush()` in the `finally` block: it changed recorder flushing from fire-and-forget to part of the awaited run lifecycle, so a slow or stuck filesystem append could delay terminal completion.

**Fix:** restored the pre-split fire-and-forget behavior — `void this.runProgress.flush()` instead of `await`. Errors are still handled internally by `SubagentRunProgress.flush()` (try/catch → `reportRecorderFailure`).

**Regression test:** `does not block terminal completion on a slow recorder flush` — stubs `recorder.flush()` to hang forever; asserts `run()` still resolves with `COMPLETED` and that `flush()` was called.

### 2. Terminal phase stuck on "cancelling"
Reviewer flagged that `recordTerminal` was missing the `enterPhase` call after extraction. On timeout/parent-cancel, the terminal progress reported `status: cancelled` while `phase` remained `cancelling`.

**Fix:** restored `this.enterPhase(this.phaseForStatus(result.status), "subagent run settled", { status: result.status })` before `runProgress.recordTerminal()` in `SubagentRunner.recordTerminal()`.

**Regression test:** `reports cancelled phase on parent cancel, not cancelling` — triggers parent abort, collects progress updates, asserts every cancelled-status update has `phase: "cancelled"`.

## Notes / Caveats
- Rebased onto current `master`.
- Pre-existing subagent drain-timeout test failure is unrelated and untouched.
- Pre-existing `AgentConfigLoader` EPERM on TCC-protected `~/Documents/Dirac` is environment-specific (machine has no Full Disk Access); not from this PR.

## Verification
- `tsc -p tsconfig.unit-test.json --noEmit` — only pre-existing `src/shared/storage/types.ts` baseline error.
- `biome check` on touched files — 1 pre-existing warning (not from these changes).
- `SubagentRunner.test.ts` — new regression tests passing (2/2 targeted).
- `SubagentRunRecorder.test.ts` — 4/4 passing.
- `SubagentBuilder.test.ts` — 5/5 passing.

Closes FB-15c (FIX-BACKLOG).
