### PR TITLE
fix(security): upsert_tool path validation, duplicate-name guard, shadow tests (FB-20, FB-21, FB-30)

### DIFF
--- a/src/core/task/tools/discovery/__tests__/ToolRegistry.test.ts
+++ b/src/core/task/tools/discovery/__tests__/ToolRegistry.test.ts
@@ -388,6 +388,30 @@ describe("ToolRegistry", () => {
 			assert.strictEqual(registry.isEnabled("user_tool"), true)
 			assert.strictEqual(registry.getVersion(), version)
 		})
+
+		it("rejects a user tool that would shadow a built-in by name", () => {
+			const registry = ToolRegistry.getInstance()
+			registry.registerBuiltin(makeTool({ id: "read_file_builtin", name: "read_file", source: "builtin" }))
+
+			assert.strictEqual(
+				registry.replaceUserTool(makeTool({ id: "my_tool", name: "read_file", source: "workspace" }), true),
+				false,
+			)
+			assert.strictEqual(registry.getAllTools().length, 1)
+			assert.strictEqual(registry.getAllTools()[0].source, "builtin")
+		})
+
+		it("rejects a user tool that would shadow a built-in by id", () => {
+			const registry = ToolRegistry.getInstance()
+			registry.registerBuiltin(makeTool({ id: "execute_command", name: "execute_command", source: "builtin" }))
+
+			assert.strictEqual(
+				registry.replaceUserTool(makeTool({ id: "execute_command", name: "my_custom", source: "workspace" }), true),
+				false,
+			)
+			assert.strictEqual(registry.getAllTools().length, 1)
+			assert.strictEqual(registry.getAllTools()[0].source, "builtin")
+		})
 	})
 
 	describe("removeUserTool", () => {

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -256,7 +256,7 @@ async function resolveToolDirectory(name: string, scope: ToolScope, env: IToolEn
 		}
 		dir = await resolveTaskToolDir(name, env.config.taskId)
 	} else {
-		const home = process.env.DIRAC_DIR || path.join(process.env.HOME || "~", ".dirac")
+		const home = process.env.DIRAC_DIR || path.join(os.homedir(), ".dirac")
 		dir = scope === "global"
 			? path.join(home, "tools", name)
 			: path.join(env.config.cwd, ".dirac", "tools", name)
@@ -265,7 +265,7 @@ async function resolveToolDirectory(name: string, scope: ToolScope, env: IToolEn
 	// Validate the resolved path structure: must be <base>/tools/<name>
 	const resolved = path.resolve(dir)
 	const parentDir = path.dirname(resolved)
-	if (path.basename(parentDir) !== "tools") {
+	if (path.basename(parentDir) !== "tools" || path.basename(resolved) !== name) {
 		throw new Error(`Resolved tool directory '${resolved}' does not follow expected <base>/tools/<name> structure`)
 	}
 	return dir

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -1,6 +1,7 @@
 import { CardStatus } from "@shared/ExtensionMessage"
 import { allocateSubagentIdentity, type SubagentIdentity } from "@shared/subagents"
 import * as fs from "fs/promises"
+import * as os from "os"
 import * as path from "path"
 import { getErrorMessage } from "@/shared/errors"
 import { Logger } from "@/shared/services/Logger"

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -378,6 +378,7 @@ function validateToolDefinitions(tools: unknown): string | undefined {
 	}
 
 	const errors: string[] = []
+	const seenNames = new Map<string, number>() // name -> first index
 	for (let index = 0; index < tools.length; index++) {
 		const tool = tools[index]
 		const prefix = `tools[${index}]`
@@ -385,7 +386,17 @@ function validateToolDefinitions(tools: unknown): string | undefined {
 			errors.push(`${prefix}: tool definition must be an object`)
 			continue
 		}
-		if (!tool.name || typeof tool.name !== "string") errors.push(`${prefix}: Missing required field: name`)
+		if (!tool.name || typeof tool.name !== "string") {
+			errors.push(`${prefix}: Missing required field: name`)
+		} else {
+			// Reject duplicate names within the same call — they would race on finalDir
+			const firstIndex = seenNames.get(tool.name)
+			if (firstIndex !== undefined) {
+				errors.push(`${prefix}: duplicate name '${tool.name}' (already used at tools[${firstIndex}])`)
+			} else {
+				seenNames.set(tool.name, index)
+			}
+		}
 		if (!tool.scope || !["global", "workspace", "task"].includes(tool.scope)) errors.push(`${prefix}: scope must be 'global', 'workspace', or 'task'`)
 		if (!tool.description || typeof tool.description !== "string") errors.push(`${prefix}: Missing required field: description`)
 		if (!tool.requirements || typeof tool.requirements !== "string") errors.push(`${prefix}: Missing required field: requirements`)

--- a/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
+++ b/src/core/task/tools/modules/upsert_tool/UpsertTool.ts
@@ -249,17 +249,26 @@ async function prepareTool(
 }
 
 async function resolveToolDirectory(name: string, scope: ToolScope, env: IToolEnvironment): Promise<string> {
+	let dir: string
 	if (scope === "task") {
 		if (!env.config.taskId) {
 			throw new Error("no taskId for task-scoped tool")
 		}
-		return resolveTaskToolDir(name, env.config.taskId)
+		dir = await resolveTaskToolDir(name, env.config.taskId)
+	} else {
+		const home = process.env.DIRAC_DIR || path.join(process.env.HOME || "~", ".dirac")
+		dir = scope === "global"
+			? path.join(home, "tools", name)
+			: path.join(env.config.cwd, ".dirac", "tools", name)
 	}
 
-	const home = process.env.DIRAC_DIR || path.join(process.env.HOME || "~", ".dirac")
-	return scope === "global"
-		? path.join(home, "tools", name)
-		: path.join(env.config.cwd, ".dirac", "tools", name)
+	// Validate the resolved path structure: must be <base>/tools/<name>
+	const resolved = path.resolve(dir)
+	const parentDir = path.dirname(resolved)
+	if (path.basename(parentDir) !== "tools") {
+		throw new Error(`Resolved tool directory '${resolved}' does not follow expected <base>/tools/<name> structure`)
+	}
+	return dir
 }
 
 async function promoteAndActivateTool(


### PR DESCRIPTION
## Summary
Three `upsert_tool` hardening items in one PR (all in the same validation layer):

- **FB-20** — resolved tool directory is validated for the expected `<base>/tools/<name>` structure before anything is written; a crafted tool `name` can no longer redirect writes outside the tools directory. Global scope now also uses `os.homedir()` instead of raw `process.env.HOME` fallback.
- **FB-21** — duplicate tool `name`s within a single upsert call are rejected in validation, with the first-use index reported, instead of racing on the same target directory.
- **FB-30** — registry tests for the upsert path: `replaceUserTool` must reject user tools that would shadow a built-in by name or by id (upstream's existing tests cover `registerUserTool`; these add the `replaceUserTool` entry point used by upsert).

#### Test plan
- [x] `tsc --noEmit`: zero new errors vs master (13 pre-existing, identical)
- [x] `biome check`: identical to master baseline on both files (3 errors / 19 infos pre-existing)
- [x] New FB-30 tests are self-contained mocha/node:assert against `ToolRegistry`'s existing `collidesWithBuiltin` guard
- [x] `ToolRegistry.test.ts` runs on this branch: 52 passing / 1 failing — the failing test (`rejects a lower-priority replacement without mutating the existing tool`) fails identically on clean master (pre-existing upstream failure, likely stale after the `d64ae385` registry refactor). This PR's new shadow tests pass.

