### PR TITLE
fix(bug): openRemoteFile now reads remote config from cache (FB-37)

### DIFF
--- a/src/core/controller/file/__tests__/openFile.test.ts
+++ b/src/core/controller/file/__tests__/openFile.test.ts
@@ -1,0 +1,160 @@
+import { strict as assert } from "node:assert"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { Controller } from "@core/controller"
+import { deleteRemoteConfigFromCache, writeRemoteConfigToCache } from "@core/storage/disk"
+import * as openFileIntegration from "@integrations/misc/open-file"
+import { Empty, StringRequest } from "@shared/proto/dirac/common"
+import type { RemoteConfig } from "@shared/remote-config/schema"
+import { afterEach, beforeEach, describe, it } from "mocha"
+import * as sinon from "sinon"
+import { HostProvider } from "@/hosts/host-provider"
+import { setVscodeHostProviderMock } from "@/test/host-provider-test-utils"
+import { openFile } from "../openFile"
+
+describe("openFile (FB-37)", () => {
+	let sandbox: sinon.SinonSandbox
+	let mockController: Controller
+	let openFileIntegrationStub: sinon.SinonStub
+	let secretKeyMap: Map<string, string | undefined>
+	let testGlobalStorageDir: string
+	const testOrgId = `test-org-${Date.now()}`
+
+	beforeEach(async () => {
+		sandbox = sinon.createSandbox()
+		secretKeyMap = new Map()
+
+		testGlobalStorageDir = await fs.mkdtemp(path.join(os.tmpdir(), "dirac-openfile-storage-"))
+		setVscodeHostProviderMock({ globalStorageFsPath: testGlobalStorageDir })
+
+		mockController = {
+			stateManager: {
+				getSecretKey: (key: string) => secretKeyMap.get(key),
+				setSecretKey: (key: string, value: string | undefined) => secretKeyMap.set(key, value),
+			},
+		} as any
+
+		openFileIntegrationStub = sandbox.stub(openFileIntegration, "openFile").resolves()
+	})
+
+	afterEach(async () => {
+		sandbox.restore()
+		await deleteRemoteConfigFromCache(testOrgId)
+		HostProvider.reset()
+		await fs.rm(testGlobalStorageDir, { recursive: true, force: true }).catch(() => {})
+	})
+
+	describe("Local file opening", () => {
+		it("delegates local file paths to openFileIntegration directly", async () => {
+			const request = StringRequest.create({ value: "/workspace/src/index.ts" })
+			const result = await openFile(mockController, request)
+
+			assert.deepEqual(result, Empty.create())
+			sinon.assert.calledOnceWithExactly(openFileIntegrationStub, "/workspace/src/index.ts")
+		})
+
+		it("returns Empty when request value is empty", async () => {
+			const request = StringRequest.create({ value: "" })
+			const result = await openFile(mockController, request)
+
+			assert.deepEqual(result, Empty.create())
+			sinon.assert.notCalled(openFileIntegrationStub)
+		})
+	})
+
+	describe("Remote file opening", () => {
+		it("opens a remote rule from cached remote config with read-only header", async () => {
+			secretKeyMap.set("dirac:diracAccountId", testOrgId)
+
+			const remoteConfig: RemoteConfig = {
+				version: "1.0",
+				globalRules: [
+					{
+						name: "company-standards.md",
+						contents: "Always follow TypeScript best practices.",
+						alwaysEnabled: true,
+					},
+				],
+			}
+			await writeRemoteConfigToCache(testOrgId, remoteConfig)
+
+			const request = StringRequest.create({ value: "remote://rule/company-standards.md" })
+			const result = await openFile(mockController, request)
+
+			assert.deepEqual(result, Empty.create())
+			sinon.assert.calledOnce(openFileIntegrationStub)
+
+			const openedPath = openFileIntegrationStub.firstCall.args[0]
+			assert.ok(openedPath.includes("dirac-remote-rule-company-standards.md"))
+
+			// Verify temp file content
+			const fileContent = await fs.readFile(openedPath, "utf-8")
+			assert.ok(fileContent.includes("# ⚠️ READ-ONLY: This rule is managed by your organization."))
+			assert.ok(fileContent.includes("Always follow TypeScript best practices."))
+
+			// Clean up temp file
+			await fs.rm(openedPath, { force: true }).catch(() => {})
+		})
+
+		it("opens a remote workflow from cached remote config with read-only header", async () => {
+			secretKeyMap.set("dirac:diracAccountId", testOrgId)
+
+			const remoteConfig: RemoteConfig = {
+				version: "1.0",
+				globalWorkflows: [
+					{
+						name: "deploy-pipeline.md",
+						contents: "Run npm test then deploy.",
+						alwaysEnabled: true,
+					},
+				],
+			}
+			await writeRemoteConfigToCache(testOrgId, remoteConfig)
+
+			const request = StringRequest.create({ value: "remote://workflow/deploy-pipeline.md" })
+			const result = await openFile(mockController, request)
+
+			assert.deepEqual(result, Empty.create())
+			sinon.assert.calledOnce(openFileIntegrationStub)
+
+			const openedPath = openFileIntegrationStub.firstCall.args[0]
+			assert.ok(openedPath.includes("dirac-remote-workflow-deploy-pipeline.md"))
+
+			const fileContent = await fs.readFile(openedPath, "utf-8")
+			assert.ok(fileContent.includes("# ⚠️ READ-ONLY: This workflow is managed by your organization."))
+			assert.ok(fileContent.includes("Run npm test then deploy."))
+
+			await fs.rm(openedPath, { force: true }).catch(() => {})
+		})
+
+		it("throws when not signed in to a Dirac organization", async () => {
+			secretKeyMap.delete("dirac:diracAccountId")
+
+			const request = StringRequest.create({ value: "remote://rule/company-standards.md" })
+			await assert.rejects(
+				() => openFile(mockController, request),
+				/Not signed in to a Dirac organization; cannot open remote rule: company-standards.md/,
+			)
+			sinon.assert.notCalled(openFileIntegrationStub)
+		})
+
+		it("throws when remote item is not found in cache", async () => {
+			secretKeyMap.set("dirac:diracAccountId", testOrgId)
+			await writeRemoteConfigToCache(testOrgId, { version: "1.0", globalRules: [] })
+
+			const request = StringRequest.create({ value: "remote://rule/nonexistent-rule.md" })
+			await assert.rejects(() => openFile(mockController, request), /Remote rule not found: nonexistent-rule.md/)
+			sinon.assert.notCalled(openFileIntegrationStub)
+		})
+
+		it("throws when remote URI has invalid format", async () => {
+			const request = StringRequest.create({ value: "remote://invalid/something.md" })
+			await assert.rejects(
+				() => openFile(mockController, request),
+				/Invalid remote file URI: remote:\/\/invalid\/something.md/,
+			)
+			sinon.assert.notCalled(openFileIntegrationStub)
+		})
+	})
+})

