### PR TITLE
refactor(fb15d): split StateManager into modules

### DIFF
--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -436,7 +436,7 @@ export class LanguageModelChat {
 		_options: LanguageModelChatRequestOptions,
 		_token?: unknown,
 	): Promise<LanguageModelChatResponse> {
-		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+		return Promise.resolve(new LanguageModelChatResponse(this.send().stream))
 	}
 }
 

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -352,3 +352,96 @@ export type Extension<T> = any
  * Components can listen to this to clean up UI before process exit.
  */
 export const shutdownEvent = new EventEmitter<void>()
+
+// ============================================================================
+// Language Model API members (used by vscode-lm provider + transform tests)
+// ============================================================================
+
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
+export class LanguageModelTextPart {
+	public readonly value: string
+	public readonly text: string
+	constructor(text: string) {
+		this.value = text
+		this.text = text
+	}
+}
+
+export enum LanguageModelChatMessageRole {
+	User = 1,
+	Assistant = 2,
+}
+
+export class LanguageModelToolCallPart {
+	constructor(
+		public readonly callId: string,
+		public readonly name: string,
+		public readonly input: unknown,
+	) {}
+}
+
+export class LanguageModelToolResultPart {
+	constructor(
+		public readonly callId: string,
+		public readonly content: LanguageModelTextPart[],
+	) {}
+}
+
+export type LanguageModelChatContentPart = LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart
+
+export class LanguageModelChatMessage {
+	constructor(
+		public readonly role: LanguageModelChatMessageRole,
+		public readonly content: LanguageModelChatContentPart[],
+	) {}
+
+	static User(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.User, toParts(content))
+	}
+	static Assistant(content: string | LanguageModelChatContentPart[]): LanguageModelChatMessage {
+		return new LanguageModelChatMessage(LanguageModelChatMessageRole.Assistant, toParts(content))
+	}
+}
+
+function toParts(content: string | LanguageModelChatContentPart[]): LanguageModelChatContentPart[] {
+	return typeof content === "string" ? [new LanguageModelTextPart(content)] : content
+}
+
+export interface LanguageModelChatRequestOptions {
+	justification?: string
+	tools?: unknown[]
+}
+
+export class LanguageModelChatResponse {
+	public readonly stream: AsyncIterable<LanguageModelChatContentPart>
+	constructor(stream: AsyncIterable<LanguageModelChatContentPart>) {
+		this.stream = stream
+	}
+}
+
+export class LanguageModelChat {
+	constructor(
+		public readonly name: string,
+		public readonly vendor: string,
+		private readonly send = () => ({ stream: (async function* () {})() as AsyncIterable<LanguageModelChatContentPart> }),
+	) {}
+	sendRequest(
+		_messages: LanguageModelChatMessage[],
+		_options: LanguageModelChatRequestOptions,
+		_token?: unknown,
+	): Promise<LanguageModelChatResponse> {
+		return Promise.resolve(new LanguageModelChatResponse(this.send()))
+	}
+}
+
+export namespace lm {
+	export function selectChatModels(_selector: LanguageModelChatSelector): Promise<LanguageModelChat[]> {
+		return Promise.resolve([])
+	}
+}

--- a/cli/src/vscode-shim.ts
+++ b/cli/src/vscode-shim.ts
@@ -357,6 +357,8 @@ export const shutdownEvent = new EventEmitter<void>()
 // Language Model API members (used by vscode-lm provider + transform tests)
 // ============================================================================
 
+// Keep LM shapes in sync with src/test/vscode-mock.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/core/storage/StateManager.ts
+++ b/src/core/storage/StateManager.ts
@@ -1,31 +1,46 @@
-import type { ApiConfiguration, ModelInfo, ModelProviderPreset } from "@shared/api"
-import { getSecretsFromEnv, getSettingsFromEnv } from "@shared/storage/env-config"
+import type { ApiConfiguration, ModelInfo } from "@shared/api"
+import { buildLegacySynthetic1mStateUpdates } from "@shared/storage/legacy-model-id-migration"
 import {
-	ApiHandlerSettingsKeys,
 	type GlobalState,
 	type GlobalStateAndSettings,
-	type GlobalStateAndSettingsKey,
-	isSecretKey,
-	isSettingsKey,
 	type LocalState,
-	type LocalStateKey,
-	type SecretKey,
-	SecretKeys,
 	type Secrets,
 	type Settings,
-	type SettingsKey,
 } from "@shared/storage/state-keys"
 import type { StorageContext } from "@shared/storage/storage-context"
-import {
-	buildLegacySynthetic1mStateUpdates,
-	normalizeLegacyModelProviderPresets,
-	normalizeLegacyOpenRouterPinMap,
-	normalizeLegacySynthetic1mModelId,
-} from "@shared/storage/legacy-model-id-migration"
 import { initializeDistinctId } from "@/services/logging/distinctId"
 import { Logger } from "@/shared/services/Logger"
 import { AgentConfigLoader } from "../task/tools/subagent/AgentConfigLoader"
