### PR TITLE
fix(api): preserve tool call arguments across mismatched delta indices

### DIFF
--- a/src/core/api/transform/__tests__/tool-call-processor.test.ts
+++ b/src/core/api/transform/__tests__/tool-call-processor.test.ts
@@ -202,6 +202,64 @@ describe("ToolCallProcessor", () => {
 		;[...processor.processToolCallDeltas(newSetupChunk)].should.have.length(0)
 		;[...processor.processToolCallDeltas(newArgsChunk)].should.have.length(1)
 	})
+
+	it("re-attributes arguments to active tool call when delta arrives with mismatched index and missing id/name", () => {
+		const warnStub = sinon.stub(Logger, "warn")
+		const processor = new ToolCallProcessor()
+
+		// Initial delta setting up tool call at index 0
+		const setupChunk = [
+			{
+				index: 0,
+				id: "call_123",
+				function: { name: "execute_command" },
+			},
+		] as any
+
+		// Provider sends arguments with mismatched index (e.g. index 1) without repeating id/name
+		const anomalyChunk = [
+			{
+				index: 1,
+				function: { arguments: '{"command":"ls"}' },
+			},
+		] as any
+
+		const firstResult = [...processor.processToolCallDeltas(setupChunk)]
+		const secondResult = [...processor.processToolCallDeltas(anomalyChunk)]
+
+		firstResult.should.have.length(0)
+		secondResult.should.have.length(1)
+
+		const toolCall = secondResult[0]!.tool_call as any
+		toolCall.call_id.should.equal("call_123")
+		toolCall.function.id.should.equal("call_123")
+		toolCall.function.name.should.equal("execute_command")
+		toolCall.function.arguments.should.equal('{"command":"ls"}')
+
+		expect(warnStub.called).to.be.true
+		const warnArg = warnStub.firstCall.args[0] as string
+		expect(warnArg).to.include("re-attributing to active tool call index 0")
+	})
+
+	it("drops argument delta and logs warning when no active tool call exists", () => {
+		const warnStub = sinon.stub(Logger, "warn")
+		const processor = new ToolCallProcessor()
+
+		// Delta with arguments but no preceding tool call setup
+		const orphanChunk = [
+			{
+				index: 0,
+				function: { arguments: '{"command":"pwd"}' },
+			},
+		] as any
+
+		const result = [...processor.processToolCallDeltas(orphanChunk)]
+		result.should.have.length(0)
+
+		expect(warnStub.called).to.be.true
+		const warnArg = warnStub.firstCall.args[0] as string
+		expect(warnArg).to.include("dropping argument fragment")
+	})
 })
 
 describe("getOpenAIToolParams", () => {

--- a/src/core/api/transform/tool-call-processor.ts
+++ b/src/core/api/transform/tool-call-processor.ts
@@ -19,6 +19,7 @@ interface ToolCallDelta {
  */
 export class ToolCallProcessor {
 	private toolCallStateByIndex: Map<number, { id: string; name: string }>
+	private lastActiveToolCallIndex?: number
 
 	constructor() {
 		this.toolCallStateByIndex = new Map()
@@ -55,32 +56,54 @@ export class ToolCallProcessor {
 				Logger.debug(`ToolCallProcessor: received function name "${toolCallDelta.function.name}"`)
 			}
 
+			if (toolCallState.id && toolCallState.name) {
+				this.lastActiveToolCallIndex = toolCallIndex
+			}
+
 			// Only yield when we have all required fields: id, name, and arguments (or web_search query)
 			const hasFunctionArgs = toolCallDelta.function?.arguments !== undefined
 			const hasWebSearchQuery = toolCallDelta.web_search?.query !== undefined
 
-			if (toolCallState.id && toolCallState.name && (hasFunctionArgs || hasWebSearchQuery)) {
+			let targetState = toolCallState
+			if ((!targetState.id || !targetState.name) && (hasFunctionArgs || hasWebSearchQuery)) {
+				if (this.lastActiveToolCallIndex !== undefined) {
+					const activeState = this.toolCallStateByIndex.get(this.lastActiveToolCallIndex)
+					if (activeState?.id && activeState?.name) {
+						Logger.warn(
+							`ToolCallProcessor: received arguments delta for index ${toolCallIndex} without tool id/name; re-attributing to active tool call index ${this.lastActiveToolCallIndex}`,
+						)
+						targetState = activeState
+					}
+				}
+				if (!targetState.id || !targetState.name) {
+					Logger.warn(
+						`ToolCallProcessor: dropping argument fragment for index ${toolCallIndex} with no active tool call id/name`,
+					)
+				}
+			}
+
+			if (targetState.id && targetState.name && (hasFunctionArgs || hasWebSearchQuery)) {
 				yield {
 					type: "tool_calls",
 					tool_call:
-						toolCallState.name === "web_search"
+						targetState.name === "web_search"
 							? {
-								call_id: toolCallState.id,
+								call_id: targetState.id,
 								type: "web_search",
 								web_search: toolCallDelta.web_search || { query: "" },
 								function: {
-									id: toolCallState.id,
+									id: targetState.id,
 									name: "web_search",
 									arguments: toolCallDelta.web_search?.query || "",
 								},
 							}
 							: {
 								...toolCallDelta,
-								call_id: toolCallState.id,
+								call_id: targetState.id,
 								function: {
 									...toolCallDelta.function,
-									id: toolCallState.id,
-									name: toolCallState.name,
+									id: targetState.id,
+									name: targetState.name,
 								},
 							},
 				}
@@ -104,6 +127,7 @@ export class ToolCallProcessor {
 	 */
 	reset(): void {
 		this.toolCallStateByIndex.clear()
+		this.lastActiveToolCallIndex = undefined
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Certain OpenAI-compatible streaming endpoints (such as Nebius or Cerebras) stream tool-call argument deltas where subsequent chunks carry an incremented or arbitrary `index` without repeating the tool call `id` or `name`. Previously, `ToolCallProcessor` required `toolCallState.id && toolCallState.name` on the exact chunk index, causing trailing argument fragments to be silently dropped and yielding truncated, invalid JSON arguments.

## Changes
- In `src/core/api/transform/tool-call-processor.ts`:
  - Track `lastActiveToolCallIndex` when a tool call with `id` and `name` is active.
  - Reset `lastActiveToolCallIndex` in `reset()`.
  - When an argument or web search query delta arrives on an index lacking `id`/`name`, re-attribute it to `lastActiveToolCallIndex` if active, log a warning, and yield the chunk with the active tool call metadata.
  - If no active tool call exists, log a warning about dropping unparented argument fragments.
- In `src/core/api/transform/__tests__/tool-call-processor.test.ts`:
  - Added unit tests verifying re-attribution of mismatched index argument deltas and warning logging.
  - Added unit test verifying orphan argument deltas are dropped with appropriate warning logging.