### PR TITLE
fix(glob): prune ignored directories during recursive traversal (ERR-7)

### DIFF
--- a/src/services/glob/__tests__/list-files-ignore.test.ts
+++ b/src/services/glob/__tests__/list-files-ignore.test.ts
@@ -35,5 +35,48 @@ describe("listFiles ignore patterns", () => {
 		normalizedFiles.should.containEql(normalizeForComparison(txtFile))
 		normalizedFiles.should.not.containEql(normalizeForComparison(logFile))
 		normalizedFiles.should.not.containEql(normalizeForComparison(nodeModulesFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(nodeModulesDir))
+	})
+
+	it("prunes ignored directories before descending into them", async () => {
+		await fs.mkdir(tmpDir, { recursive: true })
+
+		const txtFile = path.join(tmpDir, "src", "main.ts")
+		const targetDepFile = path.join(tmpDir, "target", "dependency", "bad.jar")
+		const buildDepFile = path.join(tmpDir, "build", "dependencies", "bad.jar")
+
+		await fs.mkdir(path.join(tmpDir, "src"), { recursive: true })
+		await fs.mkdir(path.join(tmpDir, "target", "dependency"), { recursive: true })
+		await fs.mkdir(path.join(tmpDir, "build", "dependencies"), { recursive: true })
+		await fs.writeFile(txtFile, "export const ok = true\n")
+		await fs.writeFile(targetDepFile, "")
+		await fs.writeFile(buildDepFile, "")
+
+		const [files] = await listFiles(tmpDir, true, 200)
+		const normalizedFiles = files.map((f) => f.path).map(normalizeForComparison)
+
+		normalizedFiles.should.containEql(normalizeForComparison(txtFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(targetDepFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(buildDepFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(path.join(tmpDir, "target", "dependency")))
+	})
+
+	it("skips hidden directories when not explicitly targeting one", async () => {
+		await fs.mkdir(tmpDir, { recursive: true })
+
+		const visibleFile = path.join(tmpDir, "src", "main.ts")
+		const hiddenFile = path.join(tmpDir, ".hidden", "secret.ts")
+
+		await fs.mkdir(path.join(tmpDir, "src"), { recursive: true })
+		await fs.mkdir(path.join(tmpDir, ".hidden"), { recursive: true })
+		await fs.writeFile(visibleFile, "export const ok = true\n")
+		await fs.writeFile(hiddenFile, "export const secret = 1\n")
+
+		const [files] = await listFiles(tmpDir, true, 200)
+		const normalizedFiles = files.map((f) => f.path).map(normalizeForComparison)
+
+		normalizedFiles.should.containEql(normalizeForComparison(visibleFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(hiddenFile))
+		normalizedFiles.should.not.containEql(normalizeForComparison(path.join(tmpDir, ".hidden")))
 	})
 })

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -1,11 +1,12 @@
 import { promises as fs } from "node:fs"
-import { isBinaryFile } from "isbinaryfile"
 import { workspaceResolver } from "@core/workspace"
 import { isDirectory } from "@utils/fs"
 import { arePathsEqual } from "@utils/path"
 import { globby, Options } from "globby"
+import { isBinaryFile } from "isbinaryfile"
 import * as os from "os"
 import * as path from "path"
+import picomatch from "picomatch"
 import { Logger } from "@/shared/services/Logger"
 
 // Constants
@@ -66,11 +67,12 @@ function buildIgnorePatterns(absolutePath: string): string[] {
 		patterns.push(".*")
 	}
 
-	return patterns.map((pattern) => {
+	return patterns.flatMap((pattern) => {
 		if (pattern.includes("*")) {
 			return `**/${pattern}`
 		}
-		return `**/${pattern}/**`
+		// Match the directory itself and everything inside it so globby can prune early.
+		return [`**/${pattern}`, `**/${pattern}/**`]
 	})
 }
 
@@ -178,6 +180,7 @@ Breadth-first traversal of directory structure level by level up to a limit:
 async function globbyLevelByLevel(limit: number, options?: Options): Promise<any[]> {
 	const results: Map<string, any> = new Map()
 	const queue: string[] = ["*"]
+	const isIgnored = options?.ignore && options.ignore.length > 0 ? picomatch(options.ignore, { dot: true }) : () => false
 
 	const globbingProcess = async () => {
 		while (queue.length > 0 && results.size < limit) {
@@ -188,8 +191,16 @@ async function globbyLevelByLevel(limit: number, options?: Options): Promise<any
 				if (results.size >= limit) {
 					break
 				}
+
+				const isDirectory = entry.path.endsWith("/")
+				const cleanPath = isDirectory ? entry.path.slice(0, -1) : entry.path
+				if (isIgnored(cleanPath)) {
+					continue
+				}
+
 				results.set(entry.path, entry)
-				if (entry.path.endsWith("/")) {
+
+				if (isDirectory) {
 					// Escape parentheses in the path to prevent glob pattern interpretation
 					// This is crucial for NextJS folder naming conventions which use parentheses like (auth), (dashboard)
 					// Without escaping, glob treats parentheses as special pattern grouping characters


### PR DESCRIPTION
## Summary
- In large codebases or repositories with heavy directories (`node_modules`, `build`, `dist`, `target`), the manual BFS directory queue traversal in `listFiles` would traverse deep into ignored subdirectories, exhausting the 10-second timeout ceiling.
- Update `buildIgnorePatterns` to match the directories themselves (`**/${dir}`) in addition to their descendants (`**/${dir}/**`).
- Check `isIgnored` before storing directory entries in results and before enqueuing child directory traversal in `globbyLevelByLevel`.
- Add unit tests in `src/services/glob/__tests__/list-files-ignore.test.ts` verifying ignored directories and hidden directory hierarchies are pruned.

#### Test plan
- [x] Unit tests passing: `src/services/glob/__tests__/list-files-ignore.test.ts` (3 passing)
- [x] `npm run check-types`: zero errors
- [x] `npm run lint`: checked 2094 files, 0 errors