### PR TITLE
fix(security): validate OTLP endpoint scheme in config (FB-40)

### DIFF
--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.test.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.test.ts
@@ -1,0 +1,271 @@
+import * as assert from "assert"
+import * as sinon from "sinon"
+import { credentials as grpcCredentials } from "@grpc/grpc-js"
+import { isLoopbackHost, isTrustedOtlpEndpoint } from "@/shared/services/config/otel-config"
+import { createOTLPLogExporter, createOTLPMetricReader, resolveGrpcCredentials } from "./OpenTelemetryExporterFactory"
+
+describe("OpenTelemetry Transport Security & Protocol/Credential Matrix", () => {
+	let sandbox: sinon.SinonSandbox
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox()
+	})
+
+	afterEach(() => {
+		sandbox.restore()
+	})
+
+	describe("Loopback and Endpoint Validation", () => {
+		it("correctly identifies loopback hostnames", () => {
+			assert.strictEqual(isLoopbackHost("localhost"), true)
+			assert.strictEqual(isLoopbackHost("127.0.0.1"), true)
+			assert.strictEqual(isLoopbackHost("::1"), true)
+			assert.strictEqual(isLoopbackHost("[::1]"), true)
+
+			assert.strictEqual(isLoopbackHost("collector.remote.com"), false)
+			assert.strictEqual(isLoopbackHost("192.168.1.100"), false)
+			assert.strictEqual(isLoopbackHost("10.0.0.1"), false)
+			assert.strictEqual(isLoopbackHost("localhost]"), false)
+			assert.strictEqual(isLoopbackHost("[localhost"), false)
+		})
+
+		it("validates OTLP endpoint schemes per security policy", () => {
+			// Remote endpoints require HTTPS
+			assert.strictEqual(isTrustedOtlpEndpoint("https://collector.remote.com:4317"), true)
+			assert.strictEqual(isTrustedOtlpEndpoint("http://collector.remote.com:4317"), false)
+			assert.strictEqual(isTrustedOtlpEndpoint("http://192.168.1.50:4317"), false)
+
+			// Loopback endpoints permit HTTP and HTTPS
+			assert.strictEqual(isTrustedOtlpEndpoint("http://localhost:4317"), true)
+			assert.strictEqual(isTrustedOtlpEndpoint("http://127.0.0.1:4317"), true)
+			assert.strictEqual(isTrustedOtlpEndpoint("http://[::1]:4317"), true)
+			assert.strictEqual(isTrustedOtlpEndpoint("https://localhost:4317"), true)
+
+			// Non-HTTP/HTTPS schemes rejected
+			assert.strictEqual(isTrustedOtlpEndpoint("ftp://collector.remote.com:4317"), false)
+			assert.strictEqual(isTrustedOtlpEndpoint("file:///var/log/otel"), false)
+			assert.strictEqual(isTrustedOtlpEndpoint("javascript:void(0)"), false)
+			assert.strictEqual(isTrustedOtlpEndpoint("not-a-valid-url"), false)
+
+			// Undefined endpoint is valid (optional endpoint)
+			assert.strictEqual(isTrustedOtlpEndpoint(undefined), true)
+		})
+	})
+
+	describe("resolveGrpcCredentials", () => {
+		it("enforces SSL credentials for remote HTTPS endpoint even if insecure is true", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const url = new URL("https://collector.remote.com:4317")
+			const creds = resolveGrpcCredentials(url, true)
+
+			assert.strictEqual(creds.constructor.name, "SecureChannelCredentialsImpl")
+			assert.strictEqual(sslSpy.calledOnce, true)
+			assert.strictEqual(insecureSpy.called, false)
+		})
+
+		it("selects SSL credentials for remote HTTPS endpoint when insecure is false", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const url = new URL("https://collector.remote.com:4317")
+			const creds = resolveGrpcCredentials(url, false)
+
+			assert.strictEqual(creds.constructor.name, "SecureChannelCredentialsImpl")
+			assert.strictEqual(sslSpy.calledOnce, true)
+			assert.strictEqual(insecureSpy.called, false)
+		})
+
+		it("enforces SSL credentials for loopback HTTPS endpoint even if insecure is true", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const url = new URL("https://localhost:4317")
+			const creds = resolveGrpcCredentials(url, true)
+
+			assert.strictEqual(creds.constructor.name, "SecureChannelCredentialsImpl")
+			assert.strictEqual(sslSpy.calledOnce, true)
+			assert.strictEqual(insecureSpy.called, false)
+		})
+
+		it("selects insecure credentials for loopback HTTP endpoint", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const url = new URL("http://localhost:4317")
+			const creds = resolveGrpcCredentials(url, true)
+
+			assert.strictEqual(creds.constructor.name, "InsecureChannelCredentialsImpl")
+			assert.strictEqual(insecureSpy.calledOnce, true)
+			assert.strictEqual(sslSpy.called, false)
+		})
+
+		it("selects insecure credentials for IPv4 and IPv6 loopback HTTP endpoints", () => {
+			const ipv4Url = new URL("http://127.0.0.1:4317")
+			const ipv4Creds = resolveGrpcCredentials(ipv4Url, false)
+			assert.strictEqual(ipv4Creds.constructor.name, "InsecureChannelCredentialsImpl")
+
+			const ipv6Url = new URL("http://[::1]:4317")
+			const ipv6Creds = resolveGrpcCredentials(ipv6Url, false)
+			assert.strictEqual(ipv6Creds.constructor.name, "InsecureChannelCredentialsImpl")
+		})
+	})
+
+	describe("Protocol and Credential Matrix - createOTLPLogExporter", () => {
+		const testCases = [
+			{
+				protocol: "grpc",
+				endpoint: "https://collector.remote.com:4317",
+				insecure: false,
+				expectedSuccess: true,
+				expectedCredentialType: "SecureChannelCredentialsImpl",
+				desc: "gRPC remote HTTPS with insecure=false uses SSL",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "https://collector.remote.com:4317",
+				insecure: true,
+				expectedSuccess: true,
+				expectedCredentialType: "SecureChannelCredentialsImpl",
+				desc: "gRPC remote HTTPS with insecure=true enforces SSL",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "http://localhost:4317",
+				insecure: true,
+				expectedSuccess: true,
+				expectedCredentialType: "InsecureChannelCredentialsImpl",
+				desc: "gRPC loopback HTTP with insecure=true uses insecure credentials",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "http://127.0.0.1:4317",
+				insecure: false,
+				expectedSuccess: true,
+				expectedCredentialType: "InsecureChannelCredentialsImpl",
+				desc: "gRPC 127.0.0.1 HTTP uses insecure credentials",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "https://localhost:4317",
+				insecure: false,
+				expectedSuccess: true,
+				expectedCredentialType: "SecureChannelCredentialsImpl",
+				desc: "gRPC localhost HTTPS uses SSL credentials",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "http://collector.remote.com:4317",
+				insecure: true,
+				expectedSuccess: false,
+				desc: "gRPC remote HTTP rejected",
+			},
+			{
+				protocol: "grpc",
+				endpoint: "ftp://collector.remote.com:4317",
+				insecure: false,
+				expectedSuccess: false,
+				desc: "gRPC untrusted scheme rejected",
+			},
+			{
+				protocol: "http/json",
+				endpoint: "https://collector.remote.com:4318",
+				insecure: false,
+				expectedSuccess: true,
+				desc: "http/json remote HTTPS accepted",
+			},
+			{
+				protocol: "http/json",
+				endpoint: "http://localhost:4318",
+				insecure: true,
+				expectedSuccess: true,
+				desc: "http/json loopback HTTP accepted",
+			},
+			{
+				protocol: "http/json",
+				endpoint: "http://collector.remote.com:4318",
+				insecure: false,
+				expectedSuccess: false,
+				desc: "http/json remote HTTP rejected",
+			},
+			{
+				protocol: "http/protobuf",
+				endpoint: "https://collector.remote.com:4318",
+				insecure: false,
+				expectedSuccess: true,
+				desc: "http/protobuf remote HTTPS accepted",
+			},
+			{
+				protocol: "http/protobuf",
+				endpoint: "http://localhost:4318",
+				insecure: true,
+				expectedSuccess: true,
+				desc: "http/protobuf loopback HTTP accepted",
+			},
+			{
+				protocol: "http/protobuf",
+				endpoint: "http://collector.remote.com:4318",
+				insecure: false,
+				expectedSuccess: false,
+				desc: "http/protobuf remote HTTP rejected",
+			},
+		]
+
+		for (const tc of testCases) {
+			it(tc.desc, () => {
+				const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+				const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+				const exporter = createOTLPLogExporter(tc.protocol, tc.endpoint, tc.insecure)
+
+				if (!tc.expectedSuccess) {
+					assert.strictEqual(exporter, null)
+				} else {
+					assert.notStrictEqual(exporter, null)
+					if (tc.expectedCredentialType === "SecureChannelCredentialsImpl") {
+						assert.strictEqual(sslSpy.calledOnce, true)
+						assert.strictEqual(insecureSpy.called, false)
+					} else if (tc.expectedCredentialType === "InsecureChannelCredentialsImpl") {
+						assert.strictEqual(insecureSpy.calledOnce, true)
+						assert.strictEqual(sslSpy.called, false)
+					}
+				}
+			})
+		}
+	})
+
+	describe("Protocol and Credential Matrix - createOTLPMetricReader", () => {
+		it("enforces SSL credentials for remote HTTPS endpoint when insecure=true", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const reader = createOTLPMetricReader("grpc", "https://collector.remote.com:4317", true, 60000, 30000)
+
+			assert.notStrictEqual(reader, null)
+			assert.strictEqual(sslSpy.calledOnce, true)
+			assert.strictEqual(insecureSpy.called, false)
+		})
+
+		it("selects insecure credentials for loopback HTTP endpoint", () => {
+			const sslSpy = sandbox.spy(grpcCredentials, "createSsl")
+			const insecureSpy = sandbox.spy(grpcCredentials, "createInsecure")
+
+			const reader = createOTLPMetricReader("grpc", "http://localhost:4317", true, 60000, 30000)
+
+			assert.notStrictEqual(reader, null)
+			assert.strictEqual(insecureSpy.calledOnce, true)
+			assert.strictEqual(sslSpy.called, false)
+		})
+
+		it("rejects remote HTTP metrics endpoint", () => {
+			const reader = createOTLPMetricReader("grpc", "http://collector.remote.com:4317", true, 60000, 30000)
+			assert.strictEqual(reader, null)
+		})
+
+		it("rejects untrusted scheme for metrics endpoint", () => {
+			const reader = createOTLPMetricReader("http/json", "ftp://collector.remote.com:4317", false, 60000, 30000)
+			assert.strictEqual(reader, null)
+		})
+	})
+})

