### PR TITLE
fix(security): prevent shell injection in detectAvailableCliTools (FB-1)

### DIFF
--- a/src/core/task/__tests__/utils.test.ts
+++ b/src/core/task/__tests__/utils.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict"
+import { afterEach, describe, it } from "mocha"
+import proxyquire from "proxyquire"
+import sinon from "sinon"
+import { extractProviderDomainFromUrl } from "../utils"
+
+describe("src/core/task/utils", () => {
+	describe("detectAvailableCliTools", () => {
+		const sandbox = sinon.createSandbox()
+
+		afterEach(() => {
+			sandbox.restore()
+		})
+
+		function loadWithExecFileSync(execFileSync: sinon.SinonStub) {
+			return proxyquire.noCallThru().load("../utils", {
+				child_process: { execFileSync },
+			}).detectAvailableCliTools as () => Promise<string[]>
+		}
+
+		it("checks each tool with an argument array (no shell interpolation)", async () => {
+			const execFileSync = sandbox.stub().returns(Buffer.from(""))
+			const detectAvailableCliTools = loadWithExecFileSync(execFileSync)
+
+			const result = await detectAvailableCliTools()
+
+			assert.ok(execFileSync.called)
+			for (const call of execFileSync.getCalls()) {
+				const checkCommand = call.args[0] as string
+				const args = call.args[1] as string[]
+				assert.ok(checkCommand === "which" || checkCommand === "where")
+				// The tool name must be passed as a separate element of the argument array
+				assert.ok(Array.isArray(args), "Command args must be passed as an array")
+				assert.strictEqual(args.length, 1, "Args array must contain exactly 1 element")
+			}
+			assert.ok(result.includes("git"))
+			assert.ok(result.includes("node"))
+		})
+
+		it("reports only the tools whose availability check succeeds", async () => {
+			const execFileSync = sandbox.stub().callsFake((_checkCommand: string, args?: ReadonlyArray<string>) => {
+				const tool = args?.[0]
+				if (tool === "git" || tool === "gh") {
+					return Buffer.from(`/usr/bin/${tool}`)
+				}
+				throw new Error(`Command failed: ${tool} not found`)
+			})
+			const detectAvailableCliTools = loadWithExecFileSync(execFileSync)
+
+			const result = await detectAvailableCliTools()
+
+			assert.deepEqual(result, ["gh", "git"])
+		})
+
+		it("skips a tool when its availability check throws", async () => {
+			const execFileSync = sandbox.stub().callsFake((_checkCommand: string, args?: ReadonlyArray<string>) => {
+				if (args?.[0] === "curl") {
+					throw new Error("execFileSync curl ENOENT")
+				}
+				return Buffer.from("")
+			})
+			const detectAvailableCliTools = loadWithExecFileSync(execFileSync)
+
+			const result = await detectAvailableCliTools()
+
+			assert.ok(result.includes("git"))
+			assert.ok(!result.includes("curl"))
+		})
+
+		it("runs live detection without throwing", async () => {
+			const { detectAvailableCliTools } = await import("../utils")
+			const result = await detectAvailableCliTools()
+			assert.ok(Array.isArray(result))
+		})
+	})
+
+	describe("extractProviderDomainFromUrl", () => {
+		it("returns undefined for undefined url", () => {
+			assert.strictEqual(extractProviderDomainFromUrl(undefined), undefined)
+		})
+
+		it("returns undefined for empty string", () => {
+			assert.strictEqual(extractProviderDomainFromUrl(""), undefined)
+		})
+
+		it("extracts hostname from valid URL", () => {
+			assert.strictEqual(extractProviderDomainFromUrl("https://api.openai.com/v1"), "api.openai.com")
+			assert.strictEqual(extractProviderDomainFromUrl("http://localhost:11434"), "localhost")
+		})
+
+		it("returns undefined for invalid URL", () => {
+			assert.strictEqual(extractProviderDomainFromUrl("not-a-valid-url"), undefined)
+		})
+	})
+})

--- a/src/core/task/utils.ts
+++ b/src/core/task/utils.ts
@@ -1,5 +1,5 @@
 import { ApiHandler } from "@core/api"
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 import { showSystemNotification } from "@/integrations/notifications"
 import { DiracApiReqCancelReason, DiracApiReqInfo, DiracMessageType } from "@/shared/ExtensionMessage"
 import { calculateApiCostAnthropic, calculateApiCostOpenAI, calculateApiCostQwen } from "@/utils/cost"
@@ -183,13 +183,13 @@ export async function detectAvailableCliTools(): Promise<string[]> {
 
 	for (const command of CLI_TOOLS) {
 		try {
-			// Use execSync to check if the command exists
-			execSync(`${checkCommand} ${command}`, {
+			// Use execFileSync to check if the command exists (no shell interpolation)
+			execFileSync(checkCommand, [command], {
 				stdio: "ignore", // Don't output to console
 				timeout: 1000, // 1 second timeout to avoid hanging
 			})
 			availableCommands.push(command)
-		} catch (error) {
+		} catch {
 			// Command not found, skip it
 		}
 	}


### PR DESCRIPTION
## Summary
- Replaced `execSync` string interpolation with `execFileSync` passing arguments as an array (`[command]`), eliminating shell command injection in `detectAvailableCliTools`.
- Added unit test suite in `src/core/task/__tests__/utils.test.ts` verifying argument array passing, successful detection, and missing tool handling.

## Verification
- `npx cross-env TS_NODE_PROJECT=./tsconfig.unit-test.json TS_NODE_TRANSPILE_ONLY=1 mocha --node-option no-experimental-strip-types src/core/task/__tests__/utils.test.ts` (8/8 passing)
- Biome lint checks passed