### PR TITLE
fix(syntax-feedback): skip diagnostics for unsupported file extensions (ERR-5)

### DIFF
--- a/src/integrations/diagnostics/SyntaxFeedbackProvider.ts
+++ b/src/integrations/diagnostics/SyntaxFeedbackProvider.ts
@@ -1,6 +1,6 @@
-import { Node as SyntaxNode, Tree } from "web-tree-sitter"
 import * as path from "path"
-import { loadRequiredLanguageParsers } from "@/services/tree-sitter/languageParser"
+import { Node as SyntaxNode, Tree } from "web-tree-sitter"
+import { isLanguageSupported, loadRequiredLanguageParsers } from "@/services/tree-sitter/languageParser"
 import { Diagnostic, DiagnosticSeverity, FileDiagnostics } from "@/shared/proto/index.dirac"
 import { Logger } from "@/shared/services/Logger"
 import { DiagnosticsFeedbackResult, IDiagnosticsProvider } from "./IDiagnosticsProvider"
@@ -19,6 +19,10 @@ export class SyntaxFeedbackProvider implements IDiagnosticsProvider {
 	): Promise<DiagnosticsFeedbackResult> {
 		try {
 			const extension = path.extname(filePath).toLowerCase().slice(1)
+			if (!isLanguageSupported(extension)) {
+				return { newProblemsMessage: "", fixedCount: 0 }
+			}
+
 			const languageParsers = await loadRequiredLanguageParsers([filePath])
 			const { parser } = languageParsers[extension] || {}
 			if (!parser) {

--- a/src/integrations/diagnostics/__tests__/SyntaxFeedbackProvider.test.ts
+++ b/src/integrations/diagnostics/__tests__/SyntaxFeedbackProvider.test.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai"
+import { describe, it } from "mocha"
+import { SyntaxFeedbackProvider } from "../SyntaxFeedbackProvider"
+
+describe("SyntaxFeedbackProvider", () => {
+	it("returns empty feedback for unsupported file extensions", async () => {
+		const provider = new SyntaxFeedbackProvider()
+		const result = await provider.getDiagnosticsFeedback("/workspace/readme.md", "# Hello\n", [])
+		expect(result).to.deep.equal({ newProblemsMessage: "", fixedCount: 0 })
+	})
+
+	it("returns empty feedback for files with no extension", async () => {
+		const provider = new SyntaxFeedbackProvider()
+		const result = await provider.getDiagnosticsFeedback("/workspace/LICENSE", "MIT License\n", [])
+		expect(result).to.deep.equal({ newProblemsMessage: "", fixedCount: 0 })
+	})
+})

--- a/src/services/tree-sitter/__tests__/languageParser.test.ts
+++ b/src/services/tree-sitter/__tests__/languageParser.test.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import { isLanguageSupported } from "../languageParser"
+
+describe("languageParser", () => {
+	describe("isLanguageSupported", () => {
+		it("returns true for supported code extensions", () => {
+			assert.strictEqual(isLanguageSupported("ts"), true)
+			assert.strictEqual(isLanguageSupported("js"), true)
+			assert.strictEqual(isLanguageSupported("py"), true)
+			assert.strictEqual(isLanguageSupported("cpp"), true)
+		})
+
+		it("returns false for unsupported or non-code extensions", () => {
+			assert.strictEqual(isLanguageSupported("md"), false)
+			assert.strictEqual(isLanguageSupported("txt"), false)
+			assert.strictEqual(isLanguageSupported("json"), false)
+			assert.strictEqual(isLanguageSupported(""), false)
+		})
+	})
+})

--- a/src/services/tree-sitter/languageParser.ts
+++ b/src/services/tree-sitter/languageParser.ts
@@ -4,20 +4,20 @@ import { Language, Parser, Query } from "web-tree-sitter"
 import { SymbolIndexTelemetry } from "@/services/symbol-index/SymbolIndexTelemetry"
 import { getErrorMessage } from "@/shared/errors"
 import {
-	cppQuery,
-	cQuery,
-	csharpQuery,
-	goQuery,
-	javaQuery,
-	javascriptQuery,
-	kotlinQuery,
-	phpQuery,
-	pythonQuery,
-	rubyQuery,
-	rustQuery,
-	swiftQuery,
-	typescriptQuery,
-	zigQuery,
+    cppQuery,
+    cQuery,
+    csharpQuery,
+    goQuery,
+    javaQuery,
+    javascriptQuery,
+    kotlinQuery,
+    phpQuery,
+    pythonQuery,
+    rubyQuery,
+    rustQuery,
+    swiftQuery,
+    typescriptQuery,
+    zigQuery,
 } from "./queries"
 
 export interface LanguageParser {
@@ -106,44 +106,38 @@ async function initializeParser(): Promise<void> {
 	return initializationPromise
 }
 
+const languageDefinitions: Record<string, LanguageDefinition> = {
+	js: { langName: "javascript", queryText: javascriptQuery },
+	jsx: { langName: "javascript", queryText: javascriptQuery },
+	ts: { langName: "typescript", queryText: typescriptQuery },
+	tsx: { langName: "tsx", queryText: typescriptQuery },
+	py: { langName: "python", queryText: pythonQuery },
+	rs: { langName: "rust", queryText: rustQuery },
+	go: { langName: "go", queryText: goQuery },
+	cpp: { langName: "cpp", queryText: cppQuery },
+	hpp: { langName: "cpp", queryText: cppQuery },
+	c: { langName: "c", queryText: cQuery },
+	h: { langName: "c", queryText: cQuery },
+	cs: { langName: "c_sharp", queryText: csharpQuery },
+	rb: { langName: "ruby", queryText: rubyQuery },
+	java: { langName: "java", queryText: javaQuery },
+	php: { langName: "php", queryText: phpQuery },
+	swift: { langName: "swift", queryText: swiftQuery },
+	kt: { langName: "kotlin", queryText: kotlinQuery },
+	zig: { langName: "zig", queryText: zigQuery },
+}
+
 function getLanguageDefinition(extension: string): LanguageDefinition {
-	switch (extension) {
-		case "js":
-		case "jsx":
-			return { langName: "javascript", queryText: javascriptQuery }
-		case "ts":
-			return { langName: "typescript", queryText: typescriptQuery }
-		case "tsx":
-			return { langName: "tsx", queryText: typescriptQuery }
-		case "py":
-			return { langName: "python", queryText: pythonQuery }
-		case "rs":
-			return { langName: "rust", queryText: rustQuery }
-		case "go":
-			return { langName: "go", queryText: goQuery }
-		case "cpp":
-		case "hpp":
-			return { langName: "cpp", queryText: cppQuery }
-		case "c":
-		case "h":
-			return { langName: "c", queryText: cQuery }
-		case "cs":
-			return { langName: "c_sharp", queryText: csharpQuery }
-		case "rb":
-			return { langName: "ruby", queryText: rubyQuery }
-		case "java":
-			return { langName: "java", queryText: javaQuery }
-		case "php":
-			return { langName: "php", queryText: phpQuery }
-		case "swift":
-			return { langName: "swift", queryText: swiftQuery }
-		case "kt":
-			return { langName: "kotlin", queryText: kotlinQuery }
-		case "zig":
-			return { langName: "zig", queryText: zigQuery }
-		default:
-			throw new Error(`Unsupported language: ${extension}`)
+	const definition = languageDefinitions[extension]
+	if (!definition) {
+		throw new Error(`Unsupported language: ${extension}`)
 	}
+	return definition
+}
+
+export function isLanguageSupported(extension: string): boolean {
+	const normalized = extension.startsWith(".") ? extension.slice(1) : extension
+	return Object.hasOwn(languageDefinitions, normalized)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Editing non-code files (such as Markdown `.md` or plaintext `.txt`) caused `DiffViewProvider` -> `SyntaxFeedbackProvider` to attempt parsing via Tree-sitter, which threw `Unsupported language: md` and logged a fatal error.
- Export `isLanguageSupported(extension)` from `languageParser.ts` and normalize extensions to handle leading dots gracefully.
- Add guard in `SyntaxFeedbackProvider.getDiagnosticsFeedback()` to return empty diagnostics immediately when a file extension is not supported by Tree-sitter, avoiding parser errors and spurious error logs.
- Add unit tests in `src/integrations/diagnostics/__tests__/SyntaxFeedbackProvider.test.ts` and `src/services/tree-sitter/__tests__/languageParser.test.ts`.

#### Test plan
- [x] Unit tests passing: `SyntaxFeedbackProvider.test.ts` (2 passing) & `languageParser.test.ts` (2 passing)
- [x] `npm run check-types`: zero errors
- [x] `npm run lint`: checked 2094 files, 0 errors