### PR TITLE
feat: add gemini-3.8-flash and trust maxTokens

### DIFF
--- a/src/core/api/providers/__tests__/gemini.test.ts
+++ b/src/core/api/providers/__tests__/gemini.test.ts
@@ -17,7 +17,7 @@ describe("GeminiHandler", () => {
 		},
 	})
 
-	it("caps maxOutputTokens to 32768 for Flash models", async () => {
+	it("sets maxOutputTokens to the model's maxTokens for Flash models", async () => {
 		const handler = new GeminiHandler({
 			geminiApiKey: "test-api-key",
 			apiModelId: TEST_MODEL_IDS.GEMINI_FLASH,
@@ -44,8 +44,9 @@ describe("GeminiHandler", () => {
 			// Consume stream to trigger request execution.
 		}
 
+		const { info } = handler.getModel()
 		const requestArgs = generateContentStream.firstCall.args[0] as Record<string, any>
-		requestArgs.config.should.have.property("maxOutputTokens", 32_768)
+		requestArgs.config.should.have.property("maxOutputTokens", info.maxTokens)
 	})
 
 	it("sets maxOutputTokens for non-Flash models", async () => {
@@ -75,8 +76,9 @@ describe("GeminiHandler", () => {
 			// Consume stream to trigger request execution.
 		}
 
+		const { info } = handler.getModel()
 		const requestArgs = generateContentStream.firstCall.args[0] as Record<string, any>
-		requestArgs.config.should.have.property("maxOutputTokens", 32_768)
+		requestArgs.config.should.have.property("maxOutputTokens", info.maxTokens)
 	})
 
 	it("aborts a stalled generation request", async () => {

--- a/src/core/api/providers/gemini.ts
+++ b/src/core/api/providers/gemini.ts
@@ -9,7 +9,7 @@ import {
 } from "@google/genai"
 import { GeminiModelId, geminiDefaultModelId, geminiModels, ModelInfo } from "@shared/api"
 import { isRateLimited } from "@shared/net"
-import { GEMINI_MAX_OUTPUT_TOKENS } from "@utils/model-utils"
+import { GEMINI_DEFAULT_MAX_OUTPUT_TOKENS } from "@utils/model-utils"
 import { buildExternalBasicHeaders } from "@/services/EnvUtils"
 import { telemetryService } from "@/services/telemetry"
 import { DiracStorageMessage } from "@/shared/messages/content"
@@ -54,10 +54,10 @@ function mapReasoningEffortToGeminiThinkingLevel(effort: string): ThinkingLevel 
 
 function getGeminiMaxOutputTokens(modelId: string, modelMaxTokens?: number): number | undefined {
 	if (modelMaxTokens && modelMaxTokens > 0) {
-		return Math.min(modelMaxTokens, GEMINI_MAX_OUTPUT_TOKENS)
+		return modelMaxTokens
 	}
 
-	return GEMINI_MAX_OUTPUT_TOKENS
+	return GEMINI_DEFAULT_MAX_OUTPUT_TOKENS
 }
 
 /**

--- a/src/shared/api/models/capabilities.ts
+++ b/src/shared/api/models/capabilities.ts
@@ -161,7 +161,7 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		supportsImages: true,
 	},
 	"gemini-2.5-flash": {
-		maxTokens: 65536,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		thinkingConfig: {
@@ -177,7 +177,7 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		},
 	},
 	"gemini-2.5-pro": {
-		maxTokens: 65536,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		thinkingConfig: {
@@ -185,12 +185,12 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		},
 	},
 	"gemini-2.5-pro-exp-03-25": {
-		maxTokens: 65536,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 	},
 	"gemini-3-flash-preview": {
-		maxTokens: 65536,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsReasoning: true,
@@ -200,7 +200,27 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		},
 	},
 	"gemini-3.5-flash": {
-		maxTokens: 65536,
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "high",
+			supportsThinkingLevel: true,
+		},
+	},
+	"gemini-3.5-flash-lite": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsReasoning: true,
+		thinkingConfig: {
+			geminiThinkingLevel: "high",
+			supportsThinkingLevel: true,
+		},
+	},
+	"gemini-3.6-flash": {
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsReasoning: true,
@@ -219,18 +239,8 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 			supportsThinkingLevel: true,
 		},
 	},
-	"gemini-3.6-flash": {
-		maxTokens: 65536,
-		contextWindow: 1_048_576,
-		supportsImages: true,
-		supportsReasoning: true,
-		thinkingConfig: {
-			geminiThinkingLevel: "high",
-			supportsThinkingLevel: true,
-		},
-	},
-	"gemini-3.5-flash-lite": {
-		maxTokens: 65536,
+	"gemini-3.8-flash": {
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsReasoning: true,
@@ -240,7 +250,7 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		},
 	},
 	"gemini-3-pro-preview": {
-		maxTokens: 8192,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsReasoning: true,
@@ -250,7 +260,7 @@ export const MODEL_CAPABILITIES: Record<string, ModelCapabilities> = {
 		},
 	},
 	"gemini-3.1-pro-preview": {
-		maxTokens: 8192,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsReasoning: true,

--- a/src/shared/api/models/gemini.ts
+++ b/src/shared/api/models/gemini.ts
@@ -8,7 +8,6 @@ export const geminiDefaultModelId: GeminiModelId = "gemini-3.1-pro-preview"
 export const geminiModels = {
 	"gemini-3.1-pro-preview": {
 		...MODEL_CAPABILITIES["gemini-3.1-pro-preview"],
-		maxTokens: 65536,
 		supportsPromptCache: true,
 		inputPrice: 4.0,
 		outputPrice: 18.0,
@@ -36,7 +35,6 @@ export const geminiModels = {
 	},
 	"gemini-3-pro-preview": {
 		...MODEL_CAPABILITIES["gemini-3-pro-preview"],
-		maxTokens: 65536,
 		supportsPromptCache: true,
 		inputPrice: 4.0,
 		outputPrice: 18.0,
@@ -88,19 +86,17 @@ export const geminiModels = {
 			supportsThinkingLevel: true,
 		},
 	},
-	"gemini-3.7-flash": {
-		...MODEL_CAPABILITIES["gemini-3.7-flash"],
+	"gemini-3.5-flash-lite": {
+		...MODEL_CAPABILITIES["gemini-3.5-flash-lite"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.75,
-		outputPrice: 3.75,
-		cacheReadsPrice: 0.075,
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.03,
 		cacheWritesPrice: 0.0,
 		temperature: 1.0,
-		description:
-			"Google's most capable Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
 		thinkingConfig: {
-			geminiThinkingLevel: "medium" as const,
+			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,
 		},
 	},
@@ -118,15 +114,33 @@ export const geminiModels = {
 			supportsThinkingLevel: true,
 		},
 	},
-	"gemini-3.5-flash-lite": {
-		...MODEL_CAPABILITIES["gemini-3.5-flash-lite"],
+	"gemini-3.7-flash": {
+		...MODEL_CAPABILITIES["gemini-3.7-flash"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.3,
-		outputPrice: 2.5,
-		cacheReadsPrice: 0.03,
+		inputPrice: 0.75,
+		outputPrice: 3.75,
+		cacheReadsPrice: 0.075,
 		cacheWritesPrice: 0.0,
 		temperature: 1.0,
+		description:
+			"Google's most capable Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
+		thinkingConfig: {
+			geminiThinkingLevel: "medium" as const,
+			supportsThinkingLevel: true,
+		},
+	},
+	"gemini-3.8-flash": {
+		...MODEL_CAPABILITIES["gemini-3.8-flash"],
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 0.75,
+		outputPrice: 3.75,
+		cacheReadsPrice: 0.075,
+		cacheWritesPrice: 0.0,
+		temperature: 1.0,
+		description:
+			"Google's Gemini 3.8 Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
 		thinkingConfig: {
 			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,

--- a/src/shared/api/models/vertex.ts
+++ b/src/shared/api/models/vertex.ts
@@ -58,19 +58,17 @@ export const vertexModels = {
 			supportsThinkingLevel: true,
 		},
 	},
-	"gemini-3.7-flash": {
-		...MODEL_CAPABILITIES["gemini-3.7-flash"],
+	"gemini-3.5-flash-lite": {
+		...MODEL_CAPABILITIES["gemini-3.5-flash-lite"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.75,
-		outputPrice: 3.75,
-		cacheReadsPrice: 0.075,
+		inputPrice: 0.3,
+		outputPrice: 2.5,
+		cacheReadsPrice: 0.03,
 		cacheWritesPrice: 0.0,
 		temperature: 1.0,
-		description:
-			"Google's most capable Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
 		thinkingConfig: {
-			geminiThinkingLevel: "medium" as const,
+			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,
 		},
 	},
@@ -88,15 +86,33 @@ export const vertexModels = {
 			supportsThinkingLevel: true,
 		},
 	},
-	"gemini-3.5-flash-lite": {
-		...MODEL_CAPABILITIES["gemini-3.5-flash-lite"],
+	"gemini-3.7-flash": {
+		...MODEL_CAPABILITIES["gemini-3.7-flash"],
 		supportsPromptCache: true,
 		supportsGlobalEndpoint: true,
-		inputPrice: 0.3,
-		outputPrice: 2.5,
-		cacheReadsPrice: 0.03,
+		inputPrice: 0.75,
+		outputPrice: 3.75,
+		cacheReadsPrice: 0.075,
 		cacheWritesPrice: 0.0,
 		temperature: 1.0,
+		description:
+			"Google's most capable Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
+		thinkingConfig: {
+			geminiThinkingLevel: "medium" as const,
+			supportsThinkingLevel: true,
+		},
+	},
+	"gemini-3.8-flash": {
+		...MODEL_CAPABILITIES["gemini-3.8-flash"],
+		supportsPromptCache: true,
+		supportsGlobalEndpoint: true,
+		inputPrice: 0.75,
+		outputPrice: 3.75,
+		cacheReadsPrice: 0.075,
+		cacheWritesPrice: 0.0,
+		temperature: 1.0,
+		description:
+			"Google's Gemini 3.8 Flash model for agentic workflows and multimodal reasoning. Introductory pricing applies through December 31, 2026.",
 		thinkingConfig: {
 			geminiThinkingLevel: "high" as const,
 			supportsThinkingLevel: true,

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -4,7 +4,7 @@ import { AnthropicModelId, anthropicModels, getProviderForModel } from "@/shared
 export { supportsReasoningEffortForModel } from "@shared/utils/reasoning-support"
 
 const CLAUDE_VERSION_MATCH_REGEX = /[-_ ]([\d](?:\.[05])?)[-_ ]?/
-export const GEMINI_MAX_OUTPUT_TOKENS = 32_768
+export const GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 32_768
 
 export function modelDoesntSupportWebp(apiHandlerModel: ApiHandlerModel): boolean {
 	const modelId = apiHandlerModel.id.toLowerCase()


### PR DESCRIPTION
### What
- `src/shared/api/models/capabilities.ts`: add `gemini-3.8-flash`; update `gemini-3-pro-preview` and `gemini-3.1-pro-preview` canonical `maxTokens` to `65_536`; reorder 3.x Flash ascending.
- `src/shared/api/models/gemini.ts`: add `gemini-3.8-flash` with intro pricing note; remove redundant `maxTokens` overrides on pro previews; reorder 3.x Flash.
- `src/shared/api/models/vertex.ts`: add `gemini-3.8-flash` with intro pricing note; reorder 3.x Flash.
- `src/utils/model-utils.ts`: rename `GEMINI_MAX_OUTPUT_TOKENS` to `GEMINI_DEFAULT_MAX_OUTPUT_TOKENS`.
- `src/core/api/providers/gemini.ts`: trust `modelMaxTokens` from registry directly instead of clamping to 32k; fall back to default only when missing.
- `src/core/api/providers/__tests__/gemini.test.ts`: update tests to assert registry `maxTokens` propagation.

### Why
- support newly introduced `gemini-3.8-flash` across direct Gemini and Vertex AI.
- stop clamping modern 64k Gemini models to arbitrary historical 32k ceiling.
- restore `capabilities.ts` as single source of truth for pro preview token limits.

### Notes / Caveats
- Vertex AI rebranded by Google to Gemini Enterprise Agent Platform; provider ID kept as `vertex` for stability and backward compatibility.

### Verification
- `npm run compile`: passed (clean tsc, protos, biome, esbuild).
- `src/core/api/providers/__tests__/gemini.test.ts`: 37 passing.
- `src/core/api/providers/__tests__/vertex.test.ts`: 43 passing (80 passing combined).

### User test
- select `gemini-3.8-flash` under Gemini or Vertex AI in settings; observe model requests succeed with thinking level high and 64k token limit.
