### PR TITLE
fix(extract-text): handle space:// and file:// URIs in task file processing (ERR-2)

### DIFF
--- a/src/integrations/misc/__tests__/extract-text.test.ts
+++ b/src/integrations/misc/__tests__/extract-text.test.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert"
+import { after, afterEach, before, describe, it } from "mocha"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import sinon from "sinon"
+import { pathToFileURL } from "url"
+import { Logger } from "@/shared/services/Logger"
+import { extractTextFromFile, processFilesIntoText } from "../extract-text"
+
+describe("extract-text", () => {
+	describe("extractTextFromFile", () => {
+		it("reads text from a local file", async () => {
+			const tempFile = path.join(os.tmpdir(), `dirac-extract-test-${Date.now()}.txt`)
+			await fs.writeFile(tempFile, "hello world")
+			try {
+				const content = await extractTextFromFile(tempFile)
+				assert.strictEqual(content, "hello world")
+			} finally {
+				await fs.unlink(tempFile).catch(() => {})
+			}
+		})
+	})
+
+	describe("processFilesIntoText", () => {
+		let tempFile: string
+		let fileUrl: string
+
+		before(async () => {
+			tempFile = path.join(os.tmpdir(), `dirac-extract-test-${Date.now()}.txt`)
+			await fs.writeFile(tempFile, "hello world")
+			fileUrl = pathToFileURL(tempFile).href
+		})
+
+		after(async () => {
+			await fs.unlink(tempFile).catch(() => {})
+		})
+
+		afterEach(() => {
+			sinon.restore()
+		})
+
+		it("resolves file:// URIs to a local path", async () => {
+			const result = await processFilesIntoText([fileUrl])
+			assert.ok(result.includes("hello world"))
+			assert.ok(result.includes(tempFile.replace(/\\/g, "/")))
+		})
+
+		it("warns and skips space:// URIs", async () => {
+			const warnStub = sinon.stub(Logger, "warn")
+			const spaceUri = "space://1788434544580-1rccxfssm/Find%20PR-FEEDBACK-STATUS.md"
+			const result = await processFilesIntoText([spaceUri])
+			assert.ok(result.includes("Space resource unavailable"))
+			assert.ok(result.includes(spaceUri))
+			assert.ok(warnStub.calledOnce)
+		})
+
+		it("warns and skips unsupported URI schemes", async () => {
+			const warnStub = sinon.stub(Logger, "warn")
+			const result = await processFilesIntoText(["foo://bar/baz.txt"])
+			assert.ok(result.includes('Unsupported URI scheme "foo"'))
+			assert.ok(warnStub.calledOnce)
+		})
+
+		it("logs error for missing local files", async () => {
+			const errorStub = sinon.stub(Logger, "error")
+			const missing = path.join(os.tmpdir(), `dirac-extract-missing-${Date.now()}.txt`)
+			const result = await processFilesIntoText([missing])
+			assert.ok(result.includes("Error fetching content"))
+			assert.ok(result.includes("File not found"))
+			assert.ok(errorStub.calledOnce)
+		})
+	})
+})

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -7,6 +7,7 @@ import mammoth from "mammoth"
 import * as path from "path"
 // @ts-expect-error-next-line
 import pdf from "pdf-parse/lib/pdf-parse"
+import { fileURLToPath } from "url"
 import { truncateContent } from "@/shared/content-limits"
 import { Logger } from "@/shared/services/Logger"
 import { sanitizeNotebookForLLM } from "./notebook-utils"
@@ -26,6 +27,35 @@ export async function detectEncoding(fileBuffer: Buffer, fileExtension?: string)
 		}
 	}
 	return "utf8"
+}
+
+class FileResourceUnavailableError extends Error {
+	constructor(message: string) {
+		super(message)
+		this.name = "FileResourceUnavailableError"
+	}
+}
+
+function resolveFileUri(filePath: string): string {
+	const match = filePath.match(/^([a-z][a-z0-9+.-]*):\/\//i)
+	if (!match) {
+		return filePath
+	}
+
+	const scheme = match[1].toLowerCase()
+	if (scheme === "file") {
+		try {
+			return fileURLToPath(filePath)
+		} catch {
+			throw new Error(`Invalid file URL: ${filePath}`)
+		}
+	}
+
+	if (scheme === "space") {
+		throw new FileResourceUnavailableError(`Space resource unavailable: ${filePath}`)
+	}
+
+	throw new FileResourceUnavailableError(`Unsupported URI scheme "${scheme}": ${filePath}`)
 }
 
 export async function extractTextFromFile(filePath: string): Promise<string> {
@@ -198,14 +228,14 @@ async function extractTextFromExcel(filePath: string): Promise<string> {
 export async function processFilesIntoText(files: string[]): Promise<string> {
 	const fileContentsPromises = files.map(async (filePath) => {
 		try {
-			// Check if file exists and is binary
-			//const isBinary = await isBinaryFile(filePath).catch(() => false)
-			//if (isBinary) {
-			//	return `<file_content path="${filePath.toPosix()}">\n(Binary file, unable to display content)\n</file_content>`
-			//}
-			const content = await extractTextFromFile(filePath)
-			return `<file_content path="${filePath.toPosix()}">\n${content}\n</file_content>`
+			const resolvedPath = resolveFileUri(filePath)
+			const content = await extractTextFromFile(resolvedPath)
+			return `<file_content path="${resolvedPath.toPosix()}">\n${content}\n</file_content>`
 		} catch (error) {
+			if (error instanceof FileResourceUnavailableError) {
+				Logger.warn(`Skipping virtual file resource ${filePath}:`, error.message)
+				return `<file_content path="${filePath.toPosix()}">\n${error.message}\n</file_content>`
+			}
 			Logger.error(`Error processing file ${filePath}:`, error)
 			return `<file_content path="${filePath.toPosix()}">\nError fetching content: ${error.message}\n</file_content>`
 		}


### PR DESCRIPTION
## Summary
- ACP clients pass attached files as URIs (`space://...` or `file://...`). Previously, `processFilesIntoText` treated all input paths as local filesystem paths, failing with `File not found` errors on URIs.
- Resolve `file://` URIs using `url.fileURLToPath()` to extract local disk paths.
- Gracefully skip `space://` and unsupported URI schemes with a `WARN` log and informative placeholder in file content instead of failing task setup.
- Add unit tests in `src/integrations/misc/__tests__/extract-text.test.ts` covering local files, `file://` URIs, `space://` URIs, unsupported schemes, and missing files.

#### Test plan
- [x] Unit test passing: `src/integrations/misc/__tests__/extract-text.test.ts` (5 passing)
- [x] `npm run check-types`: zero errors
- [x] `npm run lint`: checked 2094 files, 0 errors