### PR TITLE
fix(subagent): relocate agent configs to ~/.dirac to avoid macOS TCC EPERM (ERR-1)

### DIFF
--- a/src/core/task/tools/subagent/AgentConfigLoader.ts
+++ b/src/core/task/tools/subagent/AgentConfigLoader.ts
@@ -98,7 +98,19 @@ export function parseAgentConfigFromYaml(content: string): AgentBaseConfig {
 	}) as AgentBaseConfig
 }
 
+/**
+ * Resolves the agents configuration directory path.
+ * Defaults to ~/.dirac/Agents to avoid macOS ~/Documents TCC sandbox restrictions.
+ */
 export function getAgentsConfigPath(homeDir = os.homedir()): string {
+	const baseDir = process.env.DIRAC_DIR || path.join(homeDir, ".dirac")
+	return path.join(baseDir, AGENTS_CONFIG_DIRECTORY_NAME)
+}
+
+/**
+ * Returns the legacy ~/Documents/Dirac/Agents path used for backward-compatible migration.
+ */
+export function getLegacyAgentsConfigPath(homeDir = os.homedir()): string {
 	return path.join(homeDir, "Documents", "Dirac", AGENTS_CONFIG_DIRECTORY_NAME)
 }
 
@@ -110,8 +122,43 @@ function isYamlFile(filePath: string): boolean {
 	return /\.(yaml|yml)$/i.test(filePath)
 }
 