-import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
+import {
+	getAllGlobalStateEntries,
+	getAllWorkspaceStateEntries,
+	getApiConfiguration,
+	getGlobalSettingsKey,
+	getGlobalStateKey,
+	getSecretKey,
+	getSystemDefaultSettingsKey,
+	getWorkspaceStateKey,
+	type StateManagerGetterCaches,
+} from "./StateManagerGetters"
+import { getModelInfo, getModelsCache, type ModelCache, setModelsCache } from "./StateManagerModelCache"
+import {
+	clearTaskSettings,
+	loadTaskSettings,
+	refreshModelProviderPresetsFromDisk,
+	type StateManagerSettersContext,
+	setApiConfiguration,
+	setGlobalState,
+	setGlobalStateBatch,
+	setSecret,
+	setSecretsBatch,
+	setSessionOverride,
+	setSessionOverrideCache,
+	setTaskSettings,
+	setTaskSettingsBatch,
+	setWorkspaceState,
+	setWorkspaceStateBatch,
+} from "./StateManagerSetters"
+import { type StateManagerSettingsCaches } from "./StateManagerSettings"
 import { type PersistenceErrorEvent, StatePersistenceManager } from "./StatePersistenceManager"
 
 // Re-export for backward compatibility — consumers import PersistenceErrorEvent from StateManager
@@ -66,11 +81,8 @@ export class StateManager {
 	private persistence: StatePersistenceManager
 	private isInitialized = false
 
-	// Cache TTL: 1 hour - long enough to prevent duplicate fetches, short enough to see new models
-	private readonly MODEL_CACHE_TTL_MS = 60 * 60 * 1000
-
 	// In-memory model info cache (not persisted to disk) — keyed by `${provider}Models`
-	private modelInfoCache: Record<string, { data: Record<string, ModelInfo>; timestamp: number } | null> = {}
+	private modelInfoCache: ModelCache = {}
 
 	// Callback to sync external state changes with the UI client
 	onSyncExternalChange?: () => void | Promise<void>
@@ -97,6 +109,35 @@ export class StateManager {
 				this.globalStateCache.taskHistory = value
 			},
 		})
+	}
+
+	private get settingsCaches(): StateManagerSettingsCaches {
+		return {
+			sessionOverrideCache: this.sessionOverrideCache,
+			taskStateCache: this.taskStateCache,
+			globalStateCache: this.globalStateCache,
+			secretsCache: this.secretsCache,
+		}
+	}
+
+	private get allCaches(): StateManagerGetterCaches {
+		return {
+			...this.settingsCaches,
+			workspaceStateCache: this.workspaceStateCache,
+		}
+	}
+
+	private get settersContext(): StateManagerSettersContext {
+		return {
+			isInitialized: this.isInitialized,
+			globalStateCache: this.globalStateCache,
+			taskStateCache: this.taskStateCache,
+			sessionOverrideCache: this.sessionOverrideCache,
+			secretsCache: this.secretsCache,
+			workspaceStateCache: this.workspaceStateCache,
+			persistence: this.persistence,
+			notifyStateChange: () => this.notifyStateChange(),
+		}
 	}
 
 	/**
@@ -213,111 +254,53 @@ export class StateManager {
 	}
 
 	setGlobalState<K extends keyof GlobalStateAndSettings>(key: K, value: GlobalStateAndSettings[K]): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const normalizedValue = isSettingsKey(key) ? this.normalizeLoadedSetting(key as SettingsKey, value as never) : value
-		;(this.globalStateCache as Record<string, unknown>)[key] = normalizedValue
-		this.persistence.addPendingGlobalState(key)
-		this.notifyStateChange()
+		setGlobalState(this.settersContext, key, value)
 	}
 
 	refreshModelProviderPresetsFromDisk(): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-
-		const cachedPresets = this.globalStateCache.modelProviderPresets
-		const diskPresets = this.persistence.readGlobalStateKeyFromDisk("modelProviderPresets") as
-			| ModelProviderPreset[]
-			| undefined
-		const presetsById = new Map<string, ModelProviderPreset>()
-
-		for (const preset of [...cachedPresets, ...(diskPresets || [])]) {
-			const existing = presetsById.get(preset.id)
-			if (!existing || preset.lastUsedAt > existing.lastUsedAt) presetsById.set(preset.id, preset)
-		}
-
-		const mergedPresets = [...presetsById.values()].sort((a, b) => b.lastUsedAt - a.lastUsedAt).slice(0, 20)
-		if (JSON.stringify(mergedPresets) === JSON.stringify(cachedPresets)) return
-		this.setGlobalState("modelProviderPresets", mergedPresets)
+		refreshModelProviderPresetsFromDisk(this.settersContext)
 	}
 
 	setGlobalStateBatch(updates: Partial<GlobalStateAndSettings>): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const normalizedUpdates = { ...updates, ...buildLegacySynthetic1mStateUpdates(updates) }
-		Object.assign(this.globalStateCache, normalizedUpdates)
-		this.persistence.addPendingGlobalStateBatch(Object.keys(normalizedUpdates) as GlobalStateAndSettingsKey[])
-		this.notifyStateChange()
+		setGlobalStateBatch(this.settersContext, updates)
 	}
 
 	setTaskSettings<K extends keyof Settings>(taskId: string, key: K, value: Settings[K]): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		this.taskStateCache[key] = this.normalizeLoadedSetting(key, value)
-		this.persistence.addPendingTaskState(taskId, key)
+		setTaskSettings(this.settersContext, taskId, key, value)
 	}
 
 	setTaskSettingsBatch(taskId: string, updates: Partial<Settings>): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const normalizedUpdates = this.normalizeLoadedSettings(updates)
-		Object.assign(this.taskStateCache, normalizedUpdates)
-		this.persistence.addPendingTaskStateBatch(taskId, Object.keys(normalizedUpdates) as SettingsKey[])
+		setTaskSettingsBatch(this.settersContext, taskId, updates)
 	}
 
 	async loadTaskSettings(taskId: string): Promise<void> {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const taskSettings = (await this.persistence.loadTaskSettingsFromDisk(taskId)) as Partial<Settings>
-		const normalizedTaskSettings = this.normalizeLoadedSettings(taskSettings)
-		Object.assign(this.taskStateCache, normalizedTaskSettings)
-		if (JSON.stringify(normalizedTaskSettings) !== JSON.stringify(taskSettings)) {
-			this.persistence.addPendingTaskStateBatch(taskId, Object.keys(normalizedTaskSettings) as SettingsKey[])
-		}
+		await loadTaskSettings(this.settersContext, taskId)
 	}
 
 	async clearTaskSettings(): Promise<void> {
-		if (this.persistence.hasPendingTaskState()) {
-			await this.persistence.persistAndClearPendingTaskState()
-		}
-		this.taskStateCache = {}
-		this.persistence.clearPendingTaskState()
+		await clearTaskSettings(this.settersContext)
 	}
 
 	setSecret<K extends keyof Secrets>(key: K, value: Secrets[K]): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		this.secretsCache[key] = value
-		this.persistence.addPendingSecret(key)
+		setSecret(this.settersContext, key, value)
 	}
 
 	setSecretsBatch(updates: Partial<Secrets>): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const changedKeys: SecretKey[] = []
-		Object.entries(updates).forEach(([key, value]) => {
-			// Skip unchanged values to avoid unnecessary writes & onDidChange events
-			const current = this.secretsCache[key as keyof Secrets]
-			if (current === value) return
-			this.secretsCache[key as keyof Secrets] = value
-			changedKeys.push(key as SecretKey)
-		})
-		this.persistence.addPendingSecretBatch(changedKeys)
+		setSecretsBatch(this.settersContext, updates)
 	}
 
 	setWorkspaceState<K extends keyof LocalState>(key: K, value: LocalState[K]): void
 	setWorkspaceState(key: string, value: unknown): void
 	setWorkspaceState(key: string, value: unknown): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		;(this.workspaceStateCache as Record<string, unknown>)[key] = value
-		this.persistence.addPendingWorkspaceState(key as LocalStateKey)
+		setWorkspaceState(this.settersContext, key, value)
 	}
 
 	setWorkspaceStateBatch(updates: Partial<LocalState>): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		const changedKeys: LocalStateKey[] = []
-		Object.entries(updates).forEach(([key, value]) => {
-			this.workspaceStateCache[key as keyof LocalState] = value
-			changedKeys.push(key as LocalStateKey)
-		})
-		this.persistence.addPendingWorkspaceStateBatch(changedKeys)
+		setWorkspaceStateBatch(this.settersContext, updates)
 	}
 
 	setSessionOverride<K extends keyof Settings>(key: K, value: Settings[K]): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		this.sessionOverrideCache[key] = this.normalizeLoadedSetting(key, value)
+		setSessionOverride(this.settersContext, key, value)
 	}
 
 	/** Return the current session-override cache (in-memory only). (from main) */
