### PR TITLE
fix(controller): demote routine Controller disposed log to DEBUG (ERR-4)

### DIFF
--- a/src/core/controller/__tests__/Controller.test.ts
+++ b/src/core/controller/__tests__/Controller.test.ts
@@ -18,11 +18,12 @@ import { HostProvider } from "@/hosts/host-provider"
 import { BannerService } from "@/services/banner/BannerService"
 import type { DiracExtensionContext } from "@/shared/dirac"
 import { Session } from "@/shared/services/Session"
+import { expectLoggerErrors } from "@/test/loggerGuard"
 import * as pathUtils from "@/utils/path"
+import { Logger } from "../../../shared/services/Logger"
 import { StateManager } from "../../storage/StateManager"
 import { Task } from "../../task"
 import { Controller } from "../index"
-import { expectLoggerErrors } from "@/test/loggerGuard"
 
 describe("Controller (original)", () => {
 	let sandbox: sinon.SinonSandbox
@@ -455,5 +456,14 @@ describe("Controller (original)", () => {
 		const c = new Controller(mockContext)
 		const m = await c.readOpenRouterModels()
 		;(m === undefined).should.be.true()
+	})
+
+	it("logs routine disposal at DEBUG level", async () => {
+		const c = new Controller(mockContext)
+		const debugStub = sandbox.stub(Logger, "debug")
+		const errorStub = sandbox.stub(Logger, "error")
+		await c.dispose()
+		sinon.assert.calledWith(debugStub, "Controller disposed")
+		sinon.assert.neverCalledWith(errorStub, "Controller disposed")
 	})
 })

--- a/src/core/controller/index.ts
+++ b/src/core/controller/index.ts
@@ -173,7 +173,7 @@ export class Controller {
 		await this.goalController.dispose()
 		await this.taskController.clearTask()
 
-		Logger.error("Controller disposed")
+		Logger.debug("Controller disposed")
 	}
 
 	// Task lifecycle delegation (via TaskController)


### PR DESCRIPTION
## Summary
- Routine controller disposal during session cleanup, window closing, or task switching was logged via `Logger.error("Controller disposed")`.
- This caused false alarms in error tracking, extension host telemetry, and user log files for expected lifecycle events.
- Demote the log to `Logger.debug("Controller disposed")` so error-level reporting reflects actual faults.
- Add test in `src/core/controller/__tests__/Controller.test.ts` verifying routine disposal emits at debug level and not as an error.

#### Test plan
- [x] Unit test passing: `src/core/controller/__tests__/Controller.test.ts` (24 passing)
- [x] `npm run check-types`: zero errors
- [x] `npm run lint`: checked 2094 files, 0 errors