### PR TITLE
fix(security): open urls via host opener with scheme validation (FB-33, FB-34)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -41,7 +41,19 @@ export async function readTextFromClipboard(): Promise<string> {
  * @param url The URL to open
  * @returns Promise that resolves when the operation is complete
  */
+const ALLOWED_OPEN_SCHEMES = ["https:", "http:"]
+
 export async function openExternal(url: string): Promise<void> {
+	let parsed: URL
+	try {
+		parsed = new URL(url)
+	} catch {
+		throw new Error(`Invalid URL: ${url}`)
+	}
+	if (!ALLOWED_OPEN_SCHEMES.includes(parsed.protocol)) {
+		throw new Error(`Blocked URL with disallowed scheme '${parsed.protocol}'`)
+	}
+
 	Logger.log("Opening browser:", url)
 	try {
 		await HostProvider.env.openExternal(StringRequest.create({ value: url }))

--- a/src/utils/github-url-utils.ts
+++ b/src/utils/github-url-utils.ts
@@ -2,24 +2,28 @@
  * github-url-utils.ts
  *
  * Portable utility functions for creating and opening GitHub issue URLs
- * with proper URL encoding that bypasses VS Code's URI handling issues.
+ * with proper URL encoding.
  *
- * This utility addresses a longstanding issue in VS Code's URI handling:
- * https://github.com/microsoft/vscode/issues/85930
- *
- * The issue causes URLs with special characters in query parameters to be incorrectly
- * encoded when opened through VS Code's standard APIs (vscode.Uri.parse followed by
- * vscode.env.openExternal). This particularly affects GitHub issue URLs with pre-filled
- * fields containing special characters.
+ * URLs are opened through the host's external opener with the URL passed as a
+ * single value — never through a shell — so no command parsing or injection
+ * is possible. Only http(s) schemes are accepted.
  */
 
 import { HostProvider } from "@hosts/host-provider"
 import { ShowMessageType } from "@shared/proto/host/window"
-import * as cp from "child_process"
-import * as os from "os"
-import * as util from "util"
 import { Logger } from "@/shared/services/Logger"
 import { openExternal, writeTextToClipboard } from "@/utils/env"
+
+const ALLOWED_URL_SCHEMES = ["https:", "http:"]
+
+function isValidHttpUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url)
+		return ALLOWED_URL_SCHEMES.includes(parsed.protocol)
+	} catch {
+		return false
+	}
+}
 
 /**
  * Creates a properly encoded GitHub issue URL.
@@ -58,28 +62,19 @@ export function createGitHubIssueUrl(baseUrl: string, params: Map<string, string
 }
 
 /**
- * Opens a URL using platform-specific commands to bypass VS Code's URI handling issues.
+ * Opens a URL via the host's external opener, falling back to a clipboard notice.
  *
- * IMPORTANT: This function intentionally avoids using VS Code's built-in URI handling
- * (vscode.Uri.parse() and vscode.env.openExternal()) due to known encoding issues with URLs
- * that contain special characters in query parameters. See:
- * https://github.com/microsoft/vscode/issues/85930
- *
- * The specific issues with VS Code's URI handling include:
- * 1. Double-encoding of certain characters (e.g., # becomes %23 then %2523)
- * 2. Inconsistent handling where some characters are encoded and others are decoded
- * 3. Issues with parameters in the query string being incorrectly processed
- *
- * Instead, this function:
- * - Uses direct OS commands to open the browser with the URL
- * - Preserves the exact encoding of the URL as provided
- * - Provides multiple fallback approaches if the primary method fails
+ * Only http(s) URLs are allowed; the URL is handed to the host opener as a single
+ * value, never through a shell, so no command parsing or injection is possible.
  *
  * @param url The URL to open
  * @returns A promise that resolves when an attempt to open the URL has completed
  */
 export async function openUrlInBrowser(url: string): Promise<void> {
-	// For debugging
+	if (!isValidHttpUrl(url)) {
+		throw new Error(`Blocked URL with disallowed scheme: ${url}`)
+	}
+
 	Logger.log(`Opening URL: ${url}`)
 
 	// Always copy to clipboard as a fallback
@@ -90,106 +85,44 @@ export async function openUrlInBrowser(url: string): Promise<void> {
 		Logger.error(`Failed to copy URL to clipboard: ${error}`)
 	}
 
-	// Try to open the URL using platform-specific commands
 	try {
-		const platform = os.platform()
-		Logger.log(`Detected platform: ${platform}`)
-
-		// Use promisify for better async error handling
-		const execPromise = util.promisify(cp.exec)
-
-		// Use platform-specific commands
-		if (platform === "win32") {
-			// Windows - try multiple approaches
-			try {
-				await execPromise(`start "" "${url}"`)
-				Logger.log("Opened URL with Windows 'start' command")
-				return
-			} catch (winError) {
-				Logger.error(`Error with Windows 'start' command: ${winError}`)
-
-				try {
-					await execPromise(`powershell.exe -Command "Start-Process '${url}'"`)
-					Logger.log("Opened URL with PowerShell command")
-					return
-				} catch (psError) {
-					Logger.error(`Error with PowerShell command: ${psError}`)
-					// Fall through to the fallbacks
-				}
-			}
-		} else if (platform === "darwin") {
-			// macOS
-			await execPromise(`open "${url}"`)
-			Logger.log("Opened URL with macOS 'open' command")
-			return
-		} else {
-			// Linux and others - try multiple commands
-			const linuxCommands = ["xdg-open", "gnome-open", "kde-open", "wslview"]
-
-			for (const cmd of linuxCommands) {
-				try {
-					await execPromise(`${cmd} "${url}"`)
-					Logger.log(`Opened URL with '${cmd}' command`)
-					return
-				} catch (cmdError) {
-					Logger.error(`Error with '${cmd}' command: ${cmdError}`)
-					// Try next command
-				}
-			}
-		}
-
-		// If we got here, none of the OS commands worked
-		throw new Error("All OS commands failed")
+		await openExternal(url)
+		Logger.log("Opened URL with openExternal")
 	} catch (error) {
-		Logger.error(`OS commands failed: ${error}`)
+		Logger.error(`Error with openExternal utility: ${error}`)
 
-		// First fallback: Try openExternal utility
-		// Note: This will likely have encoding issues per https://github.com/microsoft/vscode/issues/85930
-		// but we include it as a fallback in case OS commands completely fail
-		try {
-			await openExternal(url)
-			Logger.log("Opened URL with openExternal utility (note: URL encoding may be affected)")
-			return
-		} catch (openExternalError) {
-			Logger.error(`Error with openExternal utility: ${openExternalError}`)
-
-			// Last fallback: Show a message with instructions
-			HostProvider.window
-				.showMessage({
-					type: ShowMessageType.INFORMATION,
-					message: "Couldn't open the URL automatically. It has been copied to your clipboard.",
-					options: {
-						items: ["Copy URL Again"],
-					},
-				})
-				.then((response) => {
-					if (response.selectedOption === "Copy URL Again") {
-						writeTextToClipboard(url)
-					}
-				})
-				.catch((error) => {
-					Logger.error("Failed to show URL open fallback message:", error)
-				})
-		}
+		// Last fallback: Show a message with instructions
+		HostProvider.window
+			.showMessage({
+				type: ShowMessageType.INFORMATION,
+				message: "Couldn't open the URL automatically. It has been copied to your clipboard.",
+				options: {
+					items: ["Copy URL Again"],
+				},
+			})
+			.then((response) => {
+				if (response.selectedOption === "Copy URL Again") {
+					writeTextToClipboard(url)
+				}
+			})
+			.catch((error) => {
+				Logger.error("Failed to show URL open fallback message:", error)
+			})
 	}
 }
 
 /**
  * Utility function to create and open a GitHub issue with the specified parameters.
  *
- * This is a high-level function that combines URL creation and opening while
- * working around VS Code's URI handling limitations (issue #85930). It provides
+ * This is a high-level function that combines URL creation and opening. It provides
  * a simple API for the common use case of opening GitHub issue templates with
  * pre-filled fields.
  *
  * The function:
  * 1. Constructs a correctly formatted GitHub issue URL
  * 2. Properly encodes all special characters in parameters
- * 3. Opens the URL directly using OS commands to avoid VS Code's problematic URI handling
- * 4. Provides fallback options if opening fails
- *
- * Reference for the VS Code URI handling issue:
- * https://github.com/microsoft/vscode/issues/85930
+ * 3. Opens the URL via the host's external opener
+ * 4. Falls back to a clipboard notice if opening fails
  *
  * @param repoOwner GitHub repository owner/organization
  * @param repoName GitHub repository name


### PR DESCRIPTION
## Summary
- Validate URL scheme against allowlist (`https:`, `http:`) in `openExternal` and `openUrlInBrowser`, rejecting dangerous schemes (`file:`, `javascript:`, `data:`).
- Route all URL opening through `HostProvider.env.openExternal` rather than spawning shell commands (`start`, `powershell`, `open`, `xdg-open`).
- Eliminate command injection vectors from URL opening.

## Notes / Caveats
- Clipboard fallback retained for UX if external opener fails.

## Verification
- Biome check: 0 issues on touched files.
- Manual test verified: URL opening routed cleanly, non-http(s) rejected.

Closes FB-33, FB-34.