### PR TITLE
fix(security): restrict mention URL regex to http/https only (FB-38)

### DIFF
--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -55,7 +55,7 @@ export const mentionRegex = new RegExp(
 		`|[\\w-]+:"\\/[^"]*?"` + // Workspace-prefixed quoted file paths
 		`|/[^\\s]*?` + // Simple file paths (can't contain)
 		`|"\\/[^"]*?"` + // Quoted file paths which can contain spaces
-		`|(?:\\w+:\\/\\/)[^\\s]+?` + // URLs
+		`|(?:https?:\\/\\/)[^\\s]+?` + // URLs (https/http only)
 		`|[a-f0-9]{7,40}\\b` + // Git commit hashes
 		`|problems\\b` + // Exact word 'problems'
 		`|terminal\\b` + // Exact word 'terminal'


### PR DESCRIPTION
## Summary
- Restrict URL mention pattern in `mentionRegex` from `\w+://` to `https?://`.
- Prevents arbitrary/unsafe URL protocols (`file://`, `javascript:`, `data:`) from being parsed as URL mentions.

## Verification
- Unit test suite `src/shared/__tests__/context-mentions.test.ts`: 29 tests passing.
- Biome check: 0 issues on touched file.
- Manual verification: `https://...` correctly identified as URL mention; `file://...` not treated as URL mention.

Closes FB-38.