@@ -327,93 +310,53 @@ export class StateManager {
 
 	/** Replace the session-override cache wholesale. In-memory only, never persisted. (from main) */
 	setSessionOverrideCache(overrides: Partial<Settings>): void {
-		this.sessionOverrideCache = this.normalizeLoadedSettings(overrides)
+		setSessionOverrideCache(this.settersContext, overrides)
 	}
 
 	setModelsCache(provider: string, models: Record<string, ModelInfo>): void {
-		const cacheKey = `${provider}Models`
-		this.modelInfoCache[cacheKey] = { data: models, timestamp: Date.now() }
+		setModelsCache(this.modelInfoCache, provider, models)
 	}
 
 	getModelsCache(provider: string): Record<string, ModelInfo> | null {
-		const cacheKey = `${provider}Models`
-		const cached = this.modelInfoCache[cacheKey]
-		if (!cached) return null
-		if (Date.now() - cached.timestamp > this.MODEL_CACHE_TTL_MS) {
-			this.modelInfoCache[cacheKey] = null
-			return null
-		}
-		return cached.data
+		return getModelsCache(this.modelInfoCache, provider)
 	}
 
 	getModelInfo(
 		provider: "openRouter" | "groq" | "baseten" | "huggingFace" | "requesty" | "huaweiCloudMaas" | "aihubmix" | "liteLlm",
 		modelId: string,
 	): ModelInfo | undefined {
-		const cacheKey = `${provider}Models`
-		const cached = this.modelInfoCache[cacheKey]
-		if (!cached) return undefined
-		if (Date.now() - cached.timestamp > this.MODEL_CACHE_TTL_MS) {
-			this.modelInfoCache[cacheKey] = null
-			return undefined
-		}
-		return cached.data[modelId]
+		return getModelInfo(this.modelInfoCache, provider, modelId)
 	}
 
 	getApiConfiguration(): ApiConfiguration {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return this.constructApiConfigurationFromCache()
+		return getApiConfiguration(this.settingsCaches, this.isInitialized)
 	}
 
 	setApiConfiguration(apiConfiguration: ApiConfiguration): void {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-
-		const { settingsUpdates, secretsUpdates } = Object.entries(apiConfiguration).reduce(
-			(acc, [key, value]) => {
-				if (key === undefined) return acc
-				if (isSecretKey(key)) {
-					;(acc.secretsUpdates as Record<string, string | undefined>)[key] = value as string | undefined
-				} else if (isSettingsKey(key)) {
-					;(acc.settingsUpdates as Record<string, unknown>)[key] = value
-				}
-				return acc
-			},
-			{ settingsUpdates: {} as Partial<Settings>, secretsUpdates: {} as Partial<Secrets> },
-		)
-
-		if (Object.keys(settingsUpdates).length > 0) this.setGlobalStateBatch(settingsUpdates)
-		if (Object.keys(secretsUpdates).length > 0) this.setSecretsBatch(secretsUpdates)
+		setApiConfiguration(this.settersContext, apiConfiguration)
 	}
 
 	getGlobalSettingsKey<K extends keyof Settings>(key: K): Settings[K] {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		// Precedence: session override > task settings > global settings
-		if (Object.hasOwn(this.sessionOverrideCache, key)) return this.sessionOverrideCache[key] as Settings[K]
-		if (this.taskStateCache[key] !== undefined) return this.taskStateCache[key]
-		return this.globalStateCache[key]
+		return getGlobalSettingsKey(key, this.settingsCaches, this.isInitialized)
 	}
 
 	/** Read a system default without inheriting active session or task state. */
 	getSystemDefaultSettingsKey<K extends keyof Settings>(key: K): Settings[K] {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return this.globalStateCache[key]
+		return getSystemDefaultSettingsKey(key, this.settingsCaches, this.isInitialized)
 	}
 
 	getGlobalStateKey<K extends keyof GlobalState>(key: K): GlobalState[K] {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return this.globalStateCache[key]
+		return getGlobalStateKey(key, this.settingsCaches, this.isInitialized)
 	}
 
 	getSecretKey<K extends keyof Secrets>(key: K): Secrets[K] {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return this.secretsCache[key]
+		return getSecretKey(key, this.settingsCaches, this.isInitialized)
 	}
 
 	getWorkspaceStateKey<K extends keyof LocalState>(key: K): LocalState[K]
 	getWorkspaceStateKey(key: string): unknown
 	getWorkspaceStateKey(key: string): unknown {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return (this.workspaceStateCache as Record<string, unknown>)[key]
+		return getWorkspaceStateKey(this.allCaches, this.isInitialized, key)
 	}
 
 	async reInitialize(currentTaskId?: string): Promise<void> {
@@ -436,79 +379,16 @@ export class StateManager {
 	}
 
 	getAllGlobalStateEntries(): Record<string, unknown> {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return { ...this.globalStateCache }
+		return getAllGlobalStateEntries(this.settingsCaches, this.isInitialized)
 	}
 
 	getAllWorkspaceStateEntries(): Record<string, unknown> {
-		if (!this.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
-		return { ...this.workspaceStateCache }
+		return getAllWorkspaceStateEntries(this.allCaches, this.isInitialized)
 	}
 
 	private populateCache(globalState: GlobalState, secrets: Secrets, workspaceState: LocalState): void {
 		Object.assign(this.globalStateCache, globalState)
 		Object.assign(this.secretsCache, secrets)
 		Object.assign(this.workspaceStateCache, workspaceState)
-	}
-
-	private normalizeLoadedSettings(settings: Partial<Settings>): Partial<Settings> {
-		const normalized = { ...settings }
-		for (const [key, value] of Object.entries(normalized)) {
-			;(normalized as Record<string, unknown>)[key] = this.normalizeLoadedSetting(key as keyof Settings, value as never)
-		}
-		return normalized
-	}
-
-	private normalizeLoadedSetting<K extends keyof Settings>(key: K, value: Settings[K]): Settings[K] {
-		if (typeof value === "string" && (key.endsWith("ModelId") || key.endsWith("ModelBaseId"))) {
-			return normalizeLegacySynthetic1mModelId(value) as Settings[K]
-		}
-		if (key === "openRouterPinnedProviders") {
-			return normalizeLegacyOpenRouterPinMap(value as Record<string, string[]> | undefined) as Settings[K]
-		}
-		if (key === "modelProviderPresets") {
-			return normalizeLegacyModelProviderPresets(value as ModelProviderPreset[]) as Settings[K]
-		}
-		return value
-	}
-
-	private getSettingWithOverride<K extends keyof Settings>(key: K): Settings[K] {
-		// Precedence: session override > task settings > global settings
-		if (Object.hasOwn(this.sessionOverrideCache, key)) return this.sessionOverrideCache[key] as Settings[K]
-		const taskValue = this.taskStateCache[key]
-		if (taskValue !== undefined) return taskValue
-		return this.globalStateCache[key]
-	}
-
-	private getSecret<K extends keyof Secrets>(key: K): Secrets[K] {
-		return this.secretsCache[key]
-	}
-
-	private constructApiConfigurationFromCache(): ApiConfiguration {
-		// Build secrets object from persistent storage
-		const secrets = Object.fromEntries(SecretKeys.map((key) => [key, this.getSecret(key)])) as Secrets
-
-		// Merge environment variables as fallback
-		const envSecrets = getSecretsFromEnv()
-		for (const [key, value] of Object.entries(envSecrets)) {
-			if (value && !secrets[key as keyof Secrets]) {
-				secrets[key as keyof Secrets] = value
-			}
-		}
-
-		// Build API handler settings object with task override support
-		const settings: Partial<Settings> = Object.fromEntries(
-			ApiHandlerSettingsKeys.map((key) => [key, this.getSettingWithOverride(key)]),
-		)
-
-		// Merge environment variables as fallback for settings (only fills undefined values)
-		const envSettings = getSettingsFromEnv()
-		for (const [key, value] of Object.entries(envSettings)) {
-			if (value && isSettingsKey(key) && settings[key] === undefined && !Object.hasOwn(this.sessionOverrideCache, key)) {
-				;(settings as Record<string, unknown>)[key] = this.normalizeLoadedSetting(key, value as never)
-			}
-		}
-
-		return { ...secrets, ...settings } satisfies ApiConfiguration
 	}
 }

--- a/src/core/storage/StateManagerGetters.ts
+++ b/src/core/storage/StateManagerGetters.ts
@@ -1,0 +1,74 @@
+import type { ApiConfiguration } from "@shared/api"
+import type { GlobalState, LocalState, Secrets, Settings } from "@shared/storage/state-keys"
+import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
+import { buildApiConfigurationFromCache, getSettingWithOverride, type StateManagerSettingsCaches } from "./StateManagerSettings"
+
+export interface StateManagerGetterCaches extends StateManagerSettingsCaches {
+	workspaceStateCache: LocalState
+}
+
+export function getGlobalSettingsKey<K extends keyof Settings>(
+	key: K,
+	caches: StateManagerSettingsCaches,
+	isInitialized: boolean,
+): Settings[K] {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return getSettingWithOverride(key, caches)
+}
+
+export function getSystemDefaultSettingsKey<K extends keyof Settings>(
+	key: K,
+	caches: Pick<StateManagerSettingsCaches, "globalStateCache">,
+	isInitialized: boolean,
+): Settings[K] {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return caches.globalStateCache[key]
+}
+
+export function getGlobalStateKey<K extends keyof GlobalState>(
+	key: K,
+	caches: Pick<StateManagerSettingsCaches, "globalStateCache">,
+	isInitialized: boolean,
+): GlobalState[K] {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return caches.globalStateCache[key]
+}
+
+export function getSecretKey<K extends keyof Secrets>(
+	key: K,
+	caches: Pick<StateManagerSettingsCaches, "secretsCache">,
+	isInitialized: boolean,
+): Secrets[K] {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return caches.secretsCache[key]
+}
+
+export function getWorkspaceStateKey(
+	caches: Pick<StateManagerGetterCaches, "workspaceStateCache">,
+	isInitialized: boolean,
+	key: string,
+): unknown {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return (caches.workspaceStateCache as Record<string, unknown>)[key]
+}
+
+export function getAllGlobalStateEntries(
+	caches: Pick<StateManagerSettingsCaches, "globalStateCache">,
+	isInitialized: boolean,
+): Record<string, unknown> {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return { ...caches.globalStateCache }
+}
+
+export function getAllWorkspaceStateEntries(
+	caches: Pick<StateManagerGetterCaches, "workspaceStateCache">,
+	isInitialized: boolean,
+): Record<string, unknown> {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return { ...caches.workspaceStateCache }
+}
+
+export function getApiConfiguration(caches: StateManagerSettingsCaches, isInitialized: boolean): ApiConfiguration {
+	if (!isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+	return buildApiConfigurationFromCache(caches)
+}

--- a/src/core/storage/StateManagerModelCache.ts
+++ b/src/core/storage/StateManagerModelCache.ts
@@ -1,0 +1,38 @@
+import type { ModelInfo } from "@shared/api"
+
+export interface ModelCacheEntry {
+	data: Record<string, ModelInfo>
+	timestamp: number
+}
+
+export type ModelCache = Record<string, ModelCacheEntry | null>
+
+// Cache TTL: 1 hour - long enough to prevent duplicate fetches, short enough to see new models
+export const MODEL_CACHE_TTL_MS = 60 * 60 * 1000
+
+export function setModelsCache(
+	cache: ModelCache,
+	provider: string,
+	models: Record<string, ModelInfo>,
+	timestamp = Date.now(),
+): void {
+	const cacheKey = `${provider}Models`
+	cache[cacheKey] = { data: models, timestamp }
+}
+
+export function getModelsCache(cache: ModelCache, provider: string): Record<string, ModelInfo> | null {
+	const cacheKey = `${provider}Models`
+	const cached = cache[cacheKey]
+	if (!cached) return null
+	if (Date.now() - cached.timestamp > MODEL_CACHE_TTL_MS) {
+		cache[cacheKey] = null
+		return null
+	}
+	return cached.data
+}
+
+export function getModelInfo(cache: ModelCache, provider: string, modelId: string): ModelInfo | undefined {
+	const models = getModelsCache(cache, provider)
+	if (!models) return undefined
+	return models[modelId]
+}

--- a/src/core/storage/StateManagerSetters.ts
+++ b/src/core/storage/StateManagerSetters.ts
@@ -1,0 +1,173 @@
+import type { ApiConfiguration, ModelProviderPreset } from "@shared/api"
+import { buildLegacySynthetic1mStateUpdates } from "@shared/storage/legacy-model-id-migration"
+import {
+	type GlobalStateAndSettings,
+	type GlobalStateAndSettingsKey,
+	isSecretKey,
+	isSettingsKey,
+	type LocalState,
+	type LocalStateKey,
+	type SecretKey,
+	type Secrets,
+	type Settings,
+	type SettingsKey,
+} from "@shared/storage/state-keys"
+import { STATE_MANAGER_NOT_INITIALIZED } from "./error-messages"
+import { normalizeLoadedSetting, normalizeLoadedSettings } from "./StateManagerSettings"
+import type { StatePersistenceManager } from "./StatePersistenceManager"
+
+export interface StateManagerSettersContext {
+	isInitialized: boolean
+	globalStateCache: GlobalStateAndSettings
+	taskStateCache: Partial<Settings>
+	sessionOverrideCache: Partial<Settings>
+	secretsCache: Secrets
+	workspaceStateCache: LocalState
+	persistence: StatePersistenceManager
+	notifyStateChange: () => void
+}
+
+function guardInitialized(ctx: StateManagerSettersContext): void {
+	if (!ctx.isInitialized) throw new Error(STATE_MANAGER_NOT_INITIALIZED)
+}
+
+export function setGlobalState<K extends keyof GlobalStateAndSettings>(
+	ctx: StateManagerSettersContext,
+	key: K,
+	value: GlobalStateAndSettings[K],
+): void {
+	guardInitialized(ctx)
+	const normalizedValue = isSettingsKey(key) ? normalizeLoadedSetting(key as SettingsKey, value as never) : value
+	;(ctx.globalStateCache as Record<string, unknown>)[key] = normalizedValue
+	ctx.persistence.addPendingGlobalState(key)
+	ctx.notifyStateChange()
+}
+
+export function setGlobalStateBatch(ctx: StateManagerSettersContext, updates: Partial<GlobalStateAndSettings>): void {
+	guardInitialized(ctx)
+	const normalizedUpdates = { ...updates, ...buildLegacySynthetic1mStateUpdates(updates) }
+	Object.assign(ctx.globalStateCache, normalizedUpdates)
+	ctx.persistence.addPendingGlobalStateBatch(Object.keys(normalizedUpdates) as GlobalStateAndSettingsKey[])
+	ctx.notifyStateChange()
+}
+
+export function setTaskSettings<K extends keyof Settings>(
+	ctx: StateManagerSettersContext,
+	taskId: string,
+	key: K,
+	value: Settings[K],
+): void {
+	guardInitialized(ctx)
+	ctx.taskStateCache[key] = normalizeLoadedSetting(key, value)
+	ctx.persistence.addPendingTaskState(taskId, key)
+}
+
+export function setTaskSettingsBatch(ctx: StateManagerSettersContext, taskId: string, updates: Partial<Settings>): void {
+	guardInitialized(ctx)
+	const normalizedUpdates = normalizeLoadedSettings(updates)
+	Object.assign(ctx.taskStateCache, normalizedUpdates)
+	ctx.persistence.addPendingTaskStateBatch(taskId, Object.keys(normalizedUpdates) as SettingsKey[])
+}
+
+export async function loadTaskSettings(ctx: StateManagerSettersContext, taskId: string): Promise<void> {
+	guardInitialized(ctx)
+	const taskSettings = (await ctx.persistence.loadTaskSettingsFromDisk(taskId)) as Partial<Settings>
+	const normalizedTaskSettings = normalizeLoadedSettings(taskSettings)
+	Object.assign(ctx.taskStateCache, normalizedTaskSettings)
+	if (JSON.stringify(normalizedTaskSettings) !== JSON.stringify(taskSettings)) {
+		ctx.persistence.addPendingTaskStateBatch(taskId, Object.keys(normalizedTaskSettings) as SettingsKey[])
+	}
+}
+
+export async function clearTaskSettings(ctx: StateManagerSettersContext): Promise<void> {
+	if (ctx.persistence.hasPendingTaskState()) {
+		await ctx.persistence.persistAndClearPendingTaskState()
+	}
+	for (const key of Object.keys(ctx.taskStateCache)) {
+		delete ctx.taskStateCache[key as keyof Settings]
+	}
+	ctx.persistence.clearPendingTaskState()
+}
+
+export function setSecret<K extends keyof Secrets>(ctx: StateManagerSettersContext, key: K, value: Secrets[K]): void {
+	guardInitialized(ctx)
+	ctx.secretsCache[key] = value
+	ctx.persistence.addPendingSecret(key)
+}
+
+export function setSecretsBatch(ctx: StateManagerSettersContext, updates: Partial<Secrets>): void {
+	guardInitialized(ctx)
+	const changedKeys: SecretKey[] = []
+	Object.entries(updates).forEach(([key, value]) => {
+		const current = ctx.secretsCache[key as keyof Secrets]
+		if (current === value) return
+		ctx.secretsCache[key as keyof Secrets] = value
+		changedKeys.push(key as SecretKey)
+	})
+	ctx.persistence.addPendingSecretBatch(changedKeys)
+}
+
+export function setWorkspaceState(ctx: StateManagerSettersContext, key: string, value: unknown): void {
+	guardInitialized(ctx)
+	;(ctx.workspaceStateCache as Record<string, unknown>)[key] = value
+	ctx.persistence.addPendingWorkspaceState(key as LocalStateKey)
+}
+
+export function setWorkspaceStateBatch(ctx: StateManagerSettersContext, updates: Partial<LocalState>): void {
+	guardInitialized(ctx)
+	const changedKeys: LocalStateKey[] = []
+	Object.entries(updates).forEach(([key, value]) => {
+		ctx.workspaceStateCache[key as keyof LocalState] = value
+		changedKeys.push(key as LocalStateKey)
+	})
+	ctx.persistence.addPendingWorkspaceStateBatch(changedKeys)
+}
+
+export function setSessionOverride<K extends keyof Settings>(ctx: StateManagerSettersContext, key: K, value: Settings[K]): void {
+	guardInitialized(ctx)
+	ctx.sessionOverrideCache[key] = normalizeLoadedSetting(key, value)
+}
+
+export function setSessionOverrideCache(ctx: StateManagerSettersContext, overrides: Partial<Settings>): void {
+	for (const key of Object.keys(ctx.sessionOverrideCache)) {
+		delete ctx.sessionOverrideCache[key as keyof Settings]
+	}
+	Object.assign(ctx.sessionOverrideCache, normalizeLoadedSettings(overrides))
+}
+
+export function refreshModelProviderPresetsFromDisk(ctx: StateManagerSettersContext): void {
+	guardInitialized(ctx)
+
+	const cachedPresets = ctx.globalStateCache.modelProviderPresets
+	const diskPresets = ctx.persistence.readGlobalStateKeyFromDisk("modelProviderPresets") as ModelProviderPreset[] | undefined
+	const presetsById = new Map<string, ModelProviderPreset>()
+
+	for (const preset of [...cachedPresets, ...(diskPresets || [])]) {
+		const existing = presetsById.get(preset.id)
+		if (!existing || preset.lastUsedAt > existing.lastUsedAt) presetsById.set(preset.id, preset)
+	}
+
+	const mergedPresets = [...presetsById.values()].sort((a, b) => b.lastUsedAt - a.lastUsedAt).slice(0, 20)
+	if (JSON.stringify(mergedPresets) === JSON.stringify(cachedPresets)) return
+	setGlobalState(ctx, "modelProviderPresets", mergedPresets)
+}
+
+export function setApiConfiguration(ctx: StateManagerSettersContext, apiConfiguration: ApiConfiguration): void {
+	guardInitialized(ctx)
+
+	const { settingsUpdates, secretsUpdates } = Object.entries(apiConfiguration).reduce(
+		(acc, [key, value]) => {
+			if (key === undefined) return acc
+			if (isSecretKey(key)) {
+				;(acc.secretsUpdates as Record<string, string | undefined>)[key] = value as string | undefined
+			} else if (isSettingsKey(key)) {
+				;(acc.settingsUpdates as Record<string, unknown>)[key] = value
+			}
+			return acc
+		},
+		{ settingsUpdates: {} as Partial<Settings>, secretsUpdates: {} as Partial<Secrets> },
+	)
+
+	if (Object.keys(settingsUpdates).length > 0) setGlobalStateBatch(ctx, settingsUpdates)
+	if (Object.keys(secretsUpdates).length > 0) setSecretsBatch(ctx, secretsUpdates)
+}

--- a/src/core/storage/StateManagerSettings.ts
+++ b/src/core/storage/StateManagerSettings.ts
@@ -1,0 +1,86 @@
+import type { ApiConfiguration, ModelProviderPreset } from "@shared/api"
+import { getSecretsFromEnv, getSettingsFromEnv } from "@shared/storage/env-config"
+import {
+	normalizeLegacyModelProviderPresets,
+	normalizeLegacyOpenRouterPinMap,
+	normalizeLegacySynthetic1mModelId,
+} from "@shared/storage/legacy-model-id-migration"
+import {
+	ApiHandlerSettingsKeys,
+	type GlobalStateAndSettings,
+	isSecretKey,
+	isSettingsKey,
+	SecretKeys,
+	type Secrets,
+	type Settings,
+} from "@shared/storage/state-keys"
+
+export interface StateManagerSettingsCaches {
+	sessionOverrideCache: Partial<Settings>
+	taskStateCache: Partial<Settings>
+	globalStateCache: GlobalStateAndSettings
+	secretsCache: Secrets
+}
+
+export function normalizeLoadedSetting<K extends keyof Settings>(key: K, value: Settings[K]): Settings[K] {
+	if (typeof value === "string" && (key.endsWith("ModelId") || key.endsWith("ModelBaseId"))) {
+		return normalizeLegacySynthetic1mModelId(value) as Settings[K]
+	}
+	if (key === "openRouterPinnedProviders") {
+		return normalizeLegacyOpenRouterPinMap(value as Record<string, string[]> | undefined) as Settings[K]
+	}
+	if (key === "modelProviderPresets") {
+		return normalizeLegacyModelProviderPresets(value as ModelProviderPreset[]) as Settings[K]
+	}
+	return value
+}
+
+export function normalizeLoadedSettings(settings: Partial<Settings>): Partial<Settings> {
+	const normalized = { ...settings }
+	for (const [key, value] of Object.entries(normalized)) {
+		;(normalized as Record<string, unknown>)[key] = normalizeLoadedSetting(key as keyof Settings, value as never)
+	}
+	return normalized
+}
+
+export function getSettingWithOverride<K extends keyof Settings>(
+	key: K,
+	caches: Pick<StateManagerSettingsCaches, "sessionOverrideCache" | "taskStateCache" | "globalStateCache">,
+): Settings[K] {
+	if (Object.hasOwn(caches.sessionOverrideCache, key)) return caches.sessionOverrideCache[key] as Settings[K]
+	const taskValue = caches.taskStateCache[key]
+	if (taskValue !== undefined) return taskValue
+	return caches.globalStateCache[key]
+}
+
+export function getSecret<K extends keyof Secrets>(key: K, secretsCache: Secrets): Secrets[K] {
+	return secretsCache[key]
+}
+
+export function buildApiConfigurationFromCache(caches: StateManagerSettingsCaches): ApiConfiguration {
+	const secrets = Object.fromEntries(
+		SecretKeys.map((key) => [key, getSecret(key as keyof Secrets, caches.secretsCache)]),
+	) as Secrets
+
+	const envSecrets = getSecretsFromEnv()
+	for (const [key, value] of Object.entries(envSecrets)) {
+		if (value && !secrets[key as keyof Secrets]) {
+			secrets[key as keyof Secrets] = value
+		}
+	}
+
+	const settings: Partial<Settings> = Object.fromEntries(
+		ApiHandlerSettingsKeys.map((key) => [key, getSettingWithOverride(key as keyof Settings, caches)]),
+	)
+
+	const envSettings = getSettingsFromEnv()
+	for (const [key, value] of Object.entries(envSettings)) {
+		if (value && isSettingsKey(key) && settings[key] === undefined && !Object.hasOwn(caches.sessionOverrideCache, key)) {
+			;(settings as Record<string, unknown>)[key] = normalizeLoadedSetting(key as keyof Settings, value as never)
+		}
+	}
+
+	return { ...secrets, ...settings } satisfies ApiConfiguration
+}
+
+export { isSecretKey, isSettingsKey }

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,13 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+export interface LanguageModelChatSelector {
+	vendor?: string
+	family?: string
+	version?: string
+	id?: string
+}
+
 export class LanguageModelTextPart {
 	constructor(public value: string) { }
 }

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -169,6 +169,8 @@ export enum LanguageModelChatMessageRole {
 	Assistant = 2,
 }
 
+// Keep LM shapes in sync with cli/src/vscode-shim.ts (see FU-5 - they may not be
+// consolidated until the ts-node alias-resolution bug is fixed).
 export interface LanguageModelChatSelector {
 	vendor?: string
 	family?: string

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for `node:sqlite` (available at runtime on the Node
+ * version this project runs, but the bundled `@types/node` does not ship them).
+ * Only models the subset used by `SymbolIndexDatabase`.
+ */
+declare module "node:sqlite" {
+	interface StatementResult {
+		changes: number | bigint
+		lastInsertRowid: number | bigint
+	}
+	interface StatementSync {
+		get(...args: unknown[]): Record<string, unknown> | undefined
+		all(...args: unknown[]): Record<string, unknown>[]
+		iterate(...args: unknown[]): IterableIterator<Record<string, unknown>>
+		run(...args: unknown[]): StatementResult
+	}
+	class DatabaseSync {
+		constructor(path: string)
+		prepare(sql: string, ...args: unknown[]): StatementSync
+		exec(sql: string): void
+		close(): void
+	}
+	export { DatabaseSync, type StatementSync }
+}

--- a/src/types/node-sqlite.d.ts
+++ b/src/types/node-sqlite.d.ts
@@ -1,3 +1,4 @@
+/* DELETE once @types/node ships node:sqlite types — a future types upgrade will collide with this declare module. */
 /**
  * Minimal type declarations for `node:sqlite` (available at runtime on the Node
  * version this project runs, but the bundled `@types/node` does not ship them).

--- a/src/types/vscode-augment.d.ts
+++ b/src/types/vscode-augment.d.ts
@@ -1,0 +1,68 @@
+/**
+ * Augments the installed `@types/vscode` with the newer Language Model API
+ * members used across the codebase. Type-only; merges into the vscode module.
+ * (Tests wire vscode at runtime to src/test/vscode-mock.ts via a require hook;
+ * this augmentation is what makes the TS type-checking of `import("vscode")`
+ * forms see the missing LM members.)
+ */
+declare module "vscode" {
+	export interface LanguageModelChatSelector {
+		vendor?: string
+		family?: string
+		version?: string
+		id?: string
+	}
+
+	export class LanguageModelTextPart {
+		constructor(text: string)
+		readonly value: string
+		readonly text: string
+	}
+
+	export enum LanguageModelChatMessageRole {
+		User = 1,
+		Assistant = 2,
+	}
+
+	export class LanguageModelToolCallPart {
+		constructor(callId: string, name: string, input: unknown)
+		readonly callId: string
+		readonly name: string
+		readonly input: unknown
+	}
+
+	export class LanguageModelToolResultPart {
+		constructor(callId: string, content: LanguageModelTextPart[])
+		readonly callId: string
+		readonly content: LanguageModelTextPart[]
+	}
+
+	export class LanguageModelChatMessage {
+		role: LanguageModelChatMessageRole
+		content: Array<LanguageModelTextPart | LanguageModelToolResultPart | LanguageModelToolCallPart>
+		name?: string
+	}
+
+	export interface LanguageModelChatRequestOptions {
+		justification?: string
+		tools?: unknown[]
+	}
+
+	export class LanguageModelChatResponse {
+		readonly stream: AsyncIterable<LanguageModelTextPart | LanguageModelToolCallPart | LanguageModelToolResultPart>
+	}
+
+	export class LanguageModelChat {
+		readonly name: string
+		readonly vendor: string
+		sendRequest(
+			messages: LanguageModelChatMessage[],
+			options: LanguageModelChatRequestOptions,
+			token?: unknown,
+		): Thenable<LanguageModelChatResponse>
+	}
+
+	export namespace lm {
+		function selectChatModels(selector: LanguageModelChatSelector): Thenable<LanguageModelChat[]>
+	}
+}

--- a/tsconfig.unit-test.json
+++ b/tsconfig.unit-test.json
@@ -11,7 +11,8 @@
 	"ts-node": {
 		"files": true,
 		"compilerOptions": {
-			"module": "commonjs"
+			"module": "commonjs",
+			"moduleResolution": "node"
 		},
 		"require": [
 			"tsconfig-paths/register"


### PR DESCRIPTION
**What**
Split the 514-line `StateManager.ts` (→ 426) into helper modules under `src/core/storage/`:
- `StateManagerSettings.ts` — settings normalization, secret/env merge, apiConfiguration assembly
- `StateManagerModelCache.ts` — model-info cache TTL helpers
- `StateManagerGetters.ts` / `StateManagerSetters.ts` — get/set delegation operating on explicit context objects
StateManager keeps cache ownership; setters mutate caches in place so the per-call context objects stay alias-safe. Public API and back-compat re-exports unchanged.

**Why**
FIX-BACKLOG FB-15d — single responsibility within the storage layer.

**Notes / Caveats**
- Stacks on `fix/env-test-unblock` (#166); those commits are included until #166 merges.

**Verification**
- `tsc --noEmit -p tsconfig.unit-test.json`: 0 new errors vs base (46 pre-existing, byte-identical set — vscode-lm/terminal env types, covered by CI).
- `biome lint` clean on changed files.
- Unit tests verified at branch authoring: 25/25 StateManager tests passing.

**User test**: no observable change (pure refactor).

Closes FB-15d (FIX-BACKLOG).
