### PR TITLE
fix: restore totalCost undefined guard

### DIFF
--- a/src/core/task/TaskRequestLoop.ts
+++ b/src/core/task/TaskRequestLoop.ts
@@ -190,7 +190,8 @@ export async function recursivelyMakeDiracRequests(
 			ctx.taskState.totalReasoningTokens += metrics.reasoningTokens
 			ctx.taskState.totalCacheWriteTokens += metrics.cacheWriteTokens
 			ctx.taskState.totalCacheReadTokens += metrics.cacheReadTokens
-			ctx.taskState.totalCost += metricsManager.getTotalCost() ?? 0
+			const cost = metricsManager.getTotalCost()
+			if (cost !== undefined) ctx.taskState.totalCost += cost
 
 			const currentApiReqIndex = findLastIndex(
 				ctx.messageStateHandler.getDiracMessages(),


### PR DESCRIPTION
## fix

restore `getTotalCost()` undefined guard in `TaskRequestLoop`.

## what

PR #170 split rewrote #175 guard:

```ts
ctx.taskState.totalCost += metricsManager.getTotalCost() ?? 0
```

this silently records unknown pricing as `0`.

change back to:

```ts
const cost = metricsManager.getTotalCost()
if (cost !== undefined) ctx.taskState.totalCost += cost
```

`StreamingMetricsManager` returns `undefined` for unknown pricing, `0` only when model explicitly free, and actual number for provider cost or computed paid cost. only add when defined.

## test

- `src/core/task/__tests__/StreamingMetricsManager.test.ts` passes
- `src/core/task/__tests__/TaskState.test.ts` passes
- `npx tsc --noEmit` clean except pre-existing `src/shared/storage/types.ts(14,2)` error
- `npx biome check src/core/task/TaskRequestLoop.ts` reports 2 pre-existing formatter/import-sort errors also on master
