### PR TITLE
fix(security): reject non-https baseUrl in refreshOpenAiModels (FB-36)

### DIFF
--- a/src/core/controller/models/refreshOpenAiModels.ts
+++ b/src/core/controller/models/refreshOpenAiModels.ts
@@ -22,9 +22,12 @@ export async function refreshOpenAiModels(_controller: Controller, request: Open
 			return StringArray.create({ values: [] })
 		}
 
-		// Only allow https: to prevent key exfiltration via file://, http://, data:, etc.
+		// Only allow https: (plus http: on loopback for local OpenAI-compatible servers)
+		// to prevent key exfiltration via file://, http://, data:, etc.
 		const parsedUrl = new URL(request.baseUrl)
-		if (parsedUrl.protocol !== "https:") {
+		const isHttps = parsedUrl.protocol === "https:"
+		const isLoopbackHttp = parsedUrl.protocol === "http:" && ["localhost", "127.0.0.1", "::1"].includes(parsedUrl.hostname)
+		if (!isHttps && !isLoopbackHttp) {
 			Logger.warn(`[refreshOpenAiModels] rejected non-https baseUrl: ${parsedUrl.protocol}`)
 			return StringArray.create({ values: [] })
 		}

--- a/src/core/controller/models/refreshOpenAiModels.ts
+++ b/src/core/controller/models/refreshOpenAiModels.ts
@@ -22,6 +22,13 @@ export async function refreshOpenAiModels(_controller: Controller, request: Open
 			return StringArray.create({ values: [] })
 		}
 
+		// Only allow https: to prevent key exfiltration via file://, http://, data:, etc.
+		const parsedUrl = new URL(request.baseUrl)
+		if (parsedUrl.protocol !== "https:") {
+			Logger.warn(`[refreshOpenAiModels] rejected non-https baseUrl: ${parsedUrl.protocol}`)
+			return StringArray.create({ values: [] })
+		}
+
 		const config: AxiosRequestConfig = {}
 		if (request.apiKey) {
 			config["headers"] = { Authorization: `Bearer ${request.apiKey}` }


### PR DESCRIPTION
## Summary
- Fixes FB-36: `refreshOpenAiModels` fetched `baseUrl` for OpenAI-compatible model discovery without validating the scheme, so a crafted baseUrl (`http://`, `file:`, `data:`…) could receive the user's API key in an `Authorization` header — key exfiltration.
- The `baseUrl` must now be `https:`; `http:` is only accepted on loopback hosts (`localhost`, `127.0.0.1`, `::1`) for local OpenAI-compatible servers (e.g. LM Studio, Ollama-compatible proxies).
- Rejections log a warning and return an empty model list.

## Notes for maintainers
- The loopback whitelist is hardcoded; if additional local patterns are needed (e.g. `*.local`), easy to extend.

#### Test plan
- [x] `tsc --noEmit`: zero new errors vs master (13 pre-existing, identical)
- [x] `biome check`: identical to master baseline (2 infos, pre-existing)