--- a/src/core/controller/file/openFile.ts
+++ b/src/core/controller/file/openFile.ts
@@ -1,5 +1,4 @@
 import { readRemoteConfigFromCache } from "@core/storage/disk"
-import { StateManager } from "@core/storage/StateManager"
 import { openFile as openFileIntegration } from "@integrations/misc/open-file"
 import { Empty, StringRequest } from "@shared/proto/dirac/common"
 import { REMOTE_URI_SCHEME } from "@shared/remote-config/constants"
@@ -17,11 +16,11 @@ import { Controller } from ".."
  *                - remote://workflow/{workflowName}
  * @returns Empty response
  */
-export async function openFile(_controller: Controller, request: StringRequest): Promise<Empty> {
+export async function openFile(controller: Controller, request: StringRequest): Promise<Empty> {
 	if (request.value) {
 		// Check for remote:// prefix for remote rules/workflows
 		if (request.value.startsWith(REMOTE_URI_SCHEME)) {
-			await openRemoteFile(request.value)
+			await openRemoteFile(controller, request.value)
 		} else {
 			await openFileIntegration(request.value)
 		}
@@ -31,9 +30,10 @@ export async function openFile(_controller: Controller, request: StringRequest):
 
 /**
  * Opens a remote rule or workflow file by creating a temp file with its contents
+ * @param controller The controller instance
  * @param uri The remote URI in format: remote://rule/{name} or remote://workflow/{name}
  */
-async function openRemoteFile(uri: string): Promise<void> {
+async function openRemoteFile(controller: Controller, uri: string): Promise<void> {
 	// Parse: remote://rule/{name} or remote://workflow/{name}
 	const match = uri.match(/^remote:\/\/(rule|workflow)\/(.+)$/)
 	if (!match) {
@@ -42,9 +42,8 @@ async function openRemoteFile(uri: string): Promise<void> {
 
 	const [, type, name] = match
 
-	// Look up the item from cached remote config
-	const stateManager = StateManager.get()
-	const organizationId = stateManager.getSecretKey("dirac:diracAccountId")
+	// Look up the item from cached remote config via controller's state manager
+	const organizationId = controller.stateManager.getSecretKey("dirac:diracAccountId")
 	if (!organizationId) {
 		throw new Error(`Not signed in to a Dirac organization; cannot open remote ${type}: ${name}`)
 	}

--- a/src/core/controller/file/openFile.ts
+++ b/src/core/controller/file/openFile.ts
@@ -1,3 +1,5 @@
+import { readRemoteConfigFromCache } from "@core/storage/disk"
+import { StateManager } from "@core/storage/StateManager"
 import { openFile as openFileIntegration } from "@integrations/misc/open-file"
 import { Empty, StringRequest } from "@shared/proto/dirac/common"
 import { REMOTE_URI_SCHEME } from "@shared/remote-config/constants"
@@ -39,13 +41,23 @@ async function openRemoteFile(uri: string): Promise<void> {
 	}
 
 	const [, type, name] = match
-	const item = undefined as any
+
+	// Look up the item from cached remote config
+	const stateManager = StateManager.get()
+	const organizationId = stateManager.getSecretKey("dirac:diracAccountId")
+	if (!organizationId) {
+		throw new Error(`Not signed in to a Dirac organization; cannot open remote ${type}: ${name}`)
+	}
+
+	const config = await readRemoteConfigFromCache(organizationId)
+	const items = type === "rule" ? config?.globalRules : config?.globalWorkflows
+	const item = items?.find((r) => r.name === name)
 
 	if (!item?.contents) {
 		throw new Error(`Remote ${type} not found: ${name}`)
 	}
 
-	// Create temp file with read-only header comment
+	// Create temp file with read-only header comment (only after validation)
 	const typeLabel = type === "rule" ? "rule" : "workflow"
 	const header = `# ⚠️ READ-ONLY: This ${typeLabel} is managed by your organization.\n# Changes made here will not be saved.\n\n`
 	const content = header + item.contents


### PR DESCRIPTION
## Summary
- **What**:
  - `src/core/controller/file/openFile.ts`: pass `controller` to `openRemoteFile` to access `controller.stateManager`; retrieve organization account ID (`dirac:diracAccountId`) from secrets; read cached remote config from `readRemoteConfigFromCache(organizationId)`; lookup rule/workflow from `globalRules`/`globalWorkflows`; validate contents before writing temporary files; prepend read-only header and open in editor; throw explicit errors when not signed in or item is missing.
  - `src/core/controller/file/__tests__/openFile.test.ts`: add comprehensive unit tests (7 test cases) covering local file paths, remote rules, remote workflows, unauthenticated state, missing items, and invalid URI formats.
- **Why**: Address review feedback. Connects `openRemoteFile` directly to controller state manager, validates remote config content before creating temporary files, and provides complete automated test coverage.
- **Verification**:
  - `npx tsc --noEmit` clean (0 errors)
  - `npm run lint` clean (0 errors)
  - Unit tests: 7/7 passing in `openFile.test.ts`
- **User test**: no observable change

Closes FB-37.
