### PR TITLE
fix(security): eliminate shell execution in git search and worktree include (FB-32, FB-35)

### DIFF
--- a/src/utils/__tests__/git.test.ts
+++ b/src/utils/__tests__/git.test.ts
@@ -1,0 +1,111 @@
+import { strict as assert } from "node:assert"
+import { execFile } from "node:child_process"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+import { after, before, describe, it } from "mocha"
+import { expectLoggerErrors } from "@/test/loggerGuard"
+import { getCommitInfo, getLatestGitCommitHash, getWorkingState, searchCommits } from "../git"
+
+const execFileAsync = promisify(execFile)
+
+describe("git utilities injection safety and operations (FB-32)", () => {
+	let tmpDir: string
+	let headHash: string
+	let initialHash: string
+
+	before(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-git-test-"))
+
+		// Initialize a real git repo for testing
+		await execFileAsync("git", ["init"], { cwd: tmpDir })
+		await execFileAsync("git", ["config", "user.name", "Dirac Test"], { cwd: tmpDir })
+		await execFileAsync("git", ["config", "user.email", "test@dirac.run"], { cwd: tmpDir })
+
+		// Commit 1: Initial commit
+		await fs.writeFile(path.join(tmpDir, "file1.txt"), "first line\n")
+		await execFileAsync("git", ["add", "file1.txt"], { cwd: tmpDir })
+		await execFileAsync("git", ["commit", "-m", "Initial commit with feature foo"], { cwd: tmpDir })
+		const { stdout: hash1 } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: tmpDir })
+		initialHash = hash1.trim()
+
+		// Commit 2: Second commit
+		await fs.writeFile(path.join(tmpDir, "file2.txt"), "second line\n")
+		await execFileAsync("git", ["add", "file2.txt"], { cwd: tmpDir })
+		await execFileAsync("git", ["commit", "-m", "Fix: sanitize query; injection test $(whoami)"], { cwd: tmpDir })
+		const { stdout: hash2 } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: tmpDir })
+		headHash = hash2.trim()
+	})
+
+	after(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {})
+	})
+
+	describe("searchCommits", () => {
+		it("searches commits by message safely without shell injection", async () => {
+			const queryWithMetachars = "; echo 'injected' && git status # $HOME `whoami`"
+			const results = await searchCommits(queryWithMetachars, tmpDir)
+			// No commits match the literal string, but no shell injection occurs and it returns cleanly
+			assert.deepEqual(results, [])
+		})
+
+		it("finds commits matching message query", async () => {
+			const results = await searchCommits("Initial commit", tmpDir)
+			assert.strictEqual(results.length, 1)
+			assert.strictEqual(results[0].hash, initialHash)
+			assert.strictEqual(results[0].subject, "Initial commit with feature foo")
+			assert.strictEqual(results[0].author, "Dirac Test")
+		})
+
+		it("finds commits by hash query fallback", async () => {
+			const results = await searchCommits(initialHash.slice(0, 7), tmpDir)
+			assert.strictEqual(results.length, 1)
+			assert.strictEqual(results[0].hash, initialHash)
+		})
+
+		it("returns empty array for non-repo directory", async () => {
+			expectLoggerErrors()
+			const emptyDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-non-repo-"))
+			try {
+				const results = await searchCommits("test", emptyDir)
+				assert.deepEqual(results, [])
+			} finally {
+				await fs.rm(emptyDir, { recursive: true, force: true })
+			}
+		})
+	})
+
+	describe("getCommitInfo", () => {
+		it("retrieves commit info, summary, and diff safely", async () => {
+			const info = await getCommitInfo(headHash, tmpDir)
+			assert.ok(info.includes(`Commit: ${headHash.slice(0, 7)}`))
+			assert.ok(info.includes("Author: Dirac Test"))
+			assert.ok(info.includes("Fix: sanitize query; injection test $(whoami)"))
+			assert.ok(info.includes("file2.txt"))
+		})
+
+		it("handles invalid or injected commit hashes safely", async () => {
+			expectLoggerErrors()
+			const maliciousHash = "HEAD; echo 'pwned'"
+			const info = await getCommitInfo(maliciousHash, tmpDir)
+			// Should return failure message, not execute shell command
+			assert.ok(info.includes("Failed to get commit info"))
+		})
+	})
+
+	describe("getWorkingState & getLatestGitCommitHash", () => {
+		it("returns latest commit hash", async () => {
+			const latestHash = await getLatestGitCommitHash(tmpDir)
+			assert.strictEqual(latestHash, headHash)
+		})
+
+		it("returns working state when changes are present", async () => {
+			await fs.writeFile(path.join(tmpDir, "file1.txt"), "modified line\n")
+			const state = await getWorkingState(tmpDir)
+			assert.ok(state.includes("file1.txt"))
+			// Revert modification
+			await execFileAsync("git", ["checkout", "file1.txt"], { cwd: tmpDir })
+		})
+	})
+})

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,9 +1,8 @@
-import { exec, execFile } from "child_process"
+import { execFile } from "child_process"
 import { promisify } from "util"
 import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
