### PR TITLE
fix: catch dynamic import failure in file writer

### DIFF
--- a/src/integrations/terminal/file-logging.ts
+++ b/src/integrations/terminal/file-logging.ts
@@ -28,7 +28,12 @@ class QueuedFileWriter {
 	private closePromise: Promise<void> | undefined
 
 	constructor(path: string) {
-		this.handlePromise = import("node:fs/promises").then(({ open }) => open(path, "wx"))
+		this.handlePromise = import("node:fs/promises")
+			.then(({ open }) => open(path, "wx"))
+			.catch((error) => {
+				this.firstError ??= toError(error)
+				return undefined
+			})
 	}
 
 	write(output: string): void {
@@ -37,6 +42,7 @@ class QueuedFileWriter {
 		this.pendingWrites = this.pendingWrites
 			.then(async () => {
 				const handle = await this.handlePromise
+				if (!handle) return
 				await handle.appendFile(output, "utf8")
 			})
 			.catch((error) => {
@@ -52,7 +58,7 @@ class QueuedFileWriter {
 	private async closeAfterPendingWrites(): Promise<void> {
 		await this.pendingWrites
 		const handle = await this.handlePromise
-		await handle.close()
+		if (handle) await handle.close()
 		if (this.firstError) throw this.firstError
 	}
 }


### PR DESCRIPTION
## What
- `QueuedFileWriter` constructor: `import("node:fs/promises").then(...)` had no `.catch()` — a failed dynamic import (or `open`) left an unhandled promise rejection.
- Attach `.catch()`: records the error as `firstError` (consistent with the write pipeline) and resolves `handlePromise` to `undefined`.
- `write()`/`close()` guard on `undefined` handle instead of throwing a spurious TypeError.

## Why
FB-2 — fire-and-forget `.then()` chains must have a `.catch()` so a failure can't become an unhandled rejection.

## Notes
- Remaining FB-2 sites already have `.catch()`; this was the last uncaught one.

## Verification
- `tsc -p tsconfig.unit-test.json --noEmit` — only pre-existing baseline error.
- `biome check` — clean on touched file.
