### PR TITLE
fix: audit security and correctness (FB-1, FB-19..FB-43)

### DIFF
--- a/src/core/controller/file/openFile.ts
+++ b/src/core/controller/file/openFile.ts
@@ -4,6 +4,8 @@ import { REMOTE_URI_SCHEME } from "@shared/remote-config/constants"
 import { writeFile } from "@utils/fs"
 import * as os from "os"
 import * as path from "path"
+import { readRemoteConfigFromCache } from "@core/storage/disk"
+import { StateManager } from "@core/storage/StateManager"
 import { Controller } from ".."
 
 /**
@@ -39,13 +41,23 @@ async function openRemoteFile(uri: string): Promise<void> {
 	}
 
 	const [, type, name] = match
-	const item = undefined as any
+
+	// Look up the item from cached remote config
+	const stateManager = StateManager.get()
+	const organizationId = stateManager.getSecretKey("dirac:diracAccountId")
+	if (!organizationId) {
+		throw new Error(`Not signed in to a Dirac organization; cannot open remote ${type}: ${name}`)
+	}
+
+	const config = await readRemoteConfigFromCache(organizationId)
+	const items = type === "rule" ? config?.globalRules : config?.globalWorkflows
+	const item = items?.find((r) => r.name === name)
 
 	if (!item?.contents) {
 		throw new Error(`Remote ${type} not found: ${name}`)
 	}
 
-	// Create temp file with read-only header comment
+	// Create temp file with read-only header comment (only after validation)
 	const typeLabel = type === "rule" ? "rule" : "workflow"
 	const header = `# ⚠️ READ-ONLY: This ${typeLabel} is managed by your organization.\n# Changes made here will not be saved.\n\n`
 	const content = header + item.contents

--- a/src/core/controller/models/refreshOpenAiModels.ts
+++ b/src/core/controller/models/refreshOpenAiModels.ts
@@ -22,6 +22,13 @@ export async function refreshOpenAiModels(_controller: Controller, request: Open
 			return StringArray.create({ values: [] })
 		}
 
+		// Only allow https: to prevent key exfiltration via file://, http://, data:, etc.
+		const parsedUrl = new URL(request.baseUrl)
+		if (parsedUrl.protocol !== "https:") {
+			Logger.warn(`[refreshOpenAiModels] rejected non-https baseUrl: ${parsedUrl.protocol}`)
+			return StringArray.create({ values: [] })
+		}
+
 		const config: AxiosRequestConfig = {}
 		if (request.apiKey) {
 			config["headers"] = { Authorization: `Bearer ${request.apiKey}` }

--- a/src/core/task/EnvironmentManager.ts
+++ b/src/core/task/EnvironmentManager.ts
@@ -114,8 +114,10 @@ export class EnvironmentManager {
 			const gitIgnoredNames = await this.getGitIgnoredNames()
 			const ignoredDirs = new Set([...ALWAYS_IGNORED_DIRS, ...gitIgnoredNames])
 
+			const MAX_WALK_FILES = 5000
 			const fileStats: { relativePath: string; mtime: Date }[] = []
 			for await (const absPath of this.walkCodeFiles(this.cwd, ignoredDirs)) {
+				if (fileStats.length >= MAX_WALK_FILES) break
 				try {
 					const stat = await fs.stat(absPath)
 					fileStats.push({

--- a/src/core/task/tools/adapters/traits/BrowserTraitBuilder.ts
+++ b/src/core/task/tools/adapters/traits/BrowserTraitBuilder.ts
@@ -14,6 +14,6 @@ export function buildBrowserTrait(config: TaskConfig): IBrowserTrait {
 		type: async (text: string) => await session().type(text),
 		scroll: async (direction: "up" | "down") =>
 			direction === "up" ? await session().scrollUp() : await session().scrollDown(),
-		close: async () => await session().closeBrowser(),
+		close: async () => await session().closeBrowser(config.ulid),
 	}
 }

--- a/src/core/task/tools/adapters/traits/OrchestrationTraitBuilder.ts
+++ b/src/core/task/tools/adapters/traits/OrchestrationTraitBuilder.ts
@@ -47,6 +47,23 @@ export function buildOrchestrationTrait(config: TaskConfig): IOrchestrationTrait
 				agentIdentity,
 				recorder,
 			})
+
+			// Wire external abort signal to the runner for immediate cancellation
+			const signal = options?.signal
+			if (signal) {
+				if (signal.aborted) {
+					await runner.abort("Aborted by external signal")
+				} else {
+					signal.addEventListener(
+					"abort",
+					() => {
+						void runner.abort(signal.reason ? `Aborted: ${String(signal.reason)}` : "Aborted by external signal")
+					},
+					{ once: true },
+				)
+				}
+			}
+
 			return await runner.run(prompt, options?.onUpdate || (() => {}), options?.timeout, options?.includeHistory)
 		},
 		runHook: async (name, input, options) => {

--- a/src/core/task/tools/discovery/__tests__/ToolRegistry.test.ts
+++ b/src/core/task/tools/discovery/__tests__/ToolRegistry.test.ts
@@ -390,6 +390,30 @@ describe("ToolRegistry", () => {
 			assert.strictEqual(registry.isEnabled("user_tool"), true)
 			assert.strictEqual(registry.getVersion(), version)
 		})
+
+		it("rejects a user tool that would shadow a built-in by name", () => {
+			const registry = ToolRegistry.getInstance()
+			registry.registerBuiltin(makeTool({ id: "read_file_builtin", name: "read_file", source: "builtin" }))
+
+			assert.strictEqual(
+				registry.replaceUserTool(makeTool({ id: "my_tool", name: "read_file", source: "workspace" }), true),
+				false,
+			)
+			assert.strictEqual(registry.getAllTools().length, 1)
+			assert.strictEqual(registry.getAllTools()[0].source, "builtin")
+		})
+
+		it("rejects a user tool that would shadow a built-in by id", () => {
+			const registry = ToolRegistry.getInstance()
+			registry.registerBuiltin(makeTool({ id: "execute_command", name: "execute_command", source: "builtin" }))
+
+			assert.strictEqual(
+				registry.replaceUserTool(makeTool({ id: "execute_command", name: "my_custom", source: "workspace" }), true),
+				false,
+			)
+			assert.strictEqual(registry.getAllTools().length, 1)
+			assert.strictEqual(registry.getAllTools()[0].source, "builtin")
+		})
 	})
 
 	describe("removeUserTool", () => {

--- a/src/core/task/tools/interfaces/IToolEnvironment.ts
+++ b/src/core/task/tools/interfaces/IToolEnvironment.ts
@@ -324,6 +324,8 @@ export interface IOrchestrationTrait {
 			allowedTools?: string[]
 			systemSuffix?: string
 			onUpdate?: (update: SubagentProgressUpdate) => void | Promise<void>
+			/** Abort signal to cancel the subagent run (e.g., parent task cancellation). */
+			signal?: AbortSignal
 		},
 	): Promise<SubagentRunResult>
 