-const execAsync = promisify(exec)
 const execFileAsync = promisify(execFile)
 const GIT_OUTPUT_LINE_LIMIT = 500
 
@@ -17,7 +16,7 @@ export interface GitCommit {
 
 async function checkGitRepo(cwd: string): Promise<boolean> {
 	try {
-		await execAsync("git rev-parse --git-dir", { cwd })
+		await execFileAsync("git", ["rev-parse", "--git-dir"], { cwd })
 		return true
 	} catch (_error) {
 		return false
@@ -26,7 +25,7 @@ async function checkGitRepo(cwd: string): Promise<boolean> {
 
 async function checkGitInstalled(): Promise<boolean> {
 	try {
-		await execAsync("git --version")
+		await execFileAsync("git", ["--version"])
 		return true
 	} catch (_error) {
 		return false
@@ -35,7 +34,7 @@ async function checkGitInstalled(): Promise<boolean> {
 
 async function checkGitRepoHasCommits(cwd: string): Promise<boolean> {
 	try {
-		await execAsync("git rev-parse HEAD", { cwd })
+		await execFileAsync("git", ["rev-parse", "HEAD"], { cwd })
 		return true
 	} catch (_error) {
 		return false
@@ -83,6 +82,10 @@ export async function searchCommits(query: string, cwd: string): Promise<GitComm
 			}
 
 			output = hashStdout
+		}
+
+		if (!output.trim()) {
+			return []
 		}
 
 		const commits: GitCommit[] = []
@@ -167,7 +170,7 @@ export async function getWorkingState(cwd: string): Promise<string> {
 		}
 
 		// Get status of working directory
-		const { stdout: status } = await execAsync("git status --short", { cwd })
+		const { stdout: status } = await execFileAsync("git", ["status", "--short"], { cwd })
 		if (!status.trim()) {
 			return "No changes in working directory"
 		}
@@ -176,7 +179,7 @@ export async function getWorkingState(cwd: string): Promise<string> {
 		let diff = ""
 		if (await checkGitRepoHasCommits(cwd)) {
 			// Only run git diff if there are commits
-			const { stdout: diffOutput } = await execAsync("git diff HEAD", { cwd })
+			const { stdout: diffOutput } = await execFileAsync("git", ["diff", "HEAD"], { cwd })
 			diff = diffOutput
 		} else {
 			// No commits yet, use status output only
@@ -206,13 +209,13 @@ export async function getGitDiff(cwd: string, stagedOnly = false): Promise<strin
 		let command = "git --no-pager diff --staged --diff-filter=d"
 		if (await checkGitRepoHasCommits(cwd)) {
 			// Only run git diff if there are commits
-			const { stdout: staged } = await execAsync(command, { cwd })
+			const { stdout: staged } = await execFileAsync("git", ["--no-pager", "diff", "--staged", "--diff-filter=d"], { cwd })
 			diff = staged.trim()
 		}
 
 		if (!stagedOnly && !diff) {
 			command = "git --no-pager diff HEAD --diff-filter=d"
-			const { stdout: unstaged } = await execAsync(command, { cwd })
+			const { stdout: unstaged } = await execFileAsync("git", ["--no-pager", "diff", "HEAD", "--diff-filter=d"], { cwd })
 			diff = unstaged.trim()
 		}
 
@@ -238,7 +241,7 @@ export async function getGitRemoteUrls(cwd: string): Promise<string[]> {
 			return []
 		}
 
-		const { stdout } = await execAsync("git remote -v", { cwd })
+		const { stdout } = await execFileAsync("git", ["remote", "-v"], { cwd })
 		if (!stdout.trim()) {
 			return []
 		}
@@ -274,7 +277,7 @@ export async function getLatestGitCommitHash(cwd: string): Promise<string | null
 			return null
 		}
 
-		const { stdout } = await execAsync("git rev-parse HEAD", { cwd })
+		const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd })
 		return stdout.trim() || null
 	} catch (error) {
 		Logger.error("Error getting latest git commit hash:", error)

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,9 +1,10 @@
-import { exec } from "child_process"
+import { exec, execFile } from "child_process"
 import { promisify } from "util"
 import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"
 
 const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 const GIT_OUTPUT_LINE_LIMIT = 500
 
 export interface GitCommit {
@@ -62,16 +63,18 @@ export async function searchCommits(query: string, cwd: string): Promise<GitComm
 		}
 
 		// Search commits by hash or message, limiting to 10 results
-		const { stdout } = await execAsync(
-			`git log -n 10 --format="%H%n%h%n%s%n%an%n%ad" --date=short ` + `--grep="${query}" --regexp-ignore-case`,
+		const { stdout } = await execFileAsync(
+			"git",
+			["log", "-n", "10", "--format=%H%n%h%n%s%n%an%n%ad", "--date=short", "--grep", query, "--regexp-ignore-case"],
 			{ cwd },
 		)
 
 		let output = stdout
 		if (!output.trim() && /^[a-f0-9]+$/i.test(query)) {
 			// If no results from grep search and query looks like a hash, try searching by hash
-			const { stdout: hashStdout } = await execAsync(
-				`git log -n 10 --format="%H%n%h%n%s%n%an%n%ad" --date=short ` + `--author-date-order ${query}`,
+			const { stdout: hashStdout } = await execFileAsync(
+				"git",
+				["log", "-n", "10", "--format=%H%n%h%n%s%n%an%n%ad", "--date=short", "--author-date-order", query],
 				{ cwd },
 			).catch(() => ({ stdout: "" }))
 
@@ -123,14 +126,14 @@ export async function getCommitInfo(hash: string, cwd: string): Promise<string> 
 		}
 
 		// Get commit info, stats, and diff separately
-		const { stdout: info } = await execAsync(`git show --format="%H%n%h%n%s%n%an%n%ad%n%b" --no-patch ${hash}`, {
+		const { stdout: info } = await execFileAsync("git", ["show", "--format=%H%n%h%n%s%n%an%n%ad%n%b", "--no-patch", hash], {
 			cwd,
 		})
 		const [fullHash, shortHash, subject, author, date, body] = info.trim().split("\n")
 
-		const { stdout: stats } = await execAsync(`git show --stat --format="" ${hash}`, { cwd })
+		const { stdout: stats } = await execFileAsync("git", ["show", "--stat", "--format=", hash], { cwd })
 
-		const { stdout: diff } = await execAsync(`git show --format="" ${hash}`, { cwd })
+		const { stdout: diff } = await execFileAsync("git", ["show", "--format=", hash], { cwd })
 
 		const summary = [
 			`Commit: ${shortHash} (${fullHash})`,

--- a/src/utils/worktree-include.test.ts
+++ b/src/utils/worktree-include.test.ts
@@ -135,5 +135,43 @@ describe("Worktree Include Utilities", () => {
 			// Neither file should be copied since there's no intersection
 			result.copiedCount.should.equal(0)
 		})
+
+		it("should preserve relative symlinks verbatim without pointing back to source directory", async () => {
+			const src = path.join(tmpDir, "symlink-src")
+			const tgt = path.join(tmpDir, "symlink-tgt")
+
+			// Setup source with directory containing relative symlinks
+			await fs.mkdir(path.join(src, "node_modules", "pkg"), { recursive: true })
+			await fs.mkdir(path.join(src, "node_modules", "bin"), { recursive: true })
+			await fs.mkdir(tgt, { recursive: true })
+			await fs.writeFile(path.join(src, ".worktreeinclude"), "node_modules/")
+			await fs.writeFile(path.join(src, ".gitignore"), "node_modules/")
+
+			// Real target file
+			await fs.writeFile(path.join(src, "node_modules", "pkg", "target.js"), "target module code")
+
+			// Intra-directory relative symlink: link.js -> target.js
+			await fs.symlink("target.js", path.join(src, "node_modules", "pkg", "link.js"))
+
+			// Cross-directory relative symlink: bin/run -> ../pkg/target.js
+			await fs.symlink(path.join("..", "pkg", "target.js"), path.join(src, "node_modules", "bin", "run"))
+
+			const result = await copyWorktreeIncludeFiles(src, tgt)
+
+			result.copiedCount.should.be.greaterThan(0)
+			result.errors.should.be.empty()
+
+			// 1. Verify intra-directory symlink is preserved verbatim as relative path
+			const intraLink = await fs.readlink(path.join(tgt, "node_modules", "pkg", "link.js"))
+			intraLink.should.equal("target.js")
+
+			// 2. Verify cross-directory symlink is preserved verbatim as relative path
+			const crossLink = await fs.readlink(path.join(tgt, "node_modules", "bin", "run"))
+			crossLink.should.equal(path.join("..", "pkg", "target.js"))
+
+			// 3. Verify reading through the symlink in the target directory works
+			const linkContent = await fs.readFile(path.join(tgt, "node_modules", "pkg", "link.js"), "utf-8")
+			linkContent.should.equal("target module code")
+		})
 	})
 })

--- a/src/utils/worktree-include.ts
+++ b/src/utils/worktree-include.ts
@@ -48,14 +48,14 @@ async function isDirectoryPattern(sourceDir: string, pattern: string): Promise<s
 }
 
 /**
- * Copy a directory recursively using fs.cp (no process spawn, safe with any path characters)
+ * Copy a directory recursively using fs.cp (no process spawn, safe with any path characters, preserves relative symlinks)
  */
 async function copyDirectoryNative(source: string, target: string): Promise<void> {
 	// Create parent directory if needed
 	await fs.mkdir(path.dirname(target), { recursive: true })
 
-	// Use fs.cp for safe recursive copy (no shell, no injection risk)
-	await fs.cp(source, target, { recursive: true })
+	// Use fs.cp with verbatimSymlinks to preserve relative symlinks without resolving to source absolute paths
+	await fs.cp(source, target, { recursive: true, verbatimSymlinks: true })
 }
 
 /**
@@ -109,8 +109,8 @@ async function copyFilesInBatches(
 				// Create target directory if it doesn't exist
 				await fs.mkdir(path.dirname(targetPath), { recursive: true })
 
-				// Copy the file
-				await fs.copyFile(sourcePath, targetPath)
+				// Copy the file or symlink verbatim
+				await fs.cp(sourcePath, targetPath, { verbatimSymlinks: true })
 				return file
 			}),
 		)

--- a/src/utils/worktree-include.ts
+++ b/src/utils/worktree-include.ts
@@ -1,11 +1,7 @@
-import { exec } from "child_process"
 import * as fs from "fs/promises"
 import ignore from "ignore"
 import * as path from "path"
-import { promisify } from "util"
 import { getErrorMessage } from "@/shared/errors"
-
-const execAsync = promisify(exec)
 
 /** Batch size for parallel file operations */
 const COPY_BATCH_SIZE = 100
@@ -52,21 +48,14 @@ async function isDirectoryPattern(sourceDir: string, pattern: string): Promise<s
 }
 
 /**
- * Copy a directory using native cp -r (much faster than recursive Node.js copy)
+ * Copy a directory recursively using fs.cp (no process spawn, safe with any path characters)
  */
 async function copyDirectoryNative(source: string, target: string): Promise<void> {
 	// Create parent directory if needed
 	await fs.mkdir(path.dirname(target), { recursive: true })
 
-	// Use native cp for performance (10-20x faster than Node.js)
-	const isWindows = process.platform === "win32"
-	if (isWindows) {
-		// Windows: use robocopy or xcopy
-		await execAsync(`xcopy "${source}" "${target}" /E /I /H /Y /Q`)
-	} else {
-		// Unix: use cp -r
-		await execAsync(`cp -r "${source}" "${target}"`)
-	}
+	// Use fs.cp for safe recursive copy (no shell, no injection risk)
+	await fs.cp(source, target, { recursive: true })
 }
 
 /**


### PR DESCRIPTION
## Summary
- **What**:
  - `src/utils/worktree-include.ts`: add `verbatimSymlinks: true` to `copyDirectoryNative` and `copyFilesInBatches` so `fs.cp` preserves relative symlinks verbatim instead of resolving them to absolute paths pointing to the source directory.
  - `src/utils/git.ts`: replace `exec` across all git utility operations (`searchCommits`, `getCommitInfo`, `getWorkingState`, `getGitDiff`, `getGitRemoteUrls`, `getLatestGitCommitHash`) with `execFile` and argv arrays, eliminating shell execution and injection risks.
  - `src/utils/worktree-include.test.ts`: add relative symlink regression tests covering intra-directory and cross-directory relative symlinks.
  - `src/utils/__tests__/git.test.ts`: add unit tests covering commit search, hash fallback, injection payload handling, and commit info formatting.
- **Why**: Address review feedback. Default `fs.cp` mutated relative symlinks to source absolute paths; `verbatimSymlinks: true` keeps relative symlinks self-contained within the copied worktree.
- **Verification**:
  - `npx tsc --noEmit` clean (0 errors)
  - `npm run lint` clean (0 errors)
  - Unit tests: 16/16 passing (`worktree-include.test.ts` 8/8, `git.test.ts` 8/8)
- **User test**: no observable change

Closes FB-32, FB-35.
