### PR TITLE
fix(acp): emit agent_message_chunk on task completion

### DIFF
--- a/cli/src/agent/messageTranslator.modular.test.ts
+++ b/cli/src/agent/messageTranslator.modular.test.ts
@@ -1,12 +1,12 @@
 import type * as acp from "@agentclientprotocol/sdk"
-import { DiracMessageType, CardStatus } from "@shared/ExtensionMessage"
 import type { DiracMessage } from "@shared/ExtensionMessage"
+import { CardKind, CardStatus, DiracMessageType } from "@shared/ExtensionMessage"
+import { ResponseOperation, responseCardInput } from "@shared/responseTool"
 import { beforeEach, describe, expect, it } from "vitest"
 import { translateMessage, translateMessages } from "./messageTranslator"
 import { handlePermissionResponse } from "./permissionHandler"
 import type { AcpSessionState } from "./public-types"
 import { AcpSessionStatus } from "./public-types"
-import { ResponseOperation, responseCardInput } from "@shared/responseTool"
 
 function createMarkdownMessage(content: string, isReasoning = false): DiracMessage {
 	return {
@@ -164,7 +164,6 @@ describe("messageTranslator (Modular Architecture)", () => {
 			expect(result.permissionRequest).toBeUndefined()
 		})
 
-
 		it("reports file edits as ACP diff content with before and after text", () => {
 			const result = translateMessage(
 				createCardMessage({
@@ -307,6 +306,57 @@ describe("messageTranslator (Modular Architecture)", () => {
 			expect(update.toolCallId).toBe("tool-1")
 			expect(update.status).toBe("completed")
 			expect(update.name).toBe("read_file")
+		})
+
+		it("emits agent_message_chunk with completion text when TASK_COMPLETION card succeeds", () => {
+			const card1 = {
+				id: "completion-1",
+				kind: CardKind.TASK_COMPLETION,
+				header: "Task Completed",
+				toolName: "respond",
+				status: CardStatus.RUNNING,
+				body: "Task is now complete.",
+			}
+			const runningResult = translateMessage(createCardMessage(card1), sessionState)
+			// Running status emits tool_call, no message chunk
+			expect(runningResult.updates).toHaveLength(2) // tool_call + tool_call_update(in_progress)
+			expect(runningResult.updates.every((u) => u.sessionUpdate !== "agent_message_chunk")).toBe(true)
+
+			const card2 = {
+				id: "completion-1",
+				kind: CardKind.TASK_COMPLETION,
+				header: "Task Completed",
+				toolName: "respond",
+				status: CardStatus.SUCCESS,
+				body: "Task is now complete.",
+			}
+			const successResult = translateMessage(createCardMessage(card2), sessionState)
+			expect(successResult.updates).toHaveLength(2)
+			expect(successResult.updates[0]).toMatchObject({
+				sessionUpdate: "tool_call_update",
+				toolCallId: "completion-1",
+				status: "completed",
+			})
+			expect(successResult.updates[1]).toEqual({
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: "Task is now complete." },
+			})
+		})
+
+		it("translates legacy task completion card without kind field based on header", () => {
+			const card = {
+				id: "legacy-comp-1",
+				header: "Task Completed",
+				status: CardStatus.SUCCESS,
+				body: "Legacy task finished.",
+			}
+			const result = translateMessage(createCardMessage(card), sessionState)
+			expect(result.updates).toHaveLength(2)
+			expect(result.updates[0].sessionUpdate).toBe("tool_call")
+			expect(result.updates[1]).toEqual({
+				sessionUpdate: "agent_message_chunk",
+				content: { type: "text", text: "Legacy task finished." },
+			})
 		})
 
 		it("offers once and always choices for approval requests", () => {

--- a/cli/src/agent/messageTranslator.ts
+++ b/cli/src/agent/messageTranslator.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as acp from "@agentclientprotocol/sdk"
+import { isSuccessfulTaskCompletionCard } from "@shared/cardIdentity"
 import type { DiracMessage } from "@shared/ExtensionMessage"
 import { CardStatus, DiracMessageType, isFinalStatus } from "@shared/ExtensionMessage"
 import { getBrowserActionKind } from "./browserActionTranslator.js"
@@ -353,6 +354,13 @@ function translateCardMessage(
 		if (!isFinalStatus(card.status)) {
 			sessionState.pendingToolCalls.set(toolCallId, toolCall)
 		}
+	}
+
+	if (isSuccessfulTaskCompletionCard(card) && card.body) {
+		updates.push({
+			sessionUpdate: "agent_message_chunk",
+			content: { type: "text", text: card.body },
+		})
 	}
 
 	// Permission requests are exclusively for real approval decisions.

--- a/cli/src/agent/taskMessageBridge.ts
+++ b/cli/src/agent/taskMessageBridge.ts
@@ -109,6 +109,8 @@ export class TaskMessageBridge {
 	private interactionGeneration = 0;
 	/** Steering transcripts whose delivered status has already been reported to ACP. */
 	private readonly reportedSentSteeringMessages = new Set<string>();
+	/** Completion card IDs whose text has already been emitted to avoid duplicate streaming across card state transitions. */
+	private readonly emittedCompletionCardKeys = new Set<string>();
 
 	/** Latest cumulative snapshot for every model request observed in this ACP session. */
 	private readonly usageSnapshots = new Map<string, UsageSnapshot>();
@@ -1111,6 +1113,13 @@ export class TaskMessageBridge {
 
 			// Send all updates produced by the translator
 			for (const update of result.updates) {
+				if (update.sessionUpdate === "agent_message_chunk" && message.content.type === DiracMessageType.CARD) {
+					const cardKey = `${sessionId}:${message.content.card.id}`;
+					if (this.emittedCompletionCardKeys.has(cardKey)) {
+						continue;
+					}
+					this.emittedCompletionCardKeys.add(cardKey);
+				}
 				await this.emitSessionUpdate(sessionId, update);
 			}
 


### PR DESCRIPTION
### What
- `cli/src/agent/messageTranslator.ts`: pure functional translation of `isSuccessfulTaskCompletionCard(card)` into `agent_message_chunk` with `card.body`.
- `cli/src/agent/taskMessageBridge.ts`: track emitted completion card keys to prevent duplicate streaming across card state transitions.
- `cli/src/agent/messageTranslator.modular.test.ts`: add unit tests covering active vs terminal completion cards and legacy cards.

### Why
- Devin and ACP clients render `tool_call` as collapsible metadata and chat messages strictly from `agent_message_chunk`.
- `respond(complete)` only creates a `TASK_COMPLETION` card, leaving ACP client chat stream empty when task completes.

### Notes / Caveats
- `messageTranslator.ts` remains completely pure with no state mutations.
- `TaskMessageBridge` owns all stream emission deduplication alongside its existing tracking maps.
- Core tools untouched to prevent duplicate rendering in VS Code webview and native CLI.

### Verification
- `npm run check-types`: passed (clean tsc on root, webview, cli).
- `vitest cli/src/agent/messageTranslator.modular.test.ts`: 28 passed.
- `vitest cli/src/acp/protocolConformance.test.ts`: 9 passed.

### User test
- Run task via ACP (`dirac --acp`); observe concluding text displayed in chat upon task completion.
