### PR TITLE
fix(bug): register served Nebius models; log on unknown-model fallback

### DIFF
--- a/src/core/api/providers/__tests__/nebius.test.ts
+++ b/src/core/api/providers/__tests__/nebius.test.ts
@@ -1,0 +1,118 @@
+import "should"
+import sinon from "sinon"
+import { nebiusDefaultModelId } from "@/shared/api"
+import { Logger } from "@/shared/services/Logger"
+import { expectLoggerErrors } from "@/test/loggerGuard"
+import { NebiusHandler } from "../nebius"
+
+const createAsyncIterable = (data: any[] = []) => ({
+	[Symbol.asyncIterator]: async function* () {
+		yield* data
+	},
+})
+
+describe("NebiusHandler", () => {
+	afterEach(() => sinon.restore())
+
+	const captureRequest = async (handler: NebiusHandler, messages: any[] = [{ role: "user", content: "hi" }]) => {
+		const create = sinon.stub().resolves(createAsyncIterable())
+		sinon.stub(handler as any, "ensureClient").returns({ chat: { completions: { create } } } as any)
+
+		for await (const _chunk of handler.createMessage("system prompt", messages)) {
+			// Consume stream
+		}
+
+		return create.firstCall.args[0]
+	}
+
+	describe("getModel & Catalog", () => {
+		it("uses openai/gpt-oss-120b as default", () => {
+			nebiusDefaultModelId.should.equal("openai/gpt-oss-120b")
+			const handler = new NebiusHandler({ nebiusApiKey: "test-key" })
+			const model = handler.getModel()
+			model.id.should.equal("openai/gpt-oss-120b")
+		})
+
+		it("returns registered GLM models with correct capabilities", () => {
+			const handler = new NebiusHandler({ nebiusApiKey: "test-key", apiModelId: "zai-org/GLM-5.3-Flash" })
+			const model = handler.getModel()
+			model.id.should.equal("zai-org/GLM-5.3-Flash")
+			model.info.supportsImages!.should.equal(false) // Overridden text-only on Nebius
+			model.info.supportsTools!.should.equal(true)
+		})
+
+		it("returns registered Kimi models with isR1FormatRequired", () => {
+			const handlerK26 = new NebiusHandler({ nebiusApiKey: "test-key", apiModelId: "moonshotai/Kimi-K2.6" })
+			const modelK26 = handlerK26.getModel()
+			modelK26.id.should.equal("moonshotai/Kimi-K2.6")
+			;(modelK26.info as any).isR1FormatRequired.should.equal(true)
+
+			const handlerK3 = new NebiusHandler({ nebiusApiKey: "test-key", apiModelId: "moonshotai/Kimi-K3" })
+			const modelK3 = handlerK3.getModel()
+			modelK3.id.should.equal("moonshotai/Kimi-K3")
+			;(modelK3.info as any).isR1FormatRequired.should.equal(true)
+		})
+
+		it("logs an error and falls back to default when unknown model is requested", () => {
+			expectLoggerErrors()
+			const loggerSpy = sinon.spy(Logger, "error")
+			const handler = new NebiusHandler({ nebiusApiKey: "test-key", apiModelId: "non-existent-model" })
+			const model = handler.getModel()
+
+			model.id.should.equal(nebiusDefaultModelId)
+			sinon.assert.calledOnce(loggerSpy)
+			sinon.assert.calledWithMatch(loggerSpy, sinon.match(/Unknown Nebius model 'non-existent-model'/))
+		})
+	})
+
+	describe("Message formatting & Multi-turn Tool Calls", () => {
+		it("applies addReasoningContent for Kimi models on multi-turn messages with reasoning", async () => {
+			const handler = new NebiusHandler({
+				nebiusApiKey: "test-key",
+				apiModelId: "moonshotai/Kimi-K2.6",
+			})
+
+			const multiTurnMessages = [
+				{ role: "user" as const, content: "Initial prompt" },
+				{
+					role: "assistant" as const,
+					content: [
+						{ type: "thinking" as const, thinking: "Let me check the tools" },
+						{ type: "tool_use" as const, id: "tool-1", name: "list_files", input: {} },
+					],
+				},
+				{
+					role: "user" as const,
+					content: [{ type: "tool_result" as const, tool_use_id: "tool-1", content: "file1.ts" }],
+				},
+			]
+
+			const request = await captureRequest(handler, multiTurnMessages)
+			request.model.should.equal("moonshotai/Kimi-K2.6")
+
+			// Assistant message must contain reasoning_content for Kimi models
+			const assistantMsg = request.messages.find((m: any) => m.role === "assistant")
+			assistantMsg.should.have.property("reasoning_content", "Let me check the tools")
+		})
+
+		it("does not apply R1 reasoning_content for GLM models", async () => {
+			const handler = new NebiusHandler({
+				nebiusApiKey: "test-key",
+				apiModelId: "zai-org/GLM-5.3-Flash",
+			})
+
+			const messages = [
+				{ role: "user" as const, content: "Hello" },
+				{
+					role: "assistant" as const,
+					content: [{ type: "text" as const, text: "Hi there!" }],
+				},
+			]
+
+			const request = await captureRequest(handler, messages)
+			request.model.should.equal("zai-org/GLM-5.3-Flash")
+			const assistantMsg = request.messages.find((m: any) => m.role === "assistant")
+			assistantMsg.should.not.have.property("reasoning_content")
+		})
+	})
+})

