### PR TITLE
fix(task): settle task completion on yolo mistake limit failure

### DIFF
--- a/cli/src/utils/plain-text-task.test.ts
+++ b/cli/src/utils/plain-text-task.test.ts
@@ -1,4 +1,11 @@
-import { CardStatus, type Card } from "@shared/ExtensionMessage"
+import {
+	CardStatus,
+	type Card,
+	DiracMessageType,
+	TaskStatus,
+	UIActionButtonType,
+	type ExtensionState,
+} from "@shared/ExtensionMessage"
 import { DiracAskResponse } from "@shared/WebviewMessage"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
@@ -7,6 +14,7 @@ import {
 	StandaloneCardDisposition,
 } from "./standalone-card-policy"
 import { emitTaskStartedMessage } from "./task-start-output"
+import { evaluatePlainTextTaskTerminalState } from "./plain-text-task"
 
 describe("emitTaskStartedMessage", () => {
 	afterEach(() => {
@@ -99,5 +107,94 @@ describe("getStandaloneCardDisposition", () => {
 		expect(getStandaloneCardDisposition({ ...waitingCard, requireApproval: true }, true, true)).toBe(
 			StandaloneCardDisposition.NONE,
 		)
+	})
+})
+
+describe("evaluatePlainTextTaskTerminalState", () => {
+	it("rejects immediately when a Task Failed error card is present", () => {
+		const state = {
+			taskStatus: TaskStatus.EXECUTING_TOOL,
+			diracMessages: [
+				{
+					id: "1",
+					ts: Date.now(),
+					content: {
+						type: DiracMessageType.CARD,
+						card: {
+							id: "fail-card",
+							header: "Task Failed",
+							status: CardStatus.ERROR,
+							body: "[YOLO MODE] Task failed: Too many consecutive mistakes (3).",
+							renderType: "markdown",
+						},
+					},
+				},
+			],
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state)
+		expect(result.isTerminal).toBe(true)
+		expect(result.action).toBe("reject")
+		expect(result.error?.message).toBe("[YOLO MODE] Task failed: Too many consecutive mistakes (3).")
+	})
+
+	it("resolves when taskStatus is COMPLETED", () => {
+		const state = {
+			taskStatus: TaskStatus.COMPLETED,
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state)
+		expect(result.isTerminal).toBe(true)
+		expect(result.action).toBe("resolve")
+	})
+
+	it("rejects when taskStatus is CANCELLED in normal execution", () => {
+		const state = {
+			taskStatus: TaskStatus.CANCELLED,
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state, false)
+		expect(result.isTerminal).toBe(true)
+		expect(result.action).toBe("reject")
+		expect(result.error?.message).toBe("Task was cancelled.")
+	})
+
+	it("resolves when taskStatus is CANCELLED in isViewTaskOnly mode", () => {
+		const state = {
+			taskStatus: TaskStatus.CANCELLED,
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state, true)
+		expect(result.isTerminal).toBe(true)
+		expect(result.action).toBe("resolve")
+	})
+
+	it("rejects when global buttons have both NEW_TASK and PROCEED (mistake limit projection)", () => {
+		const state = {
+			taskStatus: TaskStatus.EXECUTING_TOOL,
+			uiActionState: {
+				globalButtons: [
+					{ action: UIActionButtonType.NEW_TASK },
+					{ action: UIActionButtonType.PROCEED },
+				],
+			},
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state)
+		expect(result.isTerminal).toBe(true)
+		expect(result.action).toBe("reject")
+		expect(result.error?.message).toBe("Mistake limit reached. Task halted in YOLO mode.")
+	})
+
+	it("returns non-terminal when task is running without terminal signals", () => {
+		const state = {
+			taskStatus: TaskStatus.EXECUTING_TOOL,
+			uiActionState: {
+				globalButtons: [],
+			},
+		} as unknown as ExtensionState
+
+		const result = evaluatePlainTextTaskTerminalState(state)
+		expect(result.isTerminal).toBe(false)
 	})
 })

--- a/cli/src/utils/plain-text-task.ts
+++ b/cli/src/utils/plain-text-task.ts
@@ -43,6 +43,63 @@ import { cardBodyForDisplay } from "./card-body"
 
 export { approveCardForPlainTextYolo } from "./standalone-card-policy"
 
+export interface TerminalStateEvaluation {
+	isTerminal: boolean
+	action?: "resolve" | "reject"
+	error?: Error
+}
+
+export function evaluatePlainTextTaskTerminalState(
+	state: ExtensionState,
+	isViewTaskOnly = false,
+): TerminalStateEvaluation {
+	const hasTaskFailedCard = (state.diracMessages ?? []).some(
+		(m) =>
+			m.content.type === DiracMessageType.CARD &&
+			m.content.card.header === "Task Failed" &&
+			m.content.card.status === CardStatus.ERROR,
+	)
+
+	if (hasTaskFailedCard) {
+		const failedCard = [...(state.diracMessages ?? [])]
+			.reverse()
+			.find(
+				(m) =>
+					m.content.type === DiracMessageType.CARD &&
+					m.content.card.header === "Task Failed" &&
+					m.content.card.status === CardStatus.ERROR,
+			)
+		const msg =
+			failedCard?.content.type === DiracMessageType.CARD && failedCard.content.card.body
+				? failedCard.content.card.body
+				: "Mistake limit reached. Task halted in YOLO mode."
+		return { isTerminal: true, action: "reject", error: new Error(msg) }
+	}
+
+	const globalButtons = state.uiActionState?.globalButtons || []
+	const cardButtons = state.uiActionState?.cardButtons || []
+	const hasNewTask = globalButtons.some((button) => button.action === UIActionButtonType.NEW_TASK)
+	const hasProceed = globalButtons.some((button) => button.action === UIActionButtonType.PROCEED)
+
+	if (hasNewTask && hasProceed) {
+		return { isTerminal: true, action: "reject", error: new Error("Mistake limit reached. Task halted in YOLO mode.") }
+	}
+	if (state.taskStatus === TaskStatus.COMPLETED || (hasNewTask && !hasProceed)) {
+		return { isTerminal: true, action: "resolve" }
+	}
+	if (state.taskStatus === TaskStatus.CANCELLED) {
+		if (isViewTaskOnly) {
+			return { isTerminal: true, action: "resolve" }
+		}
+		return { isTerminal: true, action: "reject", error: new Error("Task was cancelled.") }
+	}
+	if (isViewTaskOnly && cardButtons.length > 0) {
+		return { isTerminal: true, action: "resolve" }
+	}
+
+	return { isTerminal: false }
+}
+
 export interface PlainTextTaskOptions {
 	controller: Controller
 	/** Prompt for new task or message to send to resumed task */
@@ -203,6 +260,16 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 			}
 		}
 
+		// Check for task failure card (e.g. YOLO mistake limit reached)
+		if (
+			content.type === DiracMessageType.CARD &&
+			content.card.header === "Task Failed" &&
+			content.card.status === CardStatus.ERROR
+		) {
+			rejectCompletion(new Error(content.card.body || "Mistake limit reached. Task halted in YOLO mode."))
+			return
+		}
+
 		// Check for API failure (retries exhausted)
 		if (content.type === DiracMessageType.API_STATUS && content.status.cancelReason === "retries_exhausted") {
 			rejectCompletion(new Error("API request failed: retries exhausted"))
@@ -269,22 +336,14 @@ export async function runPlainTextTask(options: PlainTextTaskOptions): Promise<b
 						await processMessage(message, state)
 					}
 
-					// Check for terminal state via task status, retaining the mistake-limit projection.
-					const globalButtons = state.uiActionState?.globalButtons || []
-					const cardButtons = state.uiActionState?.cardButtons || []
-					const hasNewTask = globalButtons.some((button) => button.action === UIActionButtonType.NEW_TASK)
-					const hasProceed = globalButtons.some((button) => button.action === UIActionButtonType.PROCEED)
-
-					if (hasNewTask && hasProceed) {
-						rejectCompletion(new Error("Mistake limit reached. Task halted in YOLO mode."))
-					} else if (state.taskStatus === TaskStatus.COMPLETED || (hasNewTask && !hasProceed)) {
-						resolveCompletion()
-					} else if (state.taskStatus === TaskStatus.CANCELLED) {
-						if (isViewTaskOnly) resolveCompletion()
-						else rejectCompletion(new Error("Task was cancelled."))
-					} else if (isViewTaskOnly && cardButtons.length > 0) {
-						// Historical task loaded and waiting for interaction (e.g. Resume Task card)
-						resolveCompletion()
+					// Check for terminal state via task status and mistake-limit projection
+					const terminalCheck = evaluatePlainTextTaskTerminalState(state, isViewTaskOnly)
+					if (terminalCheck.isTerminal) {
+						if (terminalCheck.action === "resolve") {
+							resolveCompletion()
+						} else if (terminalCheck.action === "reject" && terminalCheck.error) {
+							rejectCompletion(terminalCheck.error)
+						}
 					}
 				} catch (error) {
 					rejectCompletion(error instanceof Error ? error : new Error(String(error)))

--- a/src/core/task/TaskMistakeLimit.ts
+++ b/src/core/task/TaskMistakeLimit.ts
@@ -1,7 +1,7 @@
 import { formatResponse } from "@core/formatResponse"
 import { processFilesIntoText } from "@integrations/misc/extract-text"
 import { showSystemNotification } from "@integrations/notifications"
-import { CardStatus } from "@shared/ExtensionMessage"
+import { CardStatus, TaskStatus } from "@shared/ExtensionMessage"
 import { DiracAskResponse } from "@shared/WebviewMessage"
 import { DiracContent, type DiracUserContent } from "@shared/messages/content"
 import type { DeepReadonly } from "./runtime/TaskWorkingConfiguration"
@@ -14,6 +14,7 @@ export interface TaskMistakeLimitContext {
 	taskState: TaskState
 	settings: DeepReadonly<Settings>
 	taskMessenger: TaskMessenger
+	postStateToWebview?: () => Promise<void>
 }
 
 export async function handleMistakeLimitReached(
@@ -35,6 +36,8 @@ export async function handleMistakeLimitReached(
 			body: errorMessage,
 		})
 		await card.finalize(CardStatus.ERROR)
+		ctx.taskState.status = TaskStatus.CANCELLED
+		await ctx.postStateToWebview?.()
 		// End the task loop with failure
 		return { didEndLoop: true, userContent } // didEndLoop = true, signals task completion/failure
 	}

--- a/src/core/task/__tests__/TaskMistakeLimit.test.ts
+++ b/src/core/task/__tests__/TaskMistakeLimit.test.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "mocha"
+import sinon from "sinon"
+import { CardStatus, TaskStatus } from "@shared/ExtensionMessage"
+import { handleMistakeLimitReached, type TaskMistakeLimitContext } from "../TaskMistakeLimit"
+import { TaskState } from "../TaskState"
+
+describe("handleMistakeLimitReached", () => {
+	it("returns didEndLoop: false when consecutiveMistakeCount is below threshold", async () => {
+		const taskState = new TaskState()
+		taskState.consecutiveMistakeCount = 1
+
+		const ctx: TaskMistakeLimitContext = {
+			taskState,
+			settings: {
+				maxConsecutiveMistakes: 3,
+				yoloModeToggled: true,
+			} as any,
+			taskMessenger: {} as any,
+		}
+
+		const result = await handleMistakeLimitReached(ctx, [])
+		assert.equal(result.didEndLoop, false)
+		assert.notEqual(taskState.status, TaskStatus.CANCELLED)
+	})
+
+	it("cancels task, creates error card, calls postStateToWebview, and ends loop in yolo mode", async () => {
+		const taskState = new TaskState()
+		taskState.consecutiveMistakeCount = 3
+		taskState.status = TaskStatus.EXECUTING_TOOL
+
+		const finalizeStub = sinon.stub().resolves()
+		const createCardStub = sinon.stub().resolves({
+			finalize: finalizeStub,
+		})
+		const postStateStub = sinon.stub().resolves()
+
+		const ctx: TaskMistakeLimitContext = {
+			taskState,
+			settings: {
+				maxConsecutiveMistakes: 3,
+				yoloModeToggled: true,
+			} as any,
+			taskMessenger: {
+				createCard: createCardStub,
+			} as any,
+			postStateToWebview: postStateStub,
+		}
+
+		const result = await handleMistakeLimitReached(ctx, [])
+
+		assert.equal(result.didEndLoop, true)
+		assert.equal(taskState.status, TaskStatus.CANCELLED)
+		assert.equal(createCardStub.callCount, 1)
+		const createCardArgs = createCardStub.firstCall.args[0]
+		assert.equal(createCardArgs.header, "Task Failed")
+		assert.equal(createCardArgs.status, CardStatus.ERROR)
+		assert.equal(finalizeStub.callCount, 1)
+		assert.equal(finalizeStub.firstCall.args[0], CardStatus.ERROR)
+		assert.equal(postStateStub.callCount, 1)
+	})
+})

--- a/src/core/task/index.ts
+++ b/src/core/task/index.ts
@@ -1010,7 +1010,12 @@ export class Task {
 		userContent: DiracContent[],
 	): Promise<{ didEndLoop: boolean; userContent: DiracContent[] }> {
 		return handleMistakeLimitReached(
-			{ taskState: this.taskState, settings: this.workingConfiguration.settings, taskMessenger: this.taskMessenger },
+			{
+				taskState: this.taskState,
+				settings: this.workingConfiguration.settings,
+				taskMessenger: this.taskMessenger,
+				postStateToWebview: () => this.postStateToWebview(),
+			},
 			userContent,
 		)
 	}


### PR DESCRIPTION
## Summary
When the mistake limit is reached in YOLO mode, `TaskMistakeLimit.ts` creates a "Task Failed" error card and ends the loop with `{ didEndLoop: true }`, but `taskState.status` was never set to a terminal status (`TaskStatus.CANCELLED`) nor was state pushed to the client/webview. In plain-text / CLI mode, `runPlainTextTask` only settled on `COMPLETED`, `CANCELLED`, or interactive mistake button projections (`NEW_TASK` + `PROCEED`). Because none of those were satisfied in YOLO mode, the CLI hung indefinitely until timeout.

## Changes
- In `src/core/task/TaskMistakeLimit.ts`:
  - Set `ctx.taskState.status = TaskStatus.CANCELLED` when mistake limit is reached in YOLO mode.
  - Call `await ctx.postStateToWebview?.()` to notify the client immediately.
- In `src/core/task/index.ts`:
  - Pass `postStateToWebview` in `TaskMistakeLimitContext`.
- In `cli/src/utils/plain-text-task.ts`:
  - Detect "Task Failed" error cards in `processMessage` and immediately reject the completion promise with the error message.
  - Extract and export `evaluatePlainTextTaskTerminalState` to cleanly evaluate terminal conditions and handle failure cards during state updates.
- Added unit tests in `cli/src/utils/plain-text-task.test.ts` and `src/core/task/__tests__/TaskMistakeLimit.test.ts`.