### PR TITLE
fix(security): browser close now verifies session ownership (FB-42)

### DIFF
--- a/src/core/task/tools/adapters/traits/BrowserTraitBuilder.ts
+++ b/src/core/task/tools/adapters/traits/BrowserTraitBuilder.ts
@@ -14,6 +14,6 @@ export function buildBrowserTrait(config: TaskConfig): IBrowserTrait {
 		type: async (text: string) => await session().type(text),
 		scroll: async (direction: "up" | "down") =>
 			direction === "up" ? await session().scrollUp() : await session().scrollDown(),
-		close: async () => await session().closeBrowser(),
+		close: async () => await session().closeBrowser(config.ulid),
 	}
 }

--- a/src/services/browser/BrowserConnectionManager.ts
+++ b/src/services/browser/BrowserConnectionManager.ts
@@ -353,7 +353,11 @@ export class BrowserConnectionManager {
 
 	// --- disconnect ---
 
-	async closeBrowser(): Promise<BrowserActionResult> {
+	async closeBrowser(expectedUlid?: string): Promise<BrowserActionResult> {
+		// Ownership guard: reject close if caller's ULID doesn't match the session owner
+		if (this.ulid && expectedUlid && this.ulid !== expectedUlid) {
+			throw new Error(`Cannot close browser session owned by ${this.ulid}; caller is ${expectedUlid}`)
+		}
 		if (this.browser || this.page) {
 			// Emit end telemetry for the session
 			if (this.ulid && this.sessionStartTime > 0) {

--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -58,9 +58,9 @@ export class BrowserSession {
 		await this.connection.launchRemoteBrowser()
 	}
 
-	async closeBrowser(): Promise<BrowserActionResult> {
+	async closeBrowser(expectedUlid?: string): Promise<BrowserActionResult> {
 		try {
-			return await this.connection.closeBrowser()
+			return await this.connection.closeBrowser(expectedUlid)
 		} finally {
 			// Reset mouse state even if closeBrowser throws so a reused session doesn't report a stale position.
 			this.currentMousePosition = undefined


### PR DESCRIPTION
## Summary
- Fixes FB-42: `closeBrowser` had no ownership check — a subagent or concurrent task could close another task's browser session.
- `BrowserSession.closeBrowser` / `BrowserConnectionManager.closeBrowser` now take an optional `expectedUlid`; the close is rejected if the caller's ULID doesn't match the session owner.
- `BrowserTraitBuilder` passes the task's ULID, so task-scoped callers get ownership enforcement.
- The parameter is optional, keeping raw/legacy call sites (no ULID) working unchanged.

## Notes for maintainers
- A mismatch throws an `Error` naming both ULIDs; happy to downgrade to a warn-and-ignore if maintainers prefer close to be idempotent.

#### Test plan
- [x] `tsc --noEmit`: zero new errors vs master (13 pre-existing, identical)
- [x] `biome check`: identical to master baseline (3 pre-existing errors on these files)
- [x] Ownership guard verified standalone: matching ULID closes; mismatching ULID throws with both identifiers; legacy no-owner/no-caller paths unchanged
- [x] Browser suites run green on this branch: `BrowserSession.test.ts` + `BrowserConnectionManager.test.ts` — 12 passing (earlier 'cannot boot' note was a stale local install, since resolved)


#### Verification status
- [x] `tsc`/`biome` zero-delta vs master
- [x] Ownership guard verified standalone: matching ULID closes; mismatched ULID throws naming both ULIDs; legacy no-owner/no-caller paths unchanged
- [ ] Full browser-session flows need the extension host (launch/type/close via the browser tool in a real task). Recommend an extension-host browser run before merge.

