### PR TITLE
fix(bug): verifier success detection now rejects false positives (FB-23a)

### DIFF
--- a/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
+++ b/src/core/task/tools/modules/respond/CompletionResponseOperation.ts
@@ -260,8 +260,12 @@ Otherwise, respond with "VERIFICATION: FAILED" followed by all the details on wh
 		if (runResult.status !== SubagentExecutionStatus.COMPLETED) {
 			return `Verification Subagent Failed:\n${runResult.error}\n\nPlease verify the task manually or try again.`
 		}
-		if (runResult.result?.includes("VERIFICATION: SUCCESS")) return undefined
-		return `Verification Subagent Report:\n${runResult.result}\n\nThe solution could not be verified successfully. Please address the issues listed above and try again.`
+		// Check for explicit success marker; a failure response may mention "SUCCESS" in passing
+		const verifierOutput = runResult.result ?? ""
+		const hasSuccess = /VERIFICATION:\s*SUCCESS/.test(verifierOutput)
+		const hasFailure = /VERIFICATION:\s*FAILED/.test(verifierOutput)
+		if (hasSuccess && !hasFailure) return undefined
+		return `Verification Subagent Report:\n${verifierOutput}\n\nThe solution could not be verified successfully. Please address the issues listed above and try again.`
 	}
 
 	private async handleCompletionResult(env: IToolEnvironment, result: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixes FB-23a: the completion verifier checked success with a plain substring match — a *failing* verifier response that mentioned `VERIFICATION: SUCCESS` while explaining the expected output was incorrectly treated as passing, silently suppressing failure.
- Success now requires an explicit `VERIFICATION: SUCCESS` marker **and** the absence of any `VERIFICATION: FAILED` marker. If both markers appear, the safe side (failure) wins and the report is surfaced.
- `undefined` verifier output is treated as failure (same as before, made explicit).

#### Test plan
- [x] `tsc --noEmit`: zero new errors vs master (13 pre-existing, identical)
- [x] `biome check`: identical to master baseline (1 error / 8 infos pre-existing on this file)
- [x] Marker semantics verified standalone: clean SUCCESS passes; FAILED-with-SUCCESS-mention fails; both markers present → fails; `undefined` → fails; `VERIFICATION:  SUCCESS` with extra whitespace passes