--- a/src/core/task/tools/modules/diagnostics_scan/index.ts
+++ b/src/core/task/tools/modules/diagnostics_scan/index.ts
@@ -81,6 +81,8 @@ export class DiagnosticsScanTool implements IDiracTool<DiagnosticsScanArgs, stri
 			const validFiles = fileInfos.filter((f) => !f.error)
 
 			if (validFiles.length === 0) {
+				const currentMistakeCount = env.orchestration.getTaskState("consecutiveMistakeCount")
+				env.orchestration.setTaskState("consecutiveMistakeCount", currentMistakeCount + 1)
 				const result = errorResults.join("\n---\n")
 				if (card) {
 					await card.update({ status: CardStatus.ERROR, body: result })

--- a/src/core/task/tools/modules/diagnostics_scan/index.ts
+++ b/src/core/task/tools/modules/diagnostics_scan/index.ts
@@ -96,10 +96,11 @@ export class DiagnosticsScanTool implements IDiracTool<DiagnosticsScanArgs, stri
 			const totalLines = validFiles.reduce((sum, f) => sum + f.content.split(/\r?\n/).length, 0)
 			const timeoutMs = Math.min(this.baseDiagnosticsTimeoutMs + Math.floor(totalLines / 1000) * 1000, 10000)
 			const startTime = Date.now()
+			const abortSignal = env.orchestration.getTaskState("abortSignal")
 			let allDiagnostics: FileDiagnostics[] = []
 			let foundDiagnostics = false
 
-			while (Date.now() - startTime < timeoutMs) {
+			while (Date.now() - startTime < timeoutMs && !abortSignal?.aborted) {
 				allDiagnostics = await env.diagnostics.getRaw(validFiles.map((f) => f.absolutePath))
 
 				foundDiagnostics = validFiles.some((f) => {
@@ -119,7 +120,11 @@ export class DiagnosticsScanTool implements IDiracTool<DiagnosticsScanArgs, stri
 					break
 				}
 
-				await new Promise((resolve) => setTimeout(resolve, this.diagnosticsDelayMs))
+				// Interruptible sleep: resolve early if abort fires
+				await new Promise<void>((resolve) => {
+					const timer = setTimeout(resolve, this.diagnosticsDelayMs)
+					abortSignal?.addEventListener("abort", () => { clearTimeout(timer); resolve() }, { once: true })
+				})
 			}
 
 			const results = validFiles.map((f) => {

--- a/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
+++ b/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
@@ -1,6 +1,9 @@
 import { formatResponse } from "@core/formatResponse"
 import { DiracAskResponse } from "@shared/WebviewMessage"
 import { DiracIcon } from "@/shared/icons"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
 import { truncateHeadTail } from "../../../../../shared/content-limits"
 import { CardStatus } from "../../../../../shared/ExtensionMessage"
 import { DiracDefaultTool, DiracToolSpec } from "../../../../../shared/tools"
@@ -15,6 +18,18 @@ import { shortenCommandForDisplay } from "./path-display"
 
 const MAX_PATH_LENGTH = 255
 const MAX_COMMAND_OUTPUT_SIZE = 10 * 1024
+
+/** Allowed script interpreters — no fallthrough to arbitrary commands */
+const ALLOWED_INTERPRETERS: Record<string, { binary: string; extension: string }> = {
+	bash: { binary: "bash", extension: "sh" },
+	sh: { binary: "sh", extension: "sh" },
+	python: { binary: "python3", extension: "py" },
+	python3: { binary: "python3", extension: "py" },
+	node: { binary: "node", extension: "js" },
+	javascript: { binary: "node", extension: "js" },
+	ruby: { binary: "ruby", extension: "rb" },
+	perl: { binary: "perl", extension: "pl" },
+}
 
 export const execute_command_spec: DiracToolSpec = {
 	id: DiracDefaultTool.BASH,
@@ -64,7 +79,7 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	public async processCall(args: any, env: IToolEnvironment): Promise<any> {
-		const commands = this.normalizeCommands(args)
+		const commands = await this.normalizeCommands(args)
 		if (commands.length === 0) {
 			throw new Error("Missing required parameter: 'commands' or 'script' must be provided and non-empty.")
 		}
@@ -316,7 +331,7 @@ export class ExecuteCommandTool implements IDiracTool {
 		}
 	}
 
-	private normalizeCommands(args: any): { command: string; displayName: string; language?: string }[] {
+	private async normalizeCommands(args: any): Promise<{ command: string; displayName: string; language?: string }[]> {
 		const commands: { command: string; displayName: string; language?: string }[] = []
 		if (Array.isArray(args.commands)) {
 			args.commands.forEach((cmd: any) => {
@@ -331,8 +346,9 @@ export class ExecuteCommandTool implements IDiracTool {
 		if (args.script) {
 			const language = args.language || "bash"
 			const langDisplay = language.charAt(0).toUpperCase() + language.slice(1)
+			const command = await this.wrapScript(args.script, language)
 			commands.push({
-				command: this.wrapScript(args.script, language),
+				command,
 				displayName: `${langDisplay} script`,
 				language: language,
 			})
@@ -345,25 +361,20 @@ export class ExecuteCommandTool implements IDiracTool {
 		return commandMatch ? commandMatch[2].trim() : cmd
 	}
 
-	private wrapScript(script: string, language: string): string {
-		const delimiter = `EOF_DIRAC_SCRIPT_${Math.random().toString(36).substring(2, 10).toUpperCase()}`
+	private async wrapScript(script: string, language: string): Promise<string> {
 		const normalizedLanguage = language.toLowerCase().trim()
-
-		let interpreter = "bash"
-		if (normalizedLanguage === "python" || normalizedLanguage === "python3") {
-			interpreter = "python3"
-		} else if (normalizedLanguage === "node" || normalizedLanguage === "javascript") {
-			interpreter = "node"
-		} else if (normalizedLanguage === "sh") {
-			interpreter = "sh"
-		} else if (normalizedLanguage === "ruby") {
-			interpreter = "ruby"
-		} else if (normalizedLanguage === "perl") {
-			interpreter = "perl"
-		} else {
-			interpreter = normalizedLanguage
+		const entry = ALLOWED_INTERPRETERS[normalizedLanguage]
+		if (!entry) {
+			throw new Error(
+				`Unsupported script language '${language}'. Allowed: ${Object.keys(ALLOWED_INTERPRETERS).join(", ")}`,
+			)
 		}
 
-		return `${interpreter} << '${delimiter}'\n${script}\n${delimiter}`
+		// Write script to a temp file so its content never enters the shell command string
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-script-"))
+		const scriptPath = path.join(tmpDir, `script.${entry.extension}`)
+		await fs.writeFile(scriptPath, script, "utf-8")
+
+		return `${entry.binary} ${JSON.stringify(scriptPath)}`
 	}
 }

--- a/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
+++ b/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
@@ -249,8 +249,12 @@ Otherwise, respond with "VERIFICATION: FAILED" followed by all the details on wh
 		if (runResult.status !== SubagentExecutionStatus.COMPLETED) {
 			return `Verification Subagent Failed:\n${runResult.error}\n\nPlease verify the task manually or try again.`
 		}
-		if (runResult.result?.includes("VERIFICATION: SUCCESS")) return undefined
-		return `Verification Subagent Report:\n${runResult.result}\n\nThe solution could not be verified successfully. Please address the issues listed above and try again.`
+		// Check for explicit success marker; a failure response may mention "SUCCESS" in passing
+		const verifierOutput = runResult.result ?? ""
+		const hasSuccess = /VERIFICATION:\s*SUCCESS/.test(verifierOutput)
+		const hasFailure = /VERIFICATION:\s*FAILED/.test(verifierOutput)
+		if (hasSuccess && !hasFailure) return undefined
+		return `Verification Subagent Report:\n${verifierOutput}\n\nThe solution could not be verified successfully. Please address the issues listed above and try again.`
 	}
 
 	private async handleCompletionResult(env: IToolEnvironment, result: string): Promise<void> {

--- a/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
+++ b/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
@@ -204,6 +204,7 @@ Otherwise, respond with "VERIFICATION: FAILED" followed by all the details on wh
 			subagentName: "verifier",
 			agentIdentity: identity,
 			taskTitle,
+			signal: env.config.taskState.abortSignal,
 			onUpdate: (update) => {
 				if (update.trajectoryEvent === undefined && update.status === undefined) return
 				const status = recordSubagentProgress(trajectory, update)

--- a/src/core/task/tools/modules/search_files/index.ts
+++ b/src/core/task/tools/modules/search_files/index.ts
@@ -97,7 +97,10 @@ export class SearchFilesTool implements IDiracTool<SearchFilesArgs, string> {
 			)
 			return `Error: Missing required parameter: regex`
 		}
-		const contextLines = typeof context_lines === "string" ? Number.parseInt(context_lines, 10) : context_lines
+		let contextLines = typeof context_lines === "string" ? Number.parseInt(context_lines, 10) : context_lines
+		if (contextLines !== undefined && (!Number.isInteger(contextLines) || contextLines < 0 || contextLines > 10)) {
+			contextLines = Math.max(0, Math.min(10, Math.trunc(contextLines ?? 0)))
+		}
 		const headerPath = paths.length === 1 ? paths[0] : `${paths[0]} (+${paths.length - 1} more)`
 		const isSubagent = env.config.isSubagentExecution
 		const card = !isSubagent

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -259,6 +259,7 @@ function validateToolDefinitions(tools: unknown): string | undefined {
 	}
 
 	const errors: string[] = []
+	const seenNames = new Map<string, number>() // name -> first index
 	for (let index = 0; index < tools.length; index++) {
 		const tool = tools[index]
 		const prefix = `tools[${index}]`
@@ -266,7 +267,17 @@ function validateToolDefinitions(tools: unknown): string | undefined {
 			errors.push(`${prefix}: tool definition must be an object`)
 			continue
 		}
-		if (!tool.name || typeof tool.name !== "string") errors.push(`${prefix}: Missing required field: name`)
+		if (!tool.name || typeof tool.name !== "string") {
+			errors.push(`${prefix}: Missing required field: name`)
+		} else {
+			// Reject duplicate names within the same call — they would race on finalDir
+			const firstIndex = seenNames.get(tool.name)
+			if (firstIndex !== undefined) {
+				errors.push(`${prefix}: duplicate name '${tool.name}' (already used at tools[${firstIndex}])`)
+			} else {
+				seenNames.set(tool.name, index)
+			}
+		}
 		if (!tool.scope || !["global", "workspace", "task"].includes(tool.scope)) errors.push(`${prefix}: scope must be 'global', 'workspace', or 'task'`)
 		if (!tool.description || typeof tool.description !== "string") errors.push(`${prefix}: Missing required field: description`)
 		if (!tool.requirements || typeof tool.requirements !== "string") errors.push(`${prefix}: Missing required field: requirements`)

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -191,17 +191,26 @@ async function prepareTool(
 }
 
 async function resolveToolDirectory(name: string, scope: ToolScope, env: IToolEnvironment): Promise<string> {
+	let dir: string
 	if (scope === "task") {
 		if (!env.config.taskId) {
 			throw new Error("no taskId for task-scoped tool")
 		}
-		return resolveTaskToolDir(name, env.config.taskId)
+		dir = await resolveTaskToolDir(name, env.config.taskId)
+	} else {
+		const home = process.env.DIRAC_DIR || path.join(process.env.HOME || "~", ".dirac")
+		dir = scope === "global"
+			? path.join(home, "tools", name)
+			: path.join(env.config.cwd, ".dirac", "tools", name)
 	}
 
-	const home = process.env.DIRAC_DIR || path.join(process.env.HOME || "~", ".dirac")
-	return scope === "global"
-		? path.join(home, "tools", name)
-		: path.join(env.config.cwd, ".dirac", "tools", name)
+	// Validate the resolved path structure: must be <base>/tools/<name>
+	const resolved = path.resolve(dir)
+	const parentDir = path.dirname(resolved)
+	if (path.basename(parentDir) !== "tools") {
+		throw new Error(`Resolved tool directory '${resolved}' does not follow expected <base>/tools/<name> structure`)
+	}
+	return dir
 }
 
 async function promoteAndActivateTool(

--- a/src/core/task/tools/modules/upsert_tool/subagent-builder.ts
+++ b/src/core/task/tools/modules/upsert_tool/subagent-builder.ts
@@ -142,6 +142,7 @@ async function runBuilderSubagentAttempt(
 		timeout: SUBAGENT_TIMEOUT_SECONDS,
 		allowedTools: BUILDER_ALLOWED_TOOLS,
 		systemSuffix: TOOL_BUILDER_SYSTEM_SUFFIX,
+		signal: env.config.taskState.abortSignal,
 		onUpdate: (update) => {
 			const trajectoryChanged = update.trajectoryEvent !== undefined || update.status !== undefined
 			if (trajectoryChanged) {

--- a/src/core/task/tools/modules/use_subagents/UseSubagentsTool.ts
+++ b/src/core/task/tools/modules/use_subagents/UseSubagentsTool.ts
@@ -526,6 +526,7 @@ export class UseSubagentsTool implements IDiracTool {
 					subagentName,
 					agentIdentity: { id: entry.index, name: entry.name },
 					taskTitle: request.taskTitle,
+					signal: env.config.taskState.abortSignal,
 					onUpdate: (update) => {
 						if (runSettled) return
 						const current = entries[index]

--- a/src/core/task/utils.ts
+++ b/src/core/task/utils.ts
@@ -1,5 +1,5 @@
 import { ApiHandler } from "@core/api"
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 import { showSystemNotification } from "@/integrations/notifications"
 import { DiracApiReqCancelReason, DiracApiReqInfo, DiracMessageType } from "@/shared/ExtensionMessage"
 import { calculateApiCostAnthropic, calculateApiCostOpenAI, calculateApiCostQwen } from "@/utils/cost"
@@ -176,8 +176,8 @@ export async function detectAvailableCliTools(): Promise<string[]> {
 
 	for (const command of CLI_TOOLS) {
 		try {
-			// Use execSync to check if the command exists
-			execSync(`${checkCommand} ${command}`, {
+			// Use execFileSync to check if the command exists (no shell interpolation)
+			execFileSync(checkCommand, [command], {
 				stdio: "ignore", // Don't output to console
 				timeout: 1000, // 1 second timeout to avoid hanging
 			})

--- a/src/hosts/external/AuthHandler.ts
+++ b/src/hosts/external/AuthHandler.ts
@@ -63,73 +63,55 @@ export class AuthHandler {
 	}
 
 	private async createServer(preferredPort?: number): Promise<void> {
-		return new Promise(async (resolve, reject) => {
+		const server = http.createServer(this.handleRequest.bind(this))
+
+		// Build the port list: try preferred port first (if provided), then the normal range
+		const portsToTry = preferredPort ? [preferredPort, ...PORTS.filter((p) => p !== preferredPort)] : PORTS
+
+		// Try to bind on a port from the list
+		for (const port of portsToTry) {
 			try {
-				const server = http.createServer(this.handleRequest.bind(this))
+				await this.tryListenOnPort(server, port)
 
-				// Build the port list: try preferred port first (if provided), then the normal range
-				const portsToTry = preferredPort ? [preferredPort, ...PORTS.filter((p) => p !== preferredPort)] : PORTS
-
-				// Try to bind on a port from the list
-				for (const port of portsToTry) {
-					try {
-						await this.tryListenOnPort(server, port)
-
-						const address = server.address()
-						if (!address) {
-							Logger.error("AuthHandler: Failed to get server address")
-							this.server = null
-							this.port = 0
-							this.serverCreationPromise = null
-							reject(new Error("Failed to get server address"))
-							return
-						}
-
-						// Get the assigned port and set up the server
-						this.port = (address as AddressInfo).port
-						this.server = server
-						Logger.log("AuthHandler: Server started on port", this.port)
-						this.updateTimeout()
-						this.serverCreationPromise = null
-
-						// Attach a general error logger for visibility after successful bind
-						server.on("error", (error) => {
-							Logger.error("AuthHandler: Server error", error)
-						})
-
-						resolve()
-						return
-					} catch (error) {
-						const err = error as NodeJS.ErrnoException
-						if (err?.code === "EADDRINUSE") {
-							Logger.warn(`AuthHandler: Port ${port} in use, trying next...`)
-							continue
-						}
-						Logger.error("AuthHandler: Server error", error)
-						this.server = null
-						this.port = 0
-						this.serverCreationPromise = null
-						reject(error)
-						return
-					}
+				const address = server.address()
+				if (!address) {
+					Logger.error("AuthHandler: Failed to get server address")
+					server.close()
+					this.serverCreationPromise = null
+					throw new Error("Failed to get server address")
 				}
 
-				// If we reach here, all ports in the range are occupied
-				Logger.error(`AuthHandler: No available port in range ${PORT_RANGE_START}-${PORT_RANGE_END}`)
-				this.server = null
-				this.port = 0
+				// Get the assigned port and set up the server
+				this.port = (address as AddressInfo).port
+				this.server = server
+				Logger.log("AuthHandler: Server started on port", this.port)
+				this.updateTimeout()
 				this.serverCreationPromise = null
-				reject(
-					new Error(`No available port found for local auth callback (tried ${PORT_RANGE_START}-${PORT_RANGE_END}).`),
-				)
+
+				// Attach a general error logger for visibility after successful bind
+				server.on("error", (error) => {
+					Logger.error("AuthHandler: Server error", error)
+				})
+
+				return
 			} catch (error) {
-				Logger.error("AuthHandler: Failed to create server", error)
-				this.server = null
-				this.port = 0
+				const err = error as NodeJS.ErrnoException
+				if (err?.code === "EADDRINUSE") {
+					Logger.warn(`AuthHandler: Port ${port} in use, trying next...`)
+					continue
+				}
+				server.close()
+				Logger.error("AuthHandler: Server error", error)
 				this.serverCreationPromise = null
-				reject(error)
+				throw error
 			}
-		})
+		}
+
+		// If we reach here, all ports in the range are occupied
+		server.close()
+		Logger.error(`AuthHandler: No available port in range ${PORT_RANGE_START}-${PORT_RANGE_END}`)
+		this.serverCreationPromise = null
+		throw new Error(`No available port found for local auth callback (tried ${PORT_RANGE_START}-${PORT_RANGE_END}).`)
 	}
 
 	private tryListenOnPort(server: Server, port: number): Promise<void> {
@@ -162,11 +144,26 @@ export class AuthHandler {
 			return
 		}
 
+		// Validate that the request path looks like an auth callback (starts with /callback or /auth)
+		const urlPath = req.url.split("?")[0]
+		if (!urlPath.startsWith("/callback") && !urlPath.startsWith("/auth")) {
+			Logger.warn(`AuthHandler: Rejecting unexpected path: ${urlPath}`)
+			this.sendResponse(res, 404, "text/plain", "Not found")
+			return
+		}
+
 		try {
 			const fullUrl = `http://127.0.0.1:${this.port}${req.url}`
 
 			// Use SharedUriHandler directly - it handles all validation and processing
 			const success = await SharedUriHandler.handleUri(fullUrl)
+
+			if (!success) {
+				this.sendResponse(res, 400, "text/plain", "Bad request")
+				// Stop after a failed auth attempt — the callback was malformed
+				this.stop()
+				return
+			}
 
 			// Try to get redirect URI, but don't fail if not implemented (CLI/JetBrains)
 			let redirectUri: string | undefined
@@ -180,19 +177,14 @@ export class AuthHandler {
 			}
 
 			const html = createAuthSucceededHtml(redirectUri)
-
-			if (success) {
-				this.sendResponse(res, 200, "text/html", html)
-			} else {
-				this.sendResponse(res, 400, "text/plain", "Bad request")
-			}
+			this.sendResponse(res, 200, "text/html", html)
 		} catch (error) {
 			Logger.error("AuthHandler: Error processing request", error)
 			this.sendResponse(res, 400, "text/plain", "Bad request")
-		} finally {
-			// Stop the server after handling any request (success or failure)
-			this.stop()
 		}
+
+		// Stop the server after successfully handling the auth callback
+		this.stop()
 	}
 
 	private sendResponse(res: ServerResponse, status: number, type: string, content: string): void {

--- a/src/services/browser/BrowserConnectionManager.ts
+++ b/src/services/browser/BrowserConnectionManager.ts
@@ -348,7 +348,11 @@ export class BrowserConnectionManager {
 
 	// --- disconnect ---
 
-	async closeBrowser(): Promise<BrowserActionResult> {
+	async closeBrowser(expectedUlid?: string): Promise<BrowserActionResult> {
+		// Ownership guard: reject close if caller's ULID doesn't match the session owner
+		if (this.ulid && expectedUlid && this.ulid !== expectedUlid) {
+			throw new Error(`Cannot close browser session owned by ${this.ulid}; caller is ${expectedUlid}`)
+		}
 		if (this.browser || this.page) {
 			// Emit end telemetry for the session
 			if (this.ulid && this.sessionStartTime > 0) {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -57,9 +57,9 @@ export class BrowserSession {
 		await this.connection.launchRemoteBrowser()
 	}
 
-	async closeBrowser(): Promise<BrowserActionResult> {
+	async closeBrowser(expectedUlid?: string): Promise<BrowserActionResult> {
 		try {
-			return await this.connection.closeBrowser()
+			return await this.connection.closeBrowser(expectedUlid)
 		} finally {
 			// Reset mouse state even if closeBrowser throws so a reused session doesn't report a stale position.
 			this.currentMousePosition = undefined

--- a/src/services/telemetry/providers/DiracTelemetryProvider.ts
+++ b/src/services/telemetry/providers/DiracTelemetryProvider.ts
@@ -9,6 +9,24 @@ import { diracTelemetryConfig } from "@/shared/services/config/dirac-telemetry-c
 import type { ITelemetryProvider, TelemetryProperties, TelemetrySettings } from "./ITelemetryProvider"
 import { jsonHeaders } from "@shared/net"
 
+const TELEMETRY_SECRET_PATTERNS = [/(Bearer\s+)[^\s"']+/gi, /\bsk-[A-Za-z0-9_-]{16,}\b/g]
+const MAX_TELEMETRY_STRING_LENGTH = 2000
+
+function scrubTelemetryProperties(value: unknown): unknown {
+	if (typeof value === "string") {
+		let result = TELEMETRY_SECRET_PATTERNS.reduce((redacted, pattern) => redacted.replace(pattern, "$1[REDACTED]"), value)
+		if (result.length > MAX_TELEMETRY_STRING_LENGTH) {
+			result = result.slice(0, MAX_TELEMETRY_STRING_LENGTH) + "…[truncated]"
+		}
+		return result
+	}
+	if (Array.isArray(value)) return value.map(scrubTelemetryProperties)
+	if (value && typeof value === "object") {
+		return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, scrubTelemetryProperties(v)]))
+	}
+	return value
+}
+
 /**
  * Dirac implementation of the telemetry provider interface
  * Handles Dirac-specific analytics tracking
@@ -87,6 +105,7 @@ export class DiracTelemetryProvider implements ITelemetryProvider {
 		}
 
 		try {
+			const scrubbed = properties ? (scrubTelemetryProperties(properties) as TelemetryProperties) : undefined
 			await fetch(diracTelemetryConfig.host, {
 				method: "POST",
 				headers: {
@@ -96,7 +115,7 @@ export class DiracTelemetryProvider implements ITelemetryProvider {
 				body: JSON.stringify({
 					distinctId: getDistinctId(),
 					event,
-					properties,
+					properties: scrubbed,
 					timestamp: new Date().toISOString(),
 				}),
 			})

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -55,7 +55,7 @@ export const mentionRegex = new RegExp(
 		`|[\\w-]+:"\\/[^"]*?"` + // Workspace-prefixed quoted file paths
 		`|/[^\\s]*?` + // Simple file paths (can't contain)
 		`|"\\/[^"]*?"` + // Quoted file paths which can contain spaces
-		`|(?:\\w+:\\/\\/)[^\\s]+?` + // URLs
+		`|(?:https?:\\/\\/)[^\\s]+?` + // URLs (https/http only)
 		`|[a-f0-9]{7,40}\\b` + // Git commit hashes
 		`|problems\\b` + // Exact word 'problems'
 		`|terminal\\b` + // Exact word 'terminal'

--- a/src/shared/services/config/otel-config.ts
+++ b/src/shared/services/config/otel-config.ts
@@ -179,6 +179,25 @@ function getRuntimeOtelConfig(): OpenTelemetryClientConfig {
 	}
 }
 
+/**
+ * Validates that an OTLP endpoint uses a trusted scheme.
+ * Only https: is allowed for remote endpoints; http: is permitted for localhost (dev).
+ */
+function isTrustedOtlpEndpoint(endpoint: string | undefined): boolean {
+	if (!endpoint) return true // No endpoint set - nothing to validate
+	try {
+		const url = new URL(endpoint)
+		if (url.protocol === "https:") return true
+		if (url.protocol === "http:") {
+			// Allow http only for localhost (local development)
+			return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1"
+		}
+		return false
+	} catch {
+		return false
+	}
+}
+
 export function isOpenTelemetryConfigValid(config: OpenTelemetryClientConfig): config is OpenTelemetryClientValidConfig {
 	// Disable in test environment to enable mocking and stubbing
 	if (isTestEnv) {
@@ -190,7 +209,14 @@ export function isOpenTelemetryConfigValid(config: OpenTelemetryClientConfig): c
 	}
 
 	const hasOneExporterConfigured = !!(config.metricsExporter || config.logsExporter)
-	return hasOneExporterConfigured
+	if (!hasOneExporterConfigured) return false
+
+	// Validate OTLP endpoints use trusted schemes (https: or http://localhost)
+	if (!isTrustedOtlpEndpoint(config.otlpEndpoint)) return false
+	if (!isTrustedOtlpEndpoint(config.otlpMetricsEndpoint)) return false
+	if (!isTrustedOtlpEndpoint(config.otlpLogsEndpoint)) return false
+
+	return true
 }
 
 /**

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -41,7 +41,19 @@ export async function readTextFromClipboard(): Promise<string> {
  * @param url The URL to open
  * @returns Promise that resolves when the operation is complete
  */
+const ALLOWED_OPEN_SCHEMES = ["https:", "http:"]
+
 export async function openExternal(url: string): Promise<void> {
+	let parsed: URL
+	try {
+		parsed = new URL(url)
+	} catch {
+		throw new Error(`Invalid URL: ${url}`)
+	}
+	if (!ALLOWED_OPEN_SCHEMES.includes(parsed.protocol)) {
+		throw new Error(`Blocked URL with disallowed scheme '${parsed.protocol}'`)
+	}
+
 	Logger.log("Opening browser:", url)
 	try {
 		await HostProvider.env.openExternal(StringRequest.create({ value: url }))

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,9 +1,10 @@
-import { exec } from "child_process"
+import { exec, execFile } from "child_process"
 import { promisify } from "util"
 import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 const GIT_OUTPUT_LINE_LIMIT = 500
 
 export interface GitCommit {
@@ -62,16 +63,18 @@ export async function searchCommits(query: string, cwd: string): Promise<GitComm
 		}
 
 		// Search commits by hash or message, limiting to 10 results
-		const { stdout } = await execAsync(
-			`git log -n 10 --format="%H%n%h%n%s%n%an%n%ad" --date=short ` + `--grep="${query}" --regexp-ignore-case`,
+		const { stdout } = await execFileAsync(
+			"git",
+			["log", "-n", "10", "--format=%H%n%h%n%s%n%an%n%ad", "--date=short", "--grep", query, "--regexp-ignore-case"],
 			{ cwd },
 		)
 
 		let output = stdout
 		if (!output.trim() && /^[a-f0-9]+$/i.test(query)) {
 			// If no results from grep search and query looks like a hash, try searching by hash
-			const { stdout: hashStdout } = await execAsync(
-				`git log -n 10 --format="%H%n%h%n%s%n%an%n%ad" --date=short ` + `--author-date-order ${query}`,
+			const { stdout: hashStdout } = await execFileAsync(
+				"git",
+				["log", "-n", "10", "--format=%H%n%h%n%s%n%an%n%ad", "--date=short", "--author-date-order", query],
 				{ cwd },
 			).catch(() => ({ stdout: "" }))
 
@@ -123,14 +126,16 @@ export async function getCommitInfo(hash: string, cwd: string): Promise<string> 
 		}
 
 		// Get commit info, stats, and diff separately
-		const { stdout: info } = await execAsync(`git show --format="%H%n%h%n%s%n%an%n%ad%n%b" --no-patch ${hash}`, {
-			cwd,
-		})
+		const { stdout: info } = await execFileAsync(
+			"git",
+			["show", "--format=%H%n%h%n%s%n%an%n%ad%n%b", "--no-patch", hash],
+			{ cwd },
+		)
 		const [fullHash, shortHash, subject, author, date, body] = info.trim().split("\n")
 
-		const { stdout: stats } = await execAsync(`git show --stat --format="" ${hash}`, { cwd })
+		const { stdout: stats } = await execFileAsync("git", ["show", "--stat", "--format=", hash], { cwd })
 
-		const { stdout: diff } = await execAsync(`git show --format="" ${hash}`, { cwd })
+		const { stdout: diff } = await execFileAsync("git", ["show", "--format=", hash], { cwd })
 
 		const summary = [
 			`Commit: ${shortHash} (${fullHash})`,

--- a/src/utils/github-url-utils.ts
+++ b/src/utils/github-url-utils.ts
@@ -21,6 +21,19 @@ import * as util from "util"
 import { Logger } from "@/shared/services/Logger"
 import { openExternal, writeTextToClipboard } from "@/utils/env"
 
+const execFileAsync = util.promisify(cp.execFile)
+
+const ALLOWED_URL_SCHEMES = ["https:", "http:"]
+
+function isValidHttpUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url)
+		return ALLOWED_URL_SCHEMES.includes(parsed.protocol)
+	} catch {
+		return false
+	}
+}
+
 /**
  * Creates a properly encoded GitHub issue URL.
  *
@@ -79,6 +92,10 @@ export function createGitHubIssueUrl(baseUrl: string, params: Map<string, string
  * @returns A promise that resolves when an attempt to open the URL has completed
  */
 export async function openUrlInBrowser(url: string): Promise<void> {
+	if (!isValidHttpUrl(url)) {
+		throw new Error(`Blocked URL with disallowed scheme: ${url}`)
+	}
+
 	// For debugging
 	Logger.log(`Opening URL: ${url}`)
 
@@ -95,21 +112,18 @@ export async function openUrlInBrowser(url: string): Promise<void> {
 		const platform = os.platform()
 		Logger.log(`Detected platform: ${platform}`)
 
-		// Use promisify for better async error handling
-		const execPromise = util.promisify(cp.exec)
-
-		// Use platform-specific commands
+		// Use platform-specific commands via execFile (no shell, URL is a single argv entry)
 		if (platform === "win32") {
 			// Windows - try multiple approaches
 			try {
-				await execPromise(`start "" "${url}"`)
+				await execFileAsync("cmd.exe", ["/c", "start", "", url])
 				Logger.log("Opened URL with Windows 'start' command")
 				return
 			} catch (winError) {
 				Logger.error(`Error with Windows 'start' command: ${winError}`)
 
 				try {
-					await execPromise(`powershell.exe -Command "Start-Process '${url}'"`)
+					await execFileAsync("powershell.exe", ["-NoProfile", "-Command", "Start-Process", url])
 					Logger.log("Opened URL with PowerShell command")
 					return
 				} catch (psError) {
@@ -119,7 +133,7 @@ export async function openUrlInBrowser(url: string): Promise<void> {
 			}
 		} else if (platform === "darwin") {
 			// macOS
-			await execPromise(`open "${url}"`)
+			await execFileAsync("open", [url])
 			Logger.log("Opened URL with macOS 'open' command")
 			return
 		} else {
@@ -128,7 +142,7 @@ export async function openUrlInBrowser(url: string): Promise<void> {
 
 			for (const cmd of linuxCommands) {
 				try {
-					await execPromise(`${cmd} "${url}"`)
+					await execFileAsync(cmd, [url])
 					Logger.log(`Opened URL with '${cmd}' command`)
 					return
 				} catch (cmdError) {

--- a/src/utils/worktree-include.ts
+++ b/src/utils/worktree-include.ts
@@ -1,11 +1,7 @@
-import { exec } from "child_process"
 import * as fs from "fs/promises"
 import ignore from "ignore"
 import * as path from "path"
-import { promisify } from "util"
 import { getErrorMessage } from "@/shared/errors"
-
-const execAsync = promisify(exec)
 
 /** Batch size for parallel file operations */
 const COPY_BATCH_SIZE = 100
@@ -52,21 +48,14 @@ async function isDirectoryPattern(sourceDir: string, pattern: string): Promise<s
 }
 
 /**
- * Copy a directory using native cp -r (much faster than recursive Node.js copy)
+ * Copy a directory recursively using fs.cp (no process spawn, safe with any path characters)
  */
 async function copyDirectoryNative(source: string, target: string): Promise<void> {
 	// Create parent directory if needed
 	await fs.mkdir(path.dirname(target), { recursive: true })
 
-	// Use native cp for performance (10-20x faster than Node.js)
-	const isWindows = process.platform === "win32"
-	if (isWindows) {
-		// Windows: use robocopy or xcopy
-		await execAsync(`xcopy "${source}" "${target}" /E /I /H /Y /Q`)
-	} else {
-		// Unix: use cp -r
-		await execAsync(`cp -r "${source}" "${target}"`)
-	}
+	// Use fs.cp for safe recursive copy (no shell, no injection risk)
+	await fs.cp(source, target, { recursive: true })
 }
 
 /**


### PR DESCRIPTION
## fix

security and correctness fixes from the 2026-08-23 audit (FB-1, FB-19..FB-43).

## what

21 focused commits. no follow-up review patches — those stay local.

- shell injection: `git` argv, `execFile` URL open, `fs.cp` instead of `xcopy`/`cp`, script temp file instead of heredoc, `execFileSync` for CLI detect
- abort: subagent signal, diagnostics poll interruptible
- auth: path prefix check + non-async promise executor
- pricing/telemetry: https-only OpenAI discovery, OTLP scheme, secret scrub + truncate
- tools: upsert path structure + duplicate names, verifier SUCCESS false-positive, context_lines clamp, walk cap, browser ULID close, remote file from cache
- mention URLs restricted to http/https
- registry shadow tests for builtin collision

## test

cherry-pick onto `origin/master` was clean (no conflicts).
targeted suites on the source branch: ToolRegistry, AuthHandler, EnvironmentManager, ExecuteCommandTool, search_files, refreshOpenAiModels.
