### PR TITLE
fix(webview): re-anchor viewport on list shrink and stop following on all user scroll

### DIFF
--- a/webview-ui/src/features/modular-ui/chat/constants.ts
+++ b/webview-ui/src/features/modular-ui/chat/constants.ts
@@ -2,7 +2,7 @@
  * Constants used across the chat view components
  */
 export const CHAT_CONSTANTS = {
-	AT_BOTTOM_THRESHOLD: 4,
+	AT_BOTTOM_THRESHOLD: 64,
 	MAX_IMAGES_AND_FILES_PER_MESSAGE: 20,
 	QUICK_WINS_HISTORY_THRESHOLD: 300,
 } as const

--- a/webview-ui/src/features/modular-ui/chat/hooks/useScrollBehavior.ts
+++ b/webview-ui/src/features/modular-ui/chat/hooks/useScrollBehavior.ts
@@ -187,19 +187,26 @@ export function useScrollBehavior(
 
 	const handleListHeightChanged = useCallback((height: number) => {
 		const listGrew = height > lastListHeightRef.current
+		const listShrunk = height < lastListHeightRef.current
 		lastListHeightRef.current = height
-		if (!listGrew || !isFollowingRef.current) return
+		if (!isFollowingRef.current) return
 
 		cancelAnimationFrame(listHeightRafIdRef.current)
 		listHeightRafIdRef.current = requestAnimationFrame(() => {
-			virtuosoRef.current?.autoscrollToBottom()
+			if (listGrew) {
+				virtuosoRef.current?.autoscrollToBottom()
+			} else if (listShrunk) {
+				// autoscrollToBottom only works when notAtBottomBecause === "SIZE_INCREASED";
+				// on shrink it would no-op, so re-anchor explicitly to the new last item.
+				virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" })
+			}
 		})
 	}, [])
 
 	const handleScrollWheel = useCallback(
 		(event: React.WheelEvent) => {
-			if (event.deltaY >= 0) return
 			stopFollowing()
+			if (event.deltaY < 0) return
 			resumeFollowingIfAtBottom(event.currentTarget as HTMLElement)
 		},
 		[resumeFollowingIfAtBottom, stopFollowing],
@@ -207,11 +214,20 @@ export function useScrollBehavior(
 
 	const handleScrollKeyDown = useCallback(
 		(event: React.KeyboardEvent) => {
+			const isScrollKey =
+				event.key === "ArrowUp" ||
+				event.key === "ArrowDown" ||
+				event.key === "PageUp" ||
+				event.key === "PageDown" ||
+				event.key === "Home" ||
+				event.key === "End" ||
+				event.key === " "
+			if (!isScrollKey) return
+
 			const scrollsUp =
 				event.key === "ArrowUp" || event.key === "PageUp" || event.key === "Home" || (event.key === " " && event.shiftKey)
-			if (!scrollsUp) return
-
 			stopFollowing()
+			if (scrollsUp) return
 			resumeFollowingIfAtBottom(event.currentTarget as HTMLElement)
 		},
 		[resumeFollowingIfAtBottom, stopFollowing],
@@ -251,7 +267,9 @@ export function useScrollBehavior(
 			const currentY = event.touches[0]?.clientY
 			const previousY = touchYRef.current
 			touchYRef.current = currentY ?? null
-			if (currentY !== undefined && previousY !== null && currentY > previousY) {
+			// Any touch scroll — up or down — means the user is taking control;
+			// stop following and let handleScrollTouchEnd resume if at the bottom.
+			if (currentY !== undefined && previousY !== null && currentY !== previousY) {
 				stopFollowing()
 			}
 		},
@@ -266,7 +284,14 @@ export function useScrollBehavior(
 		[resumeFollowingIfAtBottom],
 	)
 
-	const followOutput = useCallback((): "auto" | false => (isFollowingRef.current ? "auto" : false), [])
+	const followOutput = useCallback((atBottom: boolean): "auto" | false => {
+		if (!isFollowingRef.current) return false
+		// NOTE: Virtuoso's argument is isAtBottom || scrollingInProgress, not just isAtBottom —
+		// during a programmatic scroll it is true even when the user is not at the bottom.
+		// Gate on it anyway (defense-in-depth for Mechanism B); the isFollowingRef check is
+		// the real authority that prevents following while the user is scrolling.
+		return atBottom ? "auto" : false
+	}, [])
 
 	const taskId = messages.at(0)?.id
 	// biome-ignore lint/correctness/useExhaustiveDependencies: task identity intentionally resets all scroll state.

--- a/webview-ui/src/features/modular-ui/chat/types/chatTypes.ts
+++ b/webview-ui/src/features/modular-ui/chat/types/chatTypes.ts
@@ -96,7 +96,7 @@ export interface ScrollBehavior {
 	handleScrollTouchMove: (event: React.TouchEvent) => void
 	handleScrollTouchStart: (event: React.TouchEvent) => void
 	handleScrollWheel: (event: React.WheelEvent) => void
-	followOutput: () => "auto" | false
+	followOutput: (atBottom: boolean) => "auto" | false
 }
 
 /**


### PR DESCRIPTION
## What

- `webview-ui/src/features/modular-ui/chat/constants.ts` — `AT_BOTTOM_THRESHOLD` 4 → 64
- `webview-ui/src/features/modular-ui/chat/hooks/useScrollBehavior.ts` — `handleListHeightChanged` now handles list shrink (not just growth); `handleScrollWheel`, `handleScrollKeyDown`, `handleScrollTouchMove` now stop following on any user scroll interaction (not just scroll-up); `followOutput` respects Virtuoso's `atBottom` argument
- `webview-ui/src/features/modular-ui/chat/types/chatTypes.ts` — `followOutput` type updated to match new signature

## Why

Regression from `44c8cef` ("fix: a bunch of fixes to webview-ui") made the viewport jump up to earlier messages when the user reached the bottom, making the last message unreadable. Three causes combined:

- **`handleListHeightChanged` only handled list growth.** When a card auto-collapsed near the bottom, the list height decreased, no code re-anchored the viewport, and the browser clamped the scroll position upward. `autoscrollToBottom` was no-op on shrink (it requires `notAtBottomBecause === "SIZE_INCREASED"`), so the fix uses `scrollToIndex({ index: "LAST", align: "end" })` for the shrink case.
- **`isFollowingRef` latched true.** It started `true` and only reset on scroll-up. Scroll-down via wheel, keyboard (ArrowDown/PageDown/End/Space), or touch left it true, so `followOutput` returned `"auto"` and `handleListHeightChanged` kept forcing scrolls back to the bottom even when the user was actively scrolling away. Now all input handlers stop following on any interaction and resume only when the user reaches the bottom.
- **`followOutput` ignored Virtuoso's `atBottom` argument.** It returned `"auto"` whenever `isFollowingRef` was true. Now gated on `atBottom` (which is `isAtBottom || scrollingInProgress`) as defense-in-depth.
- **`AT_BOTTOM_THRESHOLD` was reduced from 64 to 4** in `44c8cef`, causing `atBottomStateChange` to fire rapidly on minor layout shifts. Restored to 64.

Full RCA in the linked review notes.

## Notes / Caveats

- No debounce re-added. The previous 80/150ms debounce was a mitigation for a broken state machine; with the state machine now correct (stop on interaction, resume only at bottom), it is unnecessary. Can be added later if flicker persists.
- `overflowAnchor: "none"` kept — deliberate with a virtualized list; the app now has its own re-anchoring on shrink.
- `increaseViewportBy.bottom` left at 200 (was 800 pre-regression). Can be revisited if bottom pre-rendering feels tight in practice.
- The `followOutput` argument is `isAtBottom || scrollingInProgress`, not just `isAtBottom` — during a programmatic scroll it is `true` even when the user is not at the bottom. This is desired (we want to keep following during an in-progress scroll); `isFollowingRef` is the real authority that prevents following while the user is scrolling.

## Verification

- `npx biome check` on touched files: 0 new errors
- `cd webview-ui && npx tsc --noEmit`: 0 errors
- `cd webview-ui && npm run build`: passed
- 0 behind `origin/master` (clean base)
- No unit tests for `useScrollBehavior` exist in the repo; the hook is logic-heavy and would benefit from a test suite, but that is out of scope for this fix

## User test

Open a task with multiple cards that auto-collapse on completion. Scroll down toward the bottom. Before the fix: the viewport snaps up to earlier messages when a card collapses, and you cannot reach the bottom. After the fix: the viewport stays anchored at the bottom when a card collapses while you are following, and you can freely scroll up/down without being yanked back.