--- a/src/core/api/providers/nebius.ts
+++ b/src/core/api/providers/nebius.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai"
 import type { ChatCompletionTool as OpenAITool } from "openai/resources/chat/completions"
 import { DiracStorageMessage } from "@/shared/messages/content"
 import { createOpenAIClient } from "@/shared/net"
+import { Logger } from "@/shared/services/Logger"
 import { ApiHandler, CommonApiHandlerOptions } from "../index"
 import { withRetry } from "../retry"
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -98,6 +99,13 @@ export class NebiusHandler implements ApiHandler {
 
 		if (modelId !== undefined && modelId in nebiusModels) {
 			return { id: modelId, info: nebiusModels[modelId as NebiusModelId] }
+		}
+		if (modelId !== undefined) {
+			// Fail loudly: silently swapping the requested model for the default
+			// misattributes cost/behavior to a model the user never selected.
+			Logger.error(
+				`[NebiusHandler] Unknown Nebius model '${modelId}'; falling back to ${nebiusDefaultModelId}. Available: ${Object.keys(nebiusModels).join(", ")}`,
+			)
 		}
 		return { id: nebiusDefaultModelId, info: nebiusModels[nebiusDefaultModelId] }
 	}

--- a/src/shared/api/models/__tests__/nebius-catalog.test.ts
+++ b/src/shared/api/models/__tests__/nebius-catalog.test.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from "node:assert"
+import { nebiusDefaultModelId, nebiusModels } from "../nebius"
+
+describe("Nebius model catalog (FB-205)", () => {
+	it("registers the Kimi models with isR1FormatRequired for reasoning/tool message formatting", () => {
+		const kimiK26 = nebiusModels["moonshotai/Kimi-K2.6"]
+		const kimiK3 = nebiusModels["moonshotai/Kimi-K3"]
+
+		assert.ok(kimiK26, "moonshotai/Kimi-K2.6 must be registered")
+		assert.ok(kimiK3, "moonshotai/Kimi-K3 must be registered")
+		assert.strictEqual(kimiK26.isR1FormatRequired, true)
+		assert.strictEqual(kimiK3.isR1FormatRequired, true)
+	})
+
+	it("registers all GLM models with tool support", () => {
+		const glm51 = nebiusModels["zai-org/GLM-5.1"]
+		const glm52 = nebiusModels["zai-org/GLM-5.2"]
+		const glm53Flash = nebiusModels["zai-org/GLM-5.3-Flash"]
+
+		assert.ok(glm51)
+		assert.ok(glm52)
+		assert.ok(glm53Flash)
+		assert.strictEqual(glm51.supportsTools, true)
+		assert.strictEqual(glm52.supportsTools, true)
+		assert.strictEqual(glm53Flash.supportsTools, true)
+	})
+
+	it("keeps the default model registered", () => {
+		assert.ok(nebiusModels[nebiusDefaultModelId])
+		assert.strictEqual(nebiusDefaultModelId, "openai/gpt-oss-120b")
+	})
+})

