### PR TITLE
refactor: use getErrorMessage in storage migration warn

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ import { isDev } from "@shared/config/environment"
 import type { ExtensionContext } from "vscode"
 import { HostProvider } from "@/hosts/host-provider"
 import { vscodeHostBridgeClient } from "@/hosts/vscode/hostbridge/client/host-grpc-client"
-import { toError } from "@/shared/errors"
+import { getErrorMessage, toError } from "@/shared/errors"
 import { createStorageContext } from "@/shared/storage/storage-context"
 import { readTextFromClipboard, writeTextToClipboard } from "@/utils/env"
 import { initialize, tearDown } from "./common"
@@ -746,6 +746,7 @@ async function cleanupLegacyVSCodeStorage(context: ExtensionContext): Promise<vo
 
 		Logger.info("[VS Code Storage Migrations] Completed")
 	} catch (error) {
-		Logger.warn("[VS Code Storage Migrations] Failed" + (error instanceof Error ? `: ${error.message}` : ""))
+		const errorMessage = getErrorMessage(error, "")
+		Logger.warn(`[VS Code Storage Migrations] Failed${errorMessage ? `: ${errorMessage}` : ""}`)
 	}
 }


### PR DESCRIPTION
## What
- Replace the last `error instanceof Error ? `: ${error.message}` : ""` site outside `src/shared/errors.ts` with `getErrorMessage(error, "")`.
- Same output: `getErrorMessage(error, "")` returns the message for an `Error`, `""` fallback otherwise — then conditionally appends `: <message>`.
- Drop the manual error-shape check in `extension.ts` storage-migration warning.

## Why
FB-6 — consolidate error-message extraction into `getErrorMessage`. `src/shared/errors.ts` already has the helper; this was the last stray `instanceof Error ?` message site outside it.

## Notes
- Remaining `instanceof Error ?` sites: `errors.ts:7/15` (the helper itself) and `ripgrep:205` (extracts `.stack`, not a message — out of scope).

## Verification
- `tsc -p tsconfig.unit-test.json --noEmit` — only pre-existing baseline error.
- `biome check` — only pre-existing info at line 216 (unrelated).
