### PR TITLE
fix(security): eliminate shell injection in execute_command script path (FB-19)

### DIFF
--- a/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
+++ b/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
@@ -1,6 +1,10 @@
 import { formatResponse } from "@core/formatResponse"
 import { DiracAskResponse } from "@shared/WebviewMessage"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
 import { DiracIcon } from "@/shared/icons"
+import { Logger } from "@/shared/services/Logger"
 import { truncateHeadTail } from "../../../../../shared/content-limits"
 import { CardStatus } from "../../../../../shared/ExtensionMessage"
 import { DiracDefaultTool, DiracToolSpec } from "../../../../../shared/tools"
@@ -19,6 +23,18 @@ const MAX_COMMAND_OUTPUT_SIZE = 10 * 1024
 interface CommandApprovalRequirement {
 	required: boolean
 	utilityEligible: boolean
+}
+
+/** Allowed script interpreters — no fallthrough to arbitrary commands */
+const ALLOWED_INTERPRETERS: Record<string, { binary: string; extension: string }> = {
+	bash: { binary: "bash", extension: "sh" },
+	sh: { binary: "sh", extension: "sh" },
+	python: { binary: "python3", extension: "py" },
+	python3: { binary: "python3", extension: "py" },
+	node: { binary: "node", extension: "js" },
+	javascript: { binary: "node", extension: "js" },
+	ruby: { binary: "ruby", extension: "rb" },
+	perl: { binary: "perl", extension: "pl" },
 }
 
 export const execute_command_spec: DiracToolSpec = {
@@ -69,38 +85,52 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	public async processCall(args: any, env: IToolEnvironment): Promise<any> {
-		const commands = this.normalizeCommands(args)
-		if (commands.length === 0) {
-			throw new Error("Missing required parameter: 'commands' or 'script' must be provided and non-empty.")
-		}
-
-		this.validateCommands(commands)
-
-		const utilityPermissionHandlingEnabled = env.config.permissionDecisionBinding !== undefined
-		const approval = this.getCommandApprovalRequirement(commands, utilityPermissionHandlingEnabled)
-
-		if (approval.required) {
-			const { approved, message } = await this.requestApproval(
-				commands,
-				env,
-				approval.utilityEligible,
-				utilityPermissionHandlingEnabled,
-			)
-			if (!approved) {
-				return message ? formatResponse.toolDeniedWithFeedback(message) : formatResponse.toolDenied()
+		// Temp dirs created for script files; removed after the call so no leaked
+		// scripts accumulate in the OS temp dir. Kept per-call, not on the instance,
+		// so concurrent/reused tool instances can't interfere.
+		const scriptTempDirs: string[] = []
+		try {
+			const commands = await this.normalizeCommands(args, scriptTempDirs)
+			if (commands.length === 0) {
+				throw new Error("Missing required parameter: 'commands' or 'script' must be provided and non-empty.")
 			}
+
+			this.validateCommands(commands)
+
+			const utilityPermissionHandlingEnabled = env.config.permissionDecisionBinding !== undefined
+			const approval = this.getCommandApprovalRequirement(commands, utilityPermissionHandlingEnabled)
+
+			if (approval.required) {
+				const { approved, message } = await this.requestApproval(
+					commands,
+					env,
+					approval.utilityEligible,
+					utilityPermissionHandlingEnabled,
+				)
+				if (!approved) {
+					return message ? formatResponse.toolDeniedWithFeedback(message) : formatResponse.toolDenied()
+				}
+			}
+
+			const { results, usedWorkspaceHint, resolvedToNonPrimary } = await this.executeCommands(commands, env)
+
+			env.telemetry.captureCustomMetadata({
+				commandCount: commands.length,
+				usedWorkspaceHint,
+				resolvedToNonPrimary,
+				isMultiRootEnabled: this.isMultiRootEnabled,
+			})
+
+			return results.join("\n\n")
+		} finally {
+			await Promise.all(
+				scriptTempDirs.map((dir) =>
+					fs.rm(dir, { recursive: true, force: true }).catch((error) => {
+						Logger.warn(`ExecuteCommandTool: failed to remove script temp dir ${dir}: ${error}`)
+					}),
+				),
+			)
 		}
-
-		const { results, usedWorkspaceHint, resolvedToNonPrimary } = await this.executeCommands(commands, env)
-
-		env.telemetry.captureCustomMetadata({
-			commandCount: commands.length,
-			usedWorkspaceHint,
-			resolvedToNonPrimary,
-			isMultiRootEnabled: this.isMultiRootEnabled,
-		})
-
-		return results.join("\n\n")
 	}
 
 	private validateCommands(commands: { command: string; displayName: string; language?: string }[]): void {
@@ -352,7 +382,10 @@ export class ExecuteCommandTool implements IDiracTool {
 		}
 	}
 
-	private normalizeCommands(args: any): { command: string; displayName: string; language?: string }[] {
+	private async normalizeCommands(
+		args: any,
+		scriptTempDirs: string[],
+	): Promise<{ command: string; displayName: string; language?: string }[]> {
 		const commands: { command: string; displayName: string; language?: string }[] = []
 		if (Array.isArray(args.commands)) {
 			args.commands.forEach((cmd: any) => {
@@ -367,8 +400,9 @@ export class ExecuteCommandTool implements IDiracTool {
 		if (args.script) {
 			const language = args.language || "bash"
 			const langDisplay = language.charAt(0).toUpperCase() + language.slice(1)
+			const command = await this.wrapScript(args.script, language, scriptTempDirs)
 			commands.push({
-				command: this.wrapScript(args.script, language),
+				command,
 				displayName: `${langDisplay} script`,
 				language: language,
 			})
@@ -381,25 +415,19 @@ export class ExecuteCommandTool implements IDiracTool {
 		return commandMatch ? commandMatch[2].trim() : cmd
 	}
 
-	private wrapScript(script: string, language: string): string {
-		const delimiter = `EOF_DIRAC_SCRIPT_${Math.random().toString(36).substring(2, 10).toUpperCase()}`
+	private async wrapScript(script: string, language: string, scriptTempDirs: string[]): Promise<string> {
 		const normalizedLanguage = language.toLowerCase().trim()
-
-		let interpreter = "bash"
-		if (normalizedLanguage === "python" || normalizedLanguage === "python3") {
-			interpreter = "python3"
-		} else if (normalizedLanguage === "node" || normalizedLanguage === "javascript") {
-			interpreter = "node"
-		} else if (normalizedLanguage === "sh") {
-			interpreter = "sh"
-		} else if (normalizedLanguage === "ruby") {
-			interpreter = "ruby"
-		} else if (normalizedLanguage === "perl") {
-			interpreter = "perl"
-		} else {
-			interpreter = normalizedLanguage
+		const entry = ALLOWED_INTERPRETERS[normalizedLanguage]
+		if (!entry) {
+			throw new Error(`Unsupported script language '${language}'. Allowed: ${Object.keys(ALLOWED_INTERPRETERS).join(", ")}`)
 		}
 
-		return `${interpreter} << '${delimiter}'\n${script}\n${delimiter}`
+		// Write script to a temp file so its content never enters the shell command string
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-script-"))
+		scriptTempDirs.push(tmpDir)
+		const scriptPath = path.join(tmpDir, `script.${entry.extension}`)
+		await fs.writeFile(scriptPath, script, "utf-8")
+
+		return `${entry.binary} ${JSON.stringify(scriptPath)}`
 	}
 }

--- a/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
+++ b/src/core/task/tools/modules/execute_command/ExecuteCommandTool.ts
@@ -133,7 +133,7 @@ export class ExecuteCommandTool implements IDiracTool {
 		}
 	}
 
-	private validateCommands(commands: { command: string; displayName: string; language?: string }[]): void {
+	private validateCommands(commands: { command: string; displayName: string; language?: string; script?: string }[]): void {
 		for (const cmd of commands) {
 			const parts = cmd.command.split(/\s+/)
 			for (const part of parts) {
@@ -153,7 +153,7 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	private getCommandApprovalRequirement(
-		commands: { command: string; displayName: string; language?: string }[],
+		commands: { command: string; displayName: string; language?: string; script?: string }[],
 		utilityPermissionHandlingEnabled: boolean,
 	): CommandApprovalRequirement {
 		if (!utilityPermissionHandlingEnabled) {
@@ -192,7 +192,7 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	private async requestApproval(
-		commands: { command: string; displayName: string; language?: string }[],
+		commands: { command: string; displayName: string; language?: string; script?: string }[],
 		env: IToolEnvironment,
 		utilityEligible: boolean,
 		utilityPermissionHandlingEnabled: boolean,
@@ -210,13 +210,16 @@ export class ExecuteCommandTool implements IDiracTool {
 					renderType: "markdown",
 					maxHeight: 10000,
 					rawInput: {
-						commands: commands.map(({ command, displayName, language }) => ({ command, displayName, language })),
+						commands: commands.map(({ command, displayName, language, script }) => ({ command, displayName, language, script })),
 					},
 					body: commands
 						.map((command) => {
 							const language = command.language || "bash"
 							const header = command.displayName !== command.command ? `**${command.displayName}**\n` : ""
-							return `${header}\`\`\`${language}\n${shortenCommandForDisplay(command.command, env.config.cwd)}\n\`\`\``
+							// Scripts execute from a temp file, so show the script content to
+							// approve, not just the interpreter + temp path command line.
+							const display = command.script ?? shortenCommandForDisplay(command.command, env.config.cwd)
+							return `${header}\`\`\`${language}\n${display}\n\`\`\``
 						})
 						.join("\n"),
 					collapsed: false,
@@ -252,7 +255,7 @@ export class ExecuteCommandTool implements IDiracTool {
 		return { approved: true }
 	}
 
-	private permissionCardLabel(commands: { command: string; displayName: string; language?: string }[], cwd?: string): string {
+	private permissionCardLabel(commands: { command: string; displayName: string; language?: string; script?: string }[], cwd?: string): string {
 		return commands.length === 1 ? shortenCommandForDisplay(commands[0].displayName, cwd) : `${commands.length} commands`
 	}
 
@@ -272,7 +275,7 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	private async executeCommands(
-		commands: { command: string; displayName: string; language?: string }[],
+		commands: { command: string; displayName: string; language?: string; script?: string }[],
 		env: IToolEnvironment,
 	): Promise<{ results: string[]; usedWorkspaceHint: boolean; resolvedToNonPrimary: boolean }> {
 		const results: string[] = []
@@ -296,7 +299,7 @@ export class ExecuteCommandTool implements IDiracTool {
 	}
 
 	private async executeSingleCommand(
-		cmd: { command: string; displayName: string; language?: string },
+		cmd: { command: string; displayName: string; language?: string; script?: string },
 		index: number,
 		total: number,
 		env: IToolEnvironment,
@@ -308,7 +311,7 @@ export class ExecuteCommandTool implements IDiracTool {
 				header: header.replace("Executing command", "Executing"),
 				icon: DiracIcon.COMMAND,
 				collapsed: true,
-				rawInput: { command: cmd.command, displayName: cmd.displayName, language: cmd.language ?? "bash" },
+				rawInput: { command: cmd.command, displayName: cmd.displayName, language: cmd.language ?? "bash", script: cmd.script },
 			})
 			: null
 
@@ -385,8 +388,8 @@ export class ExecuteCommandTool implements IDiracTool {
 	private async normalizeCommands(
 		args: any,
 		scriptTempDirs: string[],
-	): Promise<{ command: string; displayName: string; language?: string }[]> {
-		const commands: { command: string; displayName: string; language?: string }[] = []
+	): Promise<{ command: string; displayName: string; language?: string; script?: string }[]> {
+		const commands: { command: string; displayName: string; language?: string; script?: string }[] = []
 		if (Array.isArray(args.commands)) {
 			args.commands.forEach((cmd: any) => {
 				if (typeof cmd === "string" && cmd.trim() !== "") {
@@ -405,6 +408,10 @@ export class ExecuteCommandTool implements IDiracTool {
 				command,
 				displayName: `${langDisplay} script`,
 				language: language,
+				// Original content kept for the approval card: the executed command only
+				// references the temp file path, so without this the card would show a
+				// path with no visible script to approve.
+				script: args.script,
 			})
 		}
 		return commands


### PR DESCRIPTION
## Summary
- Fixes FB-19: shell injection in the `execute_command` script path.
- `wrapScript` previously built a heredoc command string with the raw script content interpolated, and fell through to executing an arbitrary interpreter name when the language was unrecognized.
- The script language is now validated against an allowlist (`bash`, `sh`, `python3`, `node`, `ruby`, `perl`); unknown languages throw instead of executing arbitrary binaries.
- Script content is written to a temp file and only the quoted file path is passed to the shell, so script content never enters the command string.
- Temp dirs are tracked per-call (not on the tool instance) and removed in a `finally` after the call, so no script files leak into the OS temp dir and concurrent/reused tool instances cannot interfere with each other's cleanup.
- Rebased on current master, keeping the newer permission-decision-binding approval flow (`getCommandApprovalRequirement` / `permissionRequestKind`) untouched.
- Second commit: because script content no longer enters the command string, the approval card would have shown only `bash "/tmp/dirac-script-…/script.sh"` with nothing to inspect. The original script is now carried on the command entry and rendered in the approval card body (and both cards' rawInput), so the human-in-the-loop checkpoint still shows exactly what will run.

## Notes for maintainers
- The interpreter allowlist is a hardcoded constant (`ALLOWED_INTERPRETERS`) — happy to move it to config if maintainers prefer extensibility over a strict allowlist.
- Cleanup failure only logs a warning; it does not fail the tool call, since the command itself already completed.

#### Test plan
- [x] Targeted tests: `ExecuteCommandTool.timeout.test.ts` — 4 passing
- [x] `tsc --noEmit`: zero new errors vs master (40 pre-existing lines, identical)
- [x] `biome check`: zero new issues vs master (1 error / 10 infos pre-existing on this file)
- [x] Manual CLI scenario T1: success and failure script paths clean up all `dirac-script-*` temp dirs
- [x] Approval-card rendering verified: script calls show the script content in the card body, plain commands unchanged