--- a/src/shared/api/models/nebius.ts
+++ b/src/shared/api/models/nebius.ts
@@ -1,5 +1,5 @@
-import type { ModelInfo } from "./types"
 import { MODEL_CAPABILITIES } from "./capabilities"
+import type { OpenAiCompatibleModelInfo } from "./types"
 
 export type NebiusModelId = keyof typeof nebiusModels
 export const nebiusDefaultModelId = "openai/gpt-oss-120b" satisfies NebiusModelId
@@ -48,11 +48,13 @@ export const nebiusModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.95,
 		outputPrice: 4,
+		isR1FormatRequired: true,
 	},
 	"moonshotai/Kimi-K3": {
 		...MODEL_CAPABILITIES["kimi-k3"],
 		supportsPromptCache: false,
 		inputPrice: 3,
 		outputPrice: 15,
+		isR1FormatRequired: true,
 	},
-} as const satisfies Record<string, ModelInfo>
+} as const satisfies Record<string, OpenAiCompatibleModelInfo>

--- a/src/shared/api/models/nebius.ts
+++ b/src/shared/api/models/nebius.ts
@@ -5,6 +5,8 @@ export type NebiusModelId = keyof typeof nebiusModels
 export const nebiusDefaultModelId = "openai/gpt-oss-120b" satisfies NebiusModelId
 
 export const nebiusModels = {
+	// Pricing and context per Nebius Token Factory model catalog
+	// (https://tokenfactory.nebius.com/model-catalog.md)
 	"openai/gpt-oss-120b": {
 		...MODEL_CAPABILITIES["gpt-oss-120b"],
 		maxTokens: 32766, // Quantization: fp4
@@ -20,5 +22,37 @@ export const nebiusModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.05,
 		outputPrice: 0.2,
+	},
+	"zai-org/GLM-5.1": {
+		...MODEL_CAPABILITIES["glm-5.1"],
+		supportsPromptCache: false,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
+	"zai-org/GLM-5.2": {
+		...MODEL_CAPABILITIES["glm-5.2"],
+		supportsPromptCache: false,
+		inputPrice: 1.4,
+		outputPrice: 4.4,
+	},
+	"zai-org/GLM-5.3-Flash": {
+		...MODEL_CAPABILITIES["glm-5.3-flash"],
+		// Nebius currently serves this model text-only.
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.5,
+	},
+	"moonshotai/Kimi-K2.6": {
+		...MODEL_CAPABILITIES["kimi-k2.6"],
+		supportsPromptCache: false,
+		inputPrice: 0.95,
+		outputPrice: 4,
+	},
+	"moonshotai/Kimi-K3": {
+		...MODEL_CAPABILITIES["kimi-k3"],
+		supportsPromptCache: false,
+		inputPrice: 3,
+		outputPrice: 15,
 	},
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Summary
- **What**:
  - `src/shared/api/models/nebius.ts`: register served Nebius models (`zai-org/GLM-5.1`, `zai-org/GLM-5.2`, `zai-org/GLM-5.3-Flash`, `moonshotai/Kimi-K2.6`, `moonshotai/Kimi-K3`) with published pricing and context windows; set `isR1FormatRequired: true` on Kimi models to enable `addReasoningContent` for multi-turn tool calling.
  - `src/core/api/providers/nebius.ts`: log an error naming the unknown model ID and available catalog before falling back to default.
  - `src/shared/api/models/__tests__/nebius-catalog.test.ts`: test catalog registration and capability flags.
  - `src/core/api/providers/__tests__/nebius.test.ts`: test fallback logging, model resolution, and multi-turn message formatting with reasoning content.
- **Why**: Address review feedback. Kimi models require `isR1FormatRequired: true` so multi-turn tool calling preserves assistant `reasoning_content`.
- **Verification**:
  - `npx tsc --noEmit` clean (0 errors)
  - `npm run lint` clean (0 errors)
  - Unit tests: 9/9 passing (`nebius.test.ts` 6/6, `nebius-catalog.test.ts` 3/3)
  - Live verified: `nebiusModels` loads correctly, CLI builds and runs
- **User test**: select `moonshotai/Kimi-K2.6` or `zai-org/GLM-5.3-Flash` in Nebius settings

Closes FB-205.
