### PR TITLE
fix(bug): clamp search_files context_lines to valid range (FB-24)

### DIFF
--- a/src/core/task/tools/modules/search_files/index.ts
+++ b/src/core/task/tools/modules/search_files/index.ts
@@ -101,7 +101,13 @@ export class SearchFilesTool implements IDiracTool<SearchFilesArgs, string> {
 			)
 			return `Error: Missing required parameter: regex`
 		}
-		const contextLines = typeof context_lines === "string" ? Number.parseInt(context_lines, 10) : context_lines
+		// Clamp to a valid 0..10 integer; NaN/Infinity fall back to the default (undefined)
+		const parsedContextLines =
+			typeof context_lines === "string" ? Number.parseInt(context_lines, 10) : (context_lines as number | undefined)
+		const contextLines =
+			parsedContextLines !== undefined && Number.isFinite(parsedContextLines)
+				? Math.max(0, Math.min(10, Math.trunc(parsedContextLines)))
+				: undefined
 		const headerPath = paths.length === 1 ? paths[0] : `${paths[0]} (+${paths.length - 1} more)`
 		const isSubagent = env.config.isSubagentExecution
 		const card = !isSubagent


### PR DESCRIPTION
## Summary
- Clamp `context_lines` argument in `search_files` to the valid `[0, 10]` range.
- Use `Number.isFinite` to ensure `NaN` and `Infinity` (e.g. from non-numeric string parsing) fall back safely to default context lines instead of propagating down to ripgrep.

## Verification
- Unit test suite passed for search_files.
- Manual test verified: negative (-5) clamped to 0, excessive (50) clamped to 10, valid (3) preserved, non-numeric ("abc") safely defaulted without NaN crash.

Closes FB-24.