--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
@@ -1,4 +1,4 @@
-import { credentials as grpcCredentials } from "@grpc/grpc-js"
+import { type ChannelCredentials, credentials as grpcCredentials } from "@grpc/grpc-js"
 import { OTLPLogExporter as OTLPLogExporterGRPC } from "@opentelemetry/exporter-logs-otlp-grpc"
 import { OTLPLogExporter as OTLPLogExporterHTTP } from "@opentelemetry/exporter-logs-otlp-http"
 import { OTLPLogExporter as OTLPLogExporterProto } from "@opentelemetry/exporter-logs-otlp-proto"
@@ -8,6 +8,7 @@ import { OTLPMetricExporter as OTLPMetricExporterProto } from "@opentelemetry/ex
 import { ConsoleLogRecordExporter, LogRecordExporter } from "@opentelemetry/sdk-logs"
 import { ConsoleMetricExporter, MetricReader, PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics"
 import { Logger } from "@/shared/services/Logger"
+import { isLoopbackHost, isTrustedOtlpEndpoint } from "@/shared/services/config/otel-config"
 import { wrapLogsExporterWithDiagnostics, wrapMetricsExporterWithDiagnostics } from "./otel-exporter-diagnostics"
 import { isDev } from "@shared/config/environment"
 
@@ -34,6 +35,31 @@ export function ensurePathSuffix(url: URL, suffix: string): void {
 	}
 }
 
+function sanitizeEndpointForLogging(endpoint: string): string {
+	try {
+		const url = new URL(endpoint)
+		return `${url.protocol}//${url.host}${url.pathname}`
+	} catch {
+		return "[invalid-url]"
+	}
+}
+
+/**
+ * Resolves gRPC credentials according to transport security policy.
+ * Only loopback endpoints (localhost, 127.0.0.1, [::1]) may use insecure credentials.
+ * Remote endpoints and HTTPS endpoints must always use SSL credentials.
+ */
+export function resolveGrpcCredentials(url: URL, insecure: boolean): ChannelCredentials {
+	if (url.protocol === "https:" || !isLoopbackHost(url.hostname)) {
+		if (insecure) {
+			Logger.warn(`[OTEL] Insecure transport requested for remote/HTTPS endpoint '${url.host}', enforcing SSL`)
+		}
+		return grpcCredentials.createSsl()
+	}
+
+	return grpcCredentials.createInsecure()
+}
+
 /**
  * Create an OTLP log exporter based on protocol
  */
@@ -44,14 +70,19 @@ export function createOTLPLogExporter(
 	headers?: Record<string, string>,
 ): LogRecordExporter | null {
 	try {
+		if (!isTrustedOtlpEndpoint(endpoint)) {
+			Logger.warn(`[OTEL] Untrusted OTLP logs endpoint rejected: ${sanitizeEndpointForLogging(endpoint)}`)
+			return null
+		}
+
 		let exporter: any = null
 		const logsUrl = new URL(endpoint)
 		ensurePathSuffix(logsUrl, "/v1/logs")
 
 		switch (protocol) {
 			case "grpc": {
-				const grpcEndpoint = endpoint.replace(/^https?:\/\//, "")
-				const credentials = insecure ? grpcCredentials.createInsecure() : grpcCredentials.createSsl()
+				const grpcEndpoint = logsUrl.host || endpoint.replace(/^https?:\/\//, "")
+				const credentials = resolveGrpcCredentials(logsUrl, insecure)
 
 				exporter = new OTLPLogExporterGRPC({
 					url: grpcEndpoint,
@@ -109,6 +140,11 @@ export function createOTLPMetricReader(
 	headers?: Record<string, string>,
 ): MetricReader | null {
 	try {
+		if (!isTrustedOtlpEndpoint(endpoint)) {
+			Logger.warn(`[OTEL] Untrusted OTLP metrics endpoint rejected: ${sanitizeEndpointForLogging(endpoint)}`)
+			return null
+		}
+
 		let exporter: any = null
 
 		const metricsUrl = new URL(endpoint)
@@ -116,8 +152,8 @@ export function createOTLPMetricReader(
 
 		switch (protocol) {
 			case "grpc": {
-				const grpcEndpoint = endpoint.replace(/^https?:\/\//, "")
-				const credentials = insecure ? grpcCredentials.createInsecure() : grpcCredentials.createSsl()
+				const grpcEndpoint = metricsUrl.host || endpoint.replace(/^https?:\/\//, "")
+				const credentials = resolveGrpcCredentials(metricsUrl, insecure)
 
 				exporter = new OTLPMetricExporterGRPC({
 					url: grpcEndpoint,

--- a/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
+++ b/src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts
@@ -76,27 +76,25 @@ export function createOTLPLogExporter(
 		}
 
 		let exporter: any = null
-		const logsUrl = new URL(endpoint)
-		ensurePathSuffix(logsUrl, "/v1/logs")
+		const url = new URL(endpoint)
 
 		switch (protocol) {
 			case "grpc": {
-				const grpcEndpoint = logsUrl.host || endpoint.replace(/^https?:\/\//, "")
-				const credentials = resolveGrpcCredentials(logsUrl, insecure)
-
 				exporter = new OTLPLogExporterGRPC({
-					url: grpcEndpoint,
-					credentials: credentials,
+					url: url.host,
+					credentials: resolveGrpcCredentials(url, insecure),
 					headers,
 				})
 				break
 			}
 			case "http/json": {
-				exporter = new OTLPLogExporterHTTP({ url: logsUrl.toString(), headers })
+				ensurePathSuffix(url, "/v1/logs")
+				exporter = new OTLPLogExporterHTTP({ url: url.toString(), headers })
 				break
 			}
 			case "http/protobuf": {
-				exporter = new OTLPLogExporterProto({ url: logsUrl.toString(), headers })
+				ensurePathSuffix(url, "/v1/logs")
+				exporter = new OTLPLogExporterProto({ url: url.toString(), headers })
 				break
 			}
 			default:
@@ -106,7 +104,7 @@ export function createOTLPLogExporter(
 
 		// Wrap with diagnostics if debug is enabled
 		if (isDebugEnabled()) {
-			wrapLogsExporterWithDiagnostics(exporter, protocol, logsUrl.toString())
+			wrapLogsExporterWithDiagnostics(exporter, protocol, url.toString())
 		}
 
 		return exporter
@@ -146,28 +144,25 @@ export function createOTLPMetricReader(
 		}
 
 		let exporter: any = null
-
-		const metricsUrl = new URL(endpoint)
-		ensurePathSuffix(metricsUrl, "/v1/metrics")
+		const url = new URL(endpoint)
 
 		switch (protocol) {
 			case "grpc": {
-				const grpcEndpoint = metricsUrl.host || endpoint.replace(/^https?:\/\//, "")
-				const credentials = resolveGrpcCredentials(metricsUrl, insecure)
-
 				exporter = new OTLPMetricExporterGRPC({
-					url: grpcEndpoint,
-					credentials: credentials,
+					url: url.host,
+					credentials: resolveGrpcCredentials(url, insecure),
 					headers,
 				})
 				break
 			}
 			case "http/json": {
-				exporter = new OTLPMetricExporterHTTP({ url: metricsUrl.toString(), headers })
+				ensurePathSuffix(url, "/v1/metrics")
+				exporter = new OTLPMetricExporterHTTP({ url: url.toString(), headers })
 				break
 			}
 			case "http/protobuf": {
-				exporter = new OTLPMetricExporterProto({ url: metricsUrl.toString(), headers })
+				ensurePathSuffix(url, "/v1/metrics")
+				exporter = new OTLPMetricExporterProto({ url: url.toString(), headers })
 				break
 			}
 			default:
@@ -177,7 +172,7 @@ export function createOTLPMetricReader(
 
 		// Wrap with diagnostics if debug is enabled
 		if (isDebugEnabled()) {
-			wrapMetricsExporterWithDiagnostics(exporter, protocol, metricsUrl.toString())
+			wrapMetricsExporterWithDiagnostics(exporter, protocol, url.toString())
 		}
 
 		return new PeriodicExportingMetricReader({

--- a/src/shared/services/config/otel-config.ts
+++ b/src/shared/services/config/otel-config.ts
@@ -179,6 +179,25 @@ function getRuntimeOtelConfig(): OpenTelemetryClientConfig {
 	}
 }
 
+/**
+ * Validates that an OTLP endpoint uses a trusted scheme.
+ * Only https: is allowed for remote endpoints; http: is permitted for localhost (dev).
+ */
+function isTrustedOtlpEndpoint(endpoint: string | undefined): boolean {
+	if (!endpoint) return true // No endpoint set - nothing to validate
+	try {
+		const url = new URL(endpoint)
+		if (url.protocol === "https:") return true
+		if (url.protocol === "http:") {
+			// Allow http only for localhost (local development)
+			return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1"
+		}
+		return false
+	} catch {
+		return false
+	}
+}
+
 export function isOpenTelemetryConfigValid(config: OpenTelemetryClientConfig): config is OpenTelemetryClientValidConfig {
 	// Disable in test environment to enable mocking and stubbing
 	if (isTestEnv) {
@@ -190,7 +209,14 @@ export function isOpenTelemetryConfigValid(config: OpenTelemetryClientConfig): c
 	}
 
 	const hasOneExporterConfigured = !!(config.metricsExporter || config.logsExporter)
-	return hasOneExporterConfigured
+	if (!hasOneExporterConfigured) return false
+
+	// Validate OTLP endpoints use trusted schemes (https: or http://localhost)
+	if (!isTrustedOtlpEndpoint(config.otlpEndpoint)) return false
+	if (!isTrustedOtlpEndpoint(config.otlpMetricsEndpoint)) return false
+	if (!isTrustedOtlpEndpoint(config.otlpLogsEndpoint)) return false
+
+	return true
 }
 
 /**

--- a/src/shared/services/config/otel-config.ts
+++ b/src/shared/services/config/otel-config.ts
@@ -179,18 +179,23 @@ function getRuntimeOtelConfig(): OpenTelemetryClientConfig {
 	}
 }
 
+export function isLoopbackHost(hostname: string): boolean {
+	const normalized = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname
+	return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1"
+}
+
 /**
  * Validates that an OTLP endpoint uses a trusted scheme.
  * Only https: is allowed for remote endpoints; http: is permitted for localhost (dev).
  */
-function isTrustedOtlpEndpoint(endpoint: string | undefined): boolean {
+export function isTrustedOtlpEndpoint(endpoint: string | undefined): boolean {
 	if (!endpoint) return true // No endpoint set - nothing to validate
 	try {
 		const url = new URL(endpoint)
 		if (url.protocol === "https:") return true
 		if (url.protocol === "http:") {
 			// Allow http only for localhost (local development)
-			return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1"
+			return isLoopbackHost(url.hostname)
 		}
 		return false
 	} catch {


### PR DESCRIPTION
## Summary
- **What**:
  - `src/shared/services/config/otel-config.ts`: export `isLoopbackHost` and `isTrustedOtlpEndpoint`; strictly normalize loopback bracketed hosts (`[::1]`).
  - `src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.ts`: add `resolveGrpcCredentials` to enforce SSL credentials on remote and HTTPS endpoints; restrict insecure gRPC credentials to loopback hosts; reject untrusted endpoints at exporter creation; sanitize endpoint in warning logs.
  - `src/services/telemetry/providers/opentelemetry/OpenTelemetryExporterFactory.test.ts`: add protocol/credential matrix unit tests covering gRPC, http/json, and http/protobuf across remote/loopback endpoints and insecure flag combinations.
- **Why**: Address review feedback on gRPC transport security. Remote endpoints and HTTPS endpoints must never select insecure gRPC credentials after scheme stripping, even with `otlpInsecure` enabled.
- **Verification**:
  - `npx tsc --noEmit` clean (0 errors)
  - `npm run lint` clean (0 errors)
  - Unit tests: 24/24 passing in `OpenTelemetryExporterFactory.test.ts` (62/62 across telemetry suite)
- **User test**: no observable change

Closes FB-40.