+function isExpectedMigrationError(error: unknown): boolean {
+	const code = (error as NodeJS.ErrnoException)?.code
+	return code === "ENOENT" || code === "EPERM" || code === "EACCES"
+}
+
+async function migrateLegacyAgentConfigs(legacyPath: string, newPath: string): Promise<void> {
+	try {
+		const entries = await fs.readdir(legacyPath, { withFileTypes: true })
+		await fs.mkdir(newPath, { recursive: true })
+		await Promise.all(
+			entries
+				.filter((entry) => entry.isFile() && isYamlFile(entry.name))
+				.map(async (entry) => {
+					const src = path.join(legacyPath, entry.name)
+					const dest = path.join(newPath, entry.name)
+					try {
+						await fs.copyFile(src, dest, fs.constants.COPYFILE_EXCL)
+						Logger.debug(`[AgentConfigLoader] Migrated legacy agent config '${entry.name}' to ${dest}`)
+					} catch (copyErr) {
+						if ((copyErr as NodeJS.ErrnoException).code !== "EEXIST") {
+							Logger.warn(`[AgentConfigLoader] Failed to copy legacy agent config '${entry.name}': ${copyErr}`)
+						}
+					}
+				}),
+		)
+	} catch (error) {
+		if (isExpectedMigrationError(error)) {
+			return
+		}
+		Logger.warn(`[AgentConfigLoader] Failed to read legacy agent configs from '${legacyPath}': ${error}`)
+	}
+}
+
 export async function readAgentConfigsFromDisk(homeDir = os.homedir()): Promise<Map<string, AgentBaseConfig>> {
 	const agentsDirectoryPath = getAgentsConfigPath(homeDir)
+	const legacyDirectoryPath = getLegacyAgentsConfigPath(homeDir)
+	await migrateLegacyAgentConfigs(legacyDirectoryPath, agentsDirectoryPath)
 	const configs = new Map<string, AgentBaseConfig>()
 
 	try {
@@ -266,6 +313,7 @@ export class AgentConfigLoader {
 		}
 
 		try {
+			await fs.mkdir(this.directoryPath, { recursive: true })
 			const watcher = chokidar.watch(this.directoryPath, {
 				persistent: true,
 				ignoreInitial: true,
@@ -280,12 +328,22 @@ export class AgentConfigLoader {
 					if (this.watcher !== watcher) return
 					this.watcher = undefined
 					const watcherError = toError(error)
-					Logger.error("[AgentConfigLoader] Agent config live reload is disabled after watcher failure", watcherError)
+					const isPerm = (watcherError as any).code === "EPERM" || (watcherError as any).code === "EACCES"
+					if (isPerm) {
+						Logger.warn(
+							`[AgentConfigLoader] Agent config live reload is disabled due to missing filesystem permissions on '${this.directoryPath}'`,
+						)
+					} else {
+						Logger.error(
+							"[AgentConfigLoader] Agent config live reload is disabled after watcher failure",
+							watcherError,
+						)
+					}
 					this.notify(this.cachedConfigs, watcherError)
 					void this.watcherCloser
 						.close(watcher)
 						.catch((closeError) =>
-							Logger.error("[AgentConfigLoader] Failed to close disabled agent config watcher", closeError),
+							Logger.warn("[AgentConfigLoader] Failed to close disabled agent config watcher", closeError),
 						)
 				})
 				.on("add", (filePath) => {
@@ -309,7 +367,14 @@ export class AgentConfigLoader {
 		} catch (error) {
 			this.watcher = undefined
 			const watcherError = toError(error)
-			Logger.error("[AgentConfigLoader] Agent config live reload could not start and is disabled", watcherError)
+			const isPerm = (watcherError as any).code === "EPERM" || (watcherError as any).code === "EACCES"
+			if (isPerm) {
+				Logger.warn(
+					`[AgentConfigLoader] Agent config live reload could not start due to missing filesystem permissions on '${this.directoryPath}'`,
+				)
+			} else {
+				Logger.error("[AgentConfigLoader] Agent config live reload could not start and is disabled", watcherError)
+			}
 			this.notify(this.cachedConfigs, watcherError)
 		}
 	}

--- a/src/core/task/tools/subagent/__tests__/AgentConfigLoader.test.ts
+++ b/src/core/task/tools/subagent/__tests__/AgentConfigLoader.test.ts
@@ -3,8 +3,16 @@ import fs from "fs/promises"
 import { afterEach, describe, it } from "mocha"
 import os from "os"
 import * as path from "path"
+import * as sinon from "sinon"
+import { Logger } from "@/shared/services/Logger"
 import { DiracDefaultTool, getToolUseNames } from "@/shared/tools"
-import { AgentConfigLoader, getAgentsConfigPath, parseAgentConfigFromYaml, readAgentConfigsFromDisk } from "../AgentConfigLoader"
+import {
+	AgentConfigLoader,
+	getAgentsConfigPath,
+	getLegacyAgentsConfigPath,
+	parseAgentConfigFromYaml,
+	readAgentConfigsFromDisk,
+} from "../AgentConfigLoader"
 
 async function createTempHomeDir(): Promise<string> {
 	return fs.mkdtemp(path.join(os.tmpdir(), "agent-config-loader-"))
@@ -160,5 +168,71 @@ Reviewer prompt`,
 		await loader.watch()
 
 		assert.equal((loader as unknown as { watcher?: unknown }).watcher, undefined)
+	})
+
+	describe("Path resolution & legacy migration (ERR-1)", () => {
+		it("resolves agents directory inside ~/.dirac/Agents", () => {
+			const fakeHome = "/custom/home"
+			assert.strictEqual(getAgentsConfigPath(fakeHome), path.join(fakeHome, ".dirac", "Agents"))
+			assert.strictEqual(getLegacyAgentsConfigPath(fakeHome), path.join(fakeHome, "Documents", "Dirac", "Agents"))
+		})
+
+		it("migrates legacy agent configs from ~/Documents/Dirac/Agents to ~/.dirac/Agents", async () => {
+			const tempHome = await createTempHomeDir()
+			tempDirs.push(tempHome)
+
+			const legacyDir = getLegacyAgentsConfigPath(tempHome)
+			const newDir = getAgentsConfigPath(tempHome)
+			await fs.mkdir(legacyDir, { recursive: true })
+
+			await fs.writeFile(
+				path.join(legacyDir, "legacy-agent.yaml"),
+				`---
+name: legacy-agent
+description: migrated agent
+tools: read_file
+modelId: sonnet
+---
+
+Legacy prompt`,
+				"utf8",
+			)
+
+			const configs = await readAgentConfigsFromDisk(tempHome)
+			assert.strictEqual(configs.has("legacy-agent"), true)
+
+			// Verify file was migrated to new ~/.dirac/Agents directory
+			const migratedFile = path.join(newDir, "legacy-agent.yaml")
+			const exists = await fs.access(migratedFile).then(
+				() => true,
+				() => false,
+			)
+			assert.strictEqual(exists, true)
+		})
+
+		it("logs a warning instead of error when watcher encounters EPERM/EACCES", async () => {
+			const tempHome = await createTempHomeDir()
+			tempDirs.push(tempHome)
+
+			const loader = AgentConfigLoader.getInstance(tempHome)
+			const warnSpy = sinon.spy(Logger, "warn")
+			const errorSpy = sinon.spy(Logger, "error")
+
+			try {
+				await loader.ready()
+				const watcher = (loader as any).watcher
+				if (watcher) {
+					const epermError = Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" })
+					watcher.emit("error", epermError)
+				}
+
+				sinon.assert.called(warnSpy)
+				sinon.assert.notCalled(errorSpy)
+			} finally {
+				warnSpy.restore()
+				errorSpy.restore()
+				await loader.dispose()
+			}
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- Move default agent configs path from `~/Documents/Dirac/Agents` to `~/.dirac/Agents`, bypassing macOS TCC sandbox restrictions on `~/Documents`.
- Add automatic best-effort backward-compatible migration from legacy Documents path to `~/.dirac/Agents`.
- Downgrade watcher `EPERM`/`EACCES` errors from `ERROR` to `WARN` level so file watcher permission denials on restricted locations do not crash or disable agent configuration.
- Add comprehensive unit tests in `src/core/task/tools/subagent/__tests__/AgentConfigLoader.test.ts` for path resolution, legacy migration, and EPERM warning handling.

#### Test plan
- [x] Unit test passing: `src/core/task/tools/subagent/__tests__/AgentConfigLoader.test.ts` (10 passing)
- [x] `npm run check-types`: zero errors
- [x] `npm run lint`: checked 2094 files, 0